### PR TITLE
Fix after test on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.16...3.27)
 
 project(rerun_external_cpp_proj LANGUAGES CXX)
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -25,9 +25,9 @@ version = "0.1.0"
 [tasks]
 # Note: extra CLI argument after `pixi run TASK` are passed to the task cmd.
 
-prepare = "cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=Debug"
+prepare = "cmake -G Ninja -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 clean = { cmd = "rm -rf build bin CMakeFiles/" }
-build = { cmd = "mkdir -p bin && cmake --build build --config Debug --target all", depends_on = [
+build = { cmd = "mkdir -p bin && cmake --build build --config RelWithDebInfo --target all", depends_on = [
     "prepare",
 ] }
 run = { cmd = "build/rerun_ext_example", depends_on = ["build"] }


### PR DESCRIPTION
I tested the example, on Windows, and I experienced the following problems.

## Link failure due to use of Debug CMAKE_BUILD_TYPE

At the end of `pixi run run` the linking was failing with:
~~~
[151/151] Linking CXX executable rerun_ext_example.exe
FAILED: rerun_ext_example.exe
cmd.exe /C "cd . && C:\src\cpp-example-opencv-eigen\.pixi\env\Library\bin\cmake.exe -E vs_link_exe --intdir=CMakeFiles\rerun_ext_example.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x64\mt.exe --manifests  -- C:\PROGRA~2\MICROS~3\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\rerun_ext_example.rsp  /out:rerun_ext_example.exe /implib:rerun_ext_example.lib /pdb:rerun_ext_example.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console  && cd ."
LINK Pass 1: command "C:\PROGRA~2\MICROS~3\2019\BUILDT~1\VC\Tools\MSVC\1429~1.301\bin\Hostx64\x64\link.exe /nologo @CMakeFiles\rerun_ext_example.rsp /out:rerun_ext_example.exe /implib:rerun_ext_example.lib /pdb:rerun_ext_example.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console /MANIFEST /MANIFESTFILE:CMakeFiles\rerun_ext_example.dir/intermediate.manifest CMakeFiles\rerun_ext_example.dir/manifest.res" failed (exit code 1120) with the following output:
main.cpp.obj : error LNK2019: unresolved external symbol "void __cdecl cv::cvtColor(class cv::debug_build_guard::_InputArray const &,class cv::debug_build_guard::_OutputArray const &,int,int)" (?cvtColor@cv@@YAXAEBV_InputArray@debug_build_guard@1@AEBV_OutputArray@31@HH@Z) referenced in function main
rerun_ext_example.exe : fatal error LNK1120: 1 unresolved externals
ninja: build stopped: subcommand failed.
~~~

The reason for that is (I believe) that in general on Windows/MSVC the ABI of Release builds is not compatible with the Debug builds. `conda-forge` (and so pixi) only contains `Release` builds, so in general it is not possible to build C++ projects in Debug mode on Windows/MSVC. I think a good compromise is to use `RelWithDebInfo` instead of `Debug`, this is done in https://github.com/rerun-io/cpp-example-opencv-eigen/commit/6353d7e09181df421f4ae07beba876b1289cb200 .

## CMake warning due to unset policy

During CMake configuration, I get this warning:
~~~
-- Detecting CXX compile features - done
CMake Warning (dev) at .pixi/env/Library/share/cmake-3.27/Modules/FetchContent.cmake:1316 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  CMakeLists.txt:12 (FetchContent_Declare)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- Arrow version: 13.0.0
~~~

A simple way to avoid this warning is just to set `policy_max` argument of [`cmake_minimum_required`](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) to `3.27`, as done in https://github.com/rerun-io/cpp-example-opencv-eigen/commit/63bf6c60823de3e777cf45fab732f77380d1a94d .