### PR TITLE
Avoid awkward 'pixi run run'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Just type `rerun` and the rerun viewer should show up. Then it is time to run th
 The easiest way to get started is to install [pixi](https://prefix.dev/docs/pixi/overview).
 
 * Start the rerun viewer with `rerun` (see above)
-* Run the example with `pixi run run`
+* Run the example with `pixi run example`
 
 
 ### Manually

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 # https://prefix.dev/docs/pixi/overview
 #
 # Use `pixi task list` to list the available tasks,
-# and `pixi run TASK` to run it (e.g. `pixi run run`).
+# and `pixi run TASK` to run it (e.g. `pixi run example`).
 
 [project]
 name = "rerun_cpp_example_opencv_eigen"
@@ -32,7 +32,7 @@ prepare = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=Rel
 build = { cmd = "cmake --build build --config RelWithDebInfo", depends_on = [
     "prepare",
 ] }
-run = { cmd = "build/RelWithDebInfo/rerun_ext_example.exe", depends_on = [
+example = { cmd = "build/RelWithDebInfo/rerun_ext_example.exe", depends_on = [
     "build",
 ] }
 
@@ -41,7 +41,7 @@ prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 build = { cmd = "cmake --build build --config RelWithDebInfo --target all", depends_on = [
     "prepare",
 ] }
-run = { cmd = "build/rerun_ext_example", depends_on = ["build"] }
+example = { cmd = "build/rerun_ext_example", depends_on = ["build"] }
 
 
 [target.osx-64.tasks]
@@ -49,14 +49,14 @@ prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 build = { cmd = "cmake --build build --config RelWithDebInfo --target all", depends_on = [
     "prepare",
 ] }
-run = { cmd = "build/rerun_ext_example", depends_on = ["build"] }
+example = { cmd = "build/rerun_ext_example", depends_on = ["build"] }
 
 [target.osx-arm64.tasks]
 prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 build = { cmd = "cmake --build build --config RelWithDebInfo --target all", depends_on = [
     "prepare",
 ] }
-run = { cmd = "build/rerun_ext_example", depends_on = ["build"] }
+example = { cmd = "build/rerun_ext_example", depends_on = ["build"] }
 
 [dependencies]
 # Build tools:


### PR DESCRIPTION
I find `pixi run example` to read much more cleanly than `pixi run run` which feels like a typo.