### PR TITLE
Add `rerun-sdk` to the pixi.toml

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.3.0
         with:
-          pixi-version: v0.5.0
+          pixi-version: v0.6.0
           cache: true
 
       - run: pixi run build

--- a/README.md
+++ b/README.md
@@ -12,7 +12,17 @@ This is a minimal CMake project that shows how to use [Rerun](https://github.com
   </picture>
 </center>
 
-## Installing the Rerun viewer
+## Using `pixi`
+The easiest way to get started is to install [pixi](https://prefix.dev/docs/pixi/overview).
+
+The pixi environment described in `pixi.toml` contains all of the dependencies, including the rerun viewer,
+allowing you to run the example with a single command:
+* `pixi run example`
+
+## Without `pixi`
+If you choose not to use pixi, you will need to install a few things yourself before you get started.
+
+### Installing the Rerun Viewer
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun are:
@@ -21,22 +31,13 @@ If you need to install the viewer, follow the [installation guide](https://www.r
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 
-## Run this example
-
-### Using `pixi`
-The easiest way to get started is to install [pixi](https://prefix.dev/docs/pixi/overview).
-
-* Start the rerun viewer with `rerun` (see above)
-* Run the example with `pixi run example`
-
-
-### Manually
-First install the required dependencies:
+### Installing dependencies:
+This project depends on a few libraries and toolchains. Installing these is outside the scope of this README,
+but your OS should have these available though a common package manager:
 * `eigen` and `opencv` (required by this example)
 * `cmake` (for building)
 
-
-### Linux & Mac
+### Build and run on Linux & Mac
 
 Build:
 ```bash
@@ -48,8 +49,7 @@ Then run the binary with:
 `build/rerun_ext_example`
 
 
-### Windows using Visual Studio 2022
-
+### Build and run on Windows using Visual Studio 2022
 
 Build
 ```cmd

--- a/pixi.lock
+++ b/pixi.lock
@@ -18,17 +18,16 @@ metadata:
   inputs_metadata: null
   custom_metadata: null
 package:
-- name: _libgcc_mutex
+- platform: linux-64
+  name: _libgcc_mutex
   version: '0.1'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   hash:
     md5: d7c89558ba9fa0495403155b64376d81
     sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
-  optional: false
-  category: main
   build: conda_forge
   arch: x86_64
   subdir: linux-64
@@ -36,19 +35,18 @@ package:
   license: None
   size: 2562
   timestamp: 1578324546067
-- name: _openmp_mutex
+- platform: linux-64
+  name: _openmp_mutex
   version: '4.5'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
-    libgomp: '>=7.5.0'
+  - _libgcc_mutex ==0.1 conda_forge
+  - libgomp >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
   hash:
     md5: 73aaf86a425cc6e73fcf236a5a46396d
     sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
-  optional: false
-  category: main
   build: 2_gnu
   arch: x86_64
   subdir: linux-64
@@ -59,18 +57,17 @@ package:
   license_family: BSD
   size: 23621
   timestamp: 1650670423406
-- name: alsa-lib
+- platform: linux-64
+  name: alsa-lib
   version: 1.2.10
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.10-hd590300_0.conda
   hash:
     md5: 75dae9a4201732aa78a530b826ee5fe0
     sha256: 51147922bad9d3176e780eb26f748f380cd3184896a9f9125d8ac64fe330158b
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -79,19 +76,18 @@ package:
   license_family: GPL
   size: 554938
   timestamp: 1693607226431
-- name: aom
+- platform: linux-64
+  name: aom
   version: 3.6.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.6.1-h59595ed_0.conda
   hash:
     md5: 8457db6d1175ee86c8e077f6ac60ff55
     sha256: 006d10fe845374e71fb15a6c1f58ae4b3efef69be02b0992265abfb5c4c2e026
-  optional: false
-  category: main
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -100,18 +96,17 @@ package:
   license_family: BSD
   size: 2678249
   timestamp: 1694225960207
-- name: aom
+- platform: osx-64
+  name: aom
   version: 3.6.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.6.1-he965462_0.conda
   hash:
     md5: 3685ccc84e1b901601331f1aecead92c
     sha256: 254f15bbfda2e474c63f9a30bfc7f2d4d30ff49d6543481bf6a5bf414ec9bcd7
-  optional: false
-  category: main
   build: he965462_0
   arch: x86_64
   subdir: osx-64
@@ -120,18 +115,17 @@ package:
   license_family: BSD
   size: 2855123
   timestamp: 1694226514540
-- name: aom
+- platform: osx-arm64
+  name: aom
   version: 3.6.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.6.1-hb765f3a_0.conda
   hash:
     md5: efe2c75abcf259999d1779bbbc9cd3ce
     sha256: 71e86411093a5241fa9349b61e0c42a841d39364b8298bd80919ede75fc496bd
-  optional: false
-  category: main
   build: hb765f3a_0
   arch: aarch64
   subdir: osx-arm64
@@ -140,20 +134,19 @@ package:
   license_family: BSD
   size: 2067686
   timestamp: 1694226240409
-- name: aom
+- platform: win-64
+  name: aom
   version: 3.6.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/aom-3.6.1-h63175ca_0.conda
   hash:
     md5: 40e557b0d849edcb884d02d9ea6511bf
     sha256: 3d5ae5f4f032daf24b9ac412cd57047590866e09e807f5a16d8112c6fe84700c
-  optional: false
-  category: main
   build: h63175ca_0
   arch: x86_64
   subdir: win-64
@@ -162,18 +155,17 @@ package:
   license_family: BSD
   size: 7918540
   timestamp: 1694228877684
-- name: attr
+- platform: linux-64
+  name: attr
   version: 2.5.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
   hash:
     md5: d9c69a24ad678ffce24c6543a0176b00
     sha256: 82c13b1772c21fc4a17441734de471d3aabf82b61db9b11f4a1bd04a9c4ac324
-  optional: false
-  category: main
   build: h166bdaf_1
   arch: x86_64
   subdir: linux-64
@@ -182,18 +174,1273 @@ package:
   license_family: GPL
   size: 71042
   timestamp: 1660065501192
-- name: binutils
-  version: '2.40'
+- platform: linux-64
+  name: attrs
+  version: 23.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_impl_linux-64: '>=2.40,<2.41.0a0'
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  hash:
+    md5: 3edfead7cedd1ab4400a6c588f3e75f8
+    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  build: pyh71513ae_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 55022
+  timestamp: 1683424195402
+- platform: osx-64
+  name: attrs
+  version: 23.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  hash:
+    md5: 3edfead7cedd1ab4400a6c588f3e75f8
+    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  build: pyh71513ae_1
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 55022
+  timestamp: 1683424195402
+- platform: osx-arm64
+  name: attrs
+  version: 23.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  hash:
+    md5: 3edfead7cedd1ab4400a6c588f3e75f8
+    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  build: pyh71513ae_1
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 55022
+  timestamp: 1683424195402
+- platform: win-64
+  name: attrs
+  version: 23.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.7
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+  hash:
+    md5: 3edfead7cedd1ab4400a6c588f3e75f8
+    sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
+  build: pyh71513ae_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  noarch: python
+  size: 55022
+  timestamp: 1683424195402
+- platform: linux-64
+  name: aws-c-auth
+  version: 0.7.5
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.5-h1a24852_0.conda
+  hash:
+    md5: 02305820d0dbfe542c6e4d67ddb0f13b
+    sha256: 45d41ef052d0e362d0c031af7392bd1d755b29b1e6af9e3796abdd7b8b712611
+  build: h1a24852_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 101868
+  timestamp: 1698392762240
+- platform: osx-64
+  name: aws-c-auth
+  version: 0.7.5
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.5-h671831e_0.conda
+  hash:
+    md5: 7271143bc2eda1ac6e6fbe6aa9747c5f
+    sha256: 1226eddda5a90a723946ae9ed7dcf9039ba56f3ee3cb078fe6f2bad465b875b7
+  build: h671831e_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88989
+  timestamp: 1698392883157
+- platform: osx-arm64
+  name: aws-c-auth
+  version: 0.7.5
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.5-he6edc6d_0.conda
+  hash:
+    md5: 85b725ebb889fdac6efc43538a8fd2fc
+    sha256: 1d07a7156091d68e244a23e7fe186406c72c821ff31b644d86f871a95618a0d6
+  build: he6edc6d_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 87771
+  timestamp: 1698392912091
+- platform: win-64
+  name: aws-c-auth
+  version: 0.7.5
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.5-h7c265c8_0.conda
+  hash:
+    md5: d73f0231b3a9d12fc73b1dd10e3b46fd
+    sha256: 74ab208974b45be4c290d32534f545e0b69c0ccb0214d047aa7250fe98e855e0
+  build: h7c265c8_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 98064
+  timestamp: 1698392952402
+- platform: linux-64
+  name: aws-c-cal
+  version: 0.6.7
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - libgcc-ng >=12
+  - openssl >=3.1.3,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.7-h6e18cf3_0.conda
+  hash:
+    md5: cdbd44927a53a313d69f3c206a418dd2
+    sha256: 2dcb57436fe20a03373ede39c0cbb046c44b181392eb2e68963ac4ffcace0da4
+  build: h6e18cf3_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 55854
+  timestamp: 1697673168301
+- platform: osx-64
+  name: aws-c-cal
+  version: 0.6.7
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.7-h50c96e6_0.conda
+  hash:
+    md5: 542948d693c4c43fdc592b67c7bfb5e5
+    sha256: c379ddb6416bd04fc59ee877714395d0084d05406bdc05a624d59c9244dd03fa
+  build: h50c96e6_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45255
+  timestamp: 1697673379792
+- platform: osx-arm64
+  name: aws-c-cal
+  version: 0.6.7
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.7-ha251d5a_0.conda
+  hash:
+    md5: dc40c2139c44dc8078f7dd256f03ca9d
+    sha256: bcba576928617754f4625fdb9e3cc4dc05debc2845506f669c942aa182494ed7
+  build: ha251d5a_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39014
+  timestamp: 1697673430797
+- platform: win-64
+  name: aws-c-cal
+  version: 0.6.7
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.7-h85219b4_0.conda
+  hash:
+    md5: 907073c34391c73a16a2d8a8832b5781
+    sha256: 05282adc12e0603a9efb71ec721055fb409814ef4c33ea100721eacf0b01721a
+  build: h85219b4_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 55811
+  timestamp: 1697673687140
+- platform: linux-64
+  name: aws-c-common
+  version: 0.9.4
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.4-hd590300_0.conda
+  hash:
+    md5: 8dacaf703f8e57aa0c4f0c5c8f4be39b
+    sha256: 75dbc43b047ac1675422099293a2622fd9fd462dc8159c87322cd9847ca7b228
+  build: hd590300_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 220449
+  timestamp: 1697224358276
+- platform: osx-64
+  name: aws-c-common
+  version: 0.9.4
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.4-h10d778d_0.conda
+  hash:
+    md5: 7c98964b624144db902343b456b57161
+    sha256: 85509ce7dd7e3a62899255f6ab7b4f1c0e0698e03c2377f3cb713d4a830e827c
+  build: h10d778d_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 204597
+  timestamp: 1697224614121
+- platform: osx-arm64
+  name: aws-c-common
+  version: 0.9.4
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.4-h93a5062_0.conda
+  hash:
+    md5: bace1115ad120bb9878ed244b7789a38
+    sha256: 297f0f7c873a50ed054b0a9969d7313ab6ab04d80bbb97f010188977f6e8ea00
+  build: h93a5062_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 199718
+  timestamp: 1697224690584
+- platform: win-64
+  name: aws-c-common
+  version: 0.9.4
+  category: main
+  manager: conda
+  dependencies:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.4-hcfcfb64_0.conda
+  hash:
+    md5: de2da3a4925bb0631eaf77782cb5a1c3
+    sha256: f32901b945f145d19718f0e4a38852a8b1820a529e9bbfd0d3e56856f7b72ab2
+  build: hcfcfb64_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 218428
+  timestamp: 1697224807961
+- platform: linux-64
+  name: aws-c-compression
+  version: 0.2.17
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h037bafe_4.conda
+  hash:
+    md5: 72cb3661f349a95ea48b0ddcdc4c0f18
+    sha256: 71a740e9c092d4119aad6ba3ee3fcbfd33faf078ffd7b80802efe218829bd931
+  build: h037bafe_4
+  arch: x86_64
+  subdir: linux-64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 19114
+  timestamp: 1697276192851
+- platform: osx-64
+  name: aws-c-compression
+  version: 0.2.17
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-h6cdfeff_4.conda
+  hash:
+    md5: 0191b03ce3829544a993d178e8b89e88
+    sha256: d0aaf265198bd52894d69a04e2a3964343c949a4749e59f73d3fc5dc5b08df18
+  build: h6cdfeff_4
+  arch: x86_64
+  subdir: osx-64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 18008
+  timestamp: 1697276334093
+- platform: osx-arm64
+  name: aws-c-compression
+  version: 0.2.17
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-ha251d5a_4.conda
+  hash:
+    md5: e64060c7ba7008a36c39f95e94934824
+    sha256: a995826c8074250bcbc59e4640670a66d9c0d071ea7f75ac71d2e6359fb3cf12
+  build: ha251d5a_4
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 18265
+  timestamp: 1697276370819
+- platform: win-64
+  name: aws-c-compression
+  version: 0.2.17
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-h85219b4_4.conda
+  hash:
+    md5: 524e7212432b694d88787e9b3ef06f09
+    sha256: 65c2f3b48e6d59615b5dae3ca0a1e9396c4978f4a9cfa4a492dfa04e036fbbd4
+  build: h85219b4_4
+  arch: x86_64
+  subdir: win-64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 22443
+  timestamp: 1697276610135
+- platform: linux-64
+  name: aws-c-event-stream
+  version: 0.3.2
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-he4fbe49_4.conda
+  hash:
+    md5: 38da036c9d74d4d44f35e05474135f77
+    sha256: 465ea78fe57381c86e35c81b7bbdbbcfdb88ea1181e7d211b714ad892fb39e22
+  build: he4fbe49_4
+  arch: x86_64
+  subdir: linux-64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 53923
+  timestamp: 1697310102551
+- platform: osx-64
+  name: aws-c-event-stream
+  version: 0.3.2
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=16.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-h74ccef4_4.conda
+  hash:
+    md5: b827ead7cf3266cd34ad3d572c009bed
+    sha256: 562e31046f456e90573db81114d513f4973ea62b098b5f9531b867571c1191f0
+  build: h74ccef4_4
+  arch: x86_64
+  subdir: osx-64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 47235
+  timestamp: 1697310241752
+- platform: osx-arm64
+  name: aws-c-event-stream
+  version: 0.3.2
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=16.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hd73d0d5_4.conda
+  hash:
+    md5: d393bbd203ecc8489d04a86ffcdb1f4a
+    sha256: 9e95a08a335eca1acd1f43e5ff1f4f425d85420d90f6b6343752b56b7396b4fc
+  build: hd73d0d5_4
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 47016
+  timestamp: 1697310283218
+- platform: win-64
+  name: aws-c-event-stream
+  version: 0.3.2
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.3.2-h02e22aa_4.conda
+  hash:
+    md5: e78656916fbb0db53831b7f06eabeb2c
+    sha256: fc3a941a8d3e00bca9e79cd9415a94870e051f228d306b47e6843d0804de8af4
+  build: h02e22aa_4
+  arch: x86_64
+  subdir: win-64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 54561
+  timestamp: 1697310556600
+- platform: linux-64
+  name: aws-c-http
+  version: 0.7.13
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.13-hbbfb9a7_7.conda
+  hash:
+    md5: 2c4c47d83a0e111799dda4059c88621d
+    sha256: c537317a4490f085a3a58679fa05d4132a2d2b8f5480ffa51175135987faddb6
+  build: hbbfb9a7_7
+  arch: x86_64
+  subdir: linux-64
+  build_number: 7
+  license: Apache-2.0
+  license_family: Apache
+  size: 193531
+  timestamp: 1697850884300
+- platform: osx-64
+  name: aws-c-http
+  version: 0.7.13
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.13-h7fc0988_7.conda
+  hash:
+    md5: b071abb2d71cb995560f79d9079754c9
+    sha256: 136ffd3103102c4630a681973b7eaa4bf5860c77cedf0d1ef49e573d1fcd7ee1
+  build: h7fc0988_7
+  arch: x86_64
+  subdir: osx-64
+  build_number: 7
+  license: Apache-2.0
+  license_family: Apache
+  size: 162506
+  timestamp: 1697851135094
+- platform: osx-arm64
+  name: aws-c-http
+  version: 0.7.13
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.13-hb3e5a72_7.conda
+  hash:
+    md5: 6343f20b5246351926e1f304084f663c
+    sha256: 939c1c1898d228fdc7bb532cbd09517eea71c8672ce22609cb1ade9d02ce06f5
+  build: hb3e5a72_7
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 7
+  license: Apache-2.0
+  license_family: Apache
+  size: 150599
+  timestamp: 1697851203675
+- platform: win-64
+  name: aws-c-http
+  version: 0.7.13
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.7.13-hddd7df3_7.conda
+  hash:
+    md5: 4143b9c8a9dafbe49f5f20aa7e39a6dd
+    sha256: 7304c23e73fc4b975c928bc1953040e02bcb850c4a5ef6c260fac48480485725
+  build: hddd7df3_7
+  arch: x86_64
+  subdir: win-64
+  build_number: 7
+  license: Apache-2.0
+  license_family: Apache
+  size: 179787
+  timestamp: 1697851279463
+- platform: linux-64
+  name: aws-c-io
+  version: 0.13.35
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - libgcc-ng >=12
+  - s2n >=1.3.55,<1.3.56.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.35-hd1885a1_4.conda
+  hash:
+    md5: a0728c6591063bee78f037741d1da83b
+    sha256: 74843ac64d018e27460d2b45d5fafc613e45073da64bb346c6d8d059a39d22d5
+  build: hd1885a1_4
+  arch: x86_64
+  subdir: linux-64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 156768
+  timestamp: 1697832645946
+- platform: osx-64
+  name: aws-c-io
+  version: 0.13.35
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.35-h3dcb58e_4.conda
+  hash:
+    md5: d52da1ed8d8650d2dab781a19525d2f6
+    sha256: 29c4484b1d8a5ede6e72eeeadb2dc7e01e1c0ed891e8535ab2f0f09f82973d6d
+  build: h3dcb58e_4
+  arch: x86_64
+  subdir: osx-64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 136648
+  timestamp: 1697832779642
+- platform: osx-arm64
+  name: aws-c-io
+  version: 0.13.35
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.35-h0f79f92_4.conda
+  hash:
+    md5: e5dd577f857c83f99975db7368c071a7
+    sha256: 90083860c4e0f2e2d78f80b196f40b2e5d1e8340588d46e6936f21fb9a7408c2
+  build: h0f79f92_4
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 136780
+  timestamp: 1697832935753
+- platform: win-64
+  name: aws-c-io
+  version: 0.13.35
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.35-h8233182_4.conda
+  hash:
+    md5: 5317706b4f9075e4c1fdf8b72d09f266
+    sha256: 7c7c1cd69cc49b9109a6e37c13b248f04705594071d2b9c6f51ab6103401ed66
+  build: h8233182_4
+  arch: x86_64
+  subdir: win-64
+  build_number: 4
+  license: Apache-2.0
+  license_family: Apache
+  size: 158859
+  timestamp: 1697833111049
+- platform: linux-64
+  name: aws-c-mqtt
+  version: 0.9.8
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.8-h31a96f8_0.conda
+  hash:
+    md5: cf4834799534b9fcb7bca1c136bcd7a9
+    sha256: 0ec0363fa5c78f0daa50bb1313abd02d3c59d57af380fae7b9d39e0a702562f3
+  build: h31a96f8_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162688
+  timestamp: 1697770672174
+- platform: osx-64
+  name: aws-c-mqtt
+  version: 0.9.8
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.8-hb951632_0.conda
+  hash:
+    md5: 270bd917fcd02a15461a29a413cdb9b6
+    sha256: f90837bb25f5f730f7b77c32a1f79d5e60af41ce266e51b93a6e5c8087642a5b
+  build: hb951632_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 138163
+  timestamp: 1697770881386
+- platform: osx-arm64
+  name: aws-c-mqtt
+  version: 0.9.8
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.8-he2964ae_0.conda
+  hash:
+    md5: 59cad22bf55d94f54ed11a23d6f40a82
+    sha256: de85e5d0d100fc4319ccaf4540fec3f379899ced2334db47c306c1f8cd192671
+  build: he2964ae_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 117558
+  timestamp: 1697770422982
+- platform: win-64
+  name: aws-c-mqtt
+  version: 0.9.8
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.9.8-hf43a5ce_0.conda
+  hash:
+    md5: e0467f27b3eeb77e49aee9a86cd7b5a2
+    sha256: 6195d5728a00a738eb0fe26b643e60d6b65c8cf4ec05cf95e4f033b8255a21d8
+  build: hf43a5ce_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 157587
+  timestamp: 1697771116588
+- platform: linux-64
+  name: aws-c-s3
+  version: 0.3.20
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - openssl >=3.1.4,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.3.20-he249171_1.conda
+  hash:
+    md5: e7b72928833ea245d8bfb89a35ae7d5e
+    sha256: 6831f6c6af9cfc346e4d6ff63e8a46b9949cdd4e3454bcde98a6cad4f26208e9
+  build: he249171_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: Apache-2.0
+  license_family: Apache
+  size: 85837
+  timestamp: 1698603581766
+- platform: osx-64
+  name: aws-c-s3
+  version: 0.3.20
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.3.20-h4b852be_1.conda
+  hash:
+    md5: fab2b8a0e53821fb50ebcf51eee79bc2
+    sha256: d034cde20a7849ead712d1f93febb112837a3a7d0fb8a818a74dbaee1a30b0bf
+  build: h4b852be_1
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1
+  license: Apache-2.0
+  license_family: Apache
+  size: 74096
+  timestamp: 1698603730478
+- platform: osx-arm64
+  name: aws-c-s3
+  version: 0.3.20
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.20-h8d12f51_1.conda
+  hash:
+    md5: 9d9482210bd957dfaea42a66aa63a6ae
+    sha256: e314b2c1e0f155f66e48b3028db5541c9adce7504512f1991785f0e8bef59084
+  build: h8d12f51_1
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1
+  license: Apache-2.0
+  license_family: Apache
+  size: 73756
+  timestamp: 1698603819233
+- platform: win-64
+  name: aws-c-s3
+  version: 0.3.20
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.3.20-h6f899c3_1.conda
+  hash:
+    md5: a623c3e6d6bfe5c47a54eceadfddf62c
+    sha256: d6f5fcaf70ffdd862e9aa550becd52e47093f3cb77ac6b295251e1358dc4525f
+  build: h6f899c3_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: Apache-2.0
+  license_family: Apache
+  size: 83403
+  timestamp: 1698604138214
+- platform: linux-64
+  name: aws-c-sdkutils
+  version: 0.1.12
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.12-h037bafe_3.conda
+  hash:
+    md5: 6c2ea725535e0f2a18f645a0bf03a8f6
+    sha256: 249727a6ebffe314759bf367209fea9c23f96ac3b8f0a7fd7f61bad2712ec545
+  build: h037bafe_3
+  arch: x86_64
+  subdir: linux-64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 53237
+  timestamp: 1697283224279
+- platform: osx-64
+  name: aws-c-sdkutils
+  version: 0.1.12
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.12-h6cdfeff_3.conda
+  hash:
+    md5: 9e5e7fab592b8800ba097e7eade71c4c
+    sha256: 68061052827513553fc45607ec789b3123af8981580afff40b34bc5660207c9d
+  build: h6cdfeff_3
+  arch: x86_64
+  subdir: osx-64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 47361
+  timestamp: 1697283408993
+- platform: osx-arm64
+  name: aws-c-sdkutils
+  version: 0.1.12
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-ha251d5a_3.conda
+  hash:
+    md5: ddc2ae02cdaa70989069c74995506520
+    sha256: fa4e165c179093b761e0e4a946a214b65735ffec0ddc992ef3ba98559affb9da
+  build: ha251d5a_3
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 47056
+  timestamp: 1697283486854
+- platform: win-64
+  name: aws-c-sdkutils
+  version: 0.1.12
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.12-h85219b4_3.conda
+  hash:
+    md5: 08fb0bce8e142624f3c30d9ec0627a6b
+    sha256: 524e581e4eefec8c940772c73da4cfd1879172d70ad1b9032c497df866a60f7a
+  build: h85219b4_3
+  arch: x86_64
+  subdir: win-64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 51751
+  timestamp: 1697283702647
+- platform: linux-64
+  name: aws-checksums
+  version: 0.1.17
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h037bafe_3.conda
+  hash:
+    md5: ac1b0e60de127cc46a04e76a907434a1
+    sha256: 1a65c1bb49c1345f824db0129895f45434751cedd3e55a89d0300dd1b68794ed
+  build: h037bafe_3
+  arch: x86_64
+  subdir: linux-64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 50068
+  timestamp: 1697283155584
+- platform: osx-64
+  name: aws-checksums
+  version: 0.1.17
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-h6cdfeff_3.conda
+  hash:
+    md5: 17e65df5303574a696923f9f8c08d8a3
+    sha256: a4d513e217fad50fdcf7dfec88b59a54b2b6b0c2e2567b57263bf720a1f02287
+  build: h6cdfeff_3
+  arch: x86_64
+  subdir: osx-64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 48720
+  timestamp: 1697283251979
+- platform: osx-arm64
+  name: aws-checksums
+  version: 0.1.17
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-ha251d5a_3.conda
+  hash:
+    md5: b1082e09e43f954ea65e947a6b5029af
+    sha256: 82534e9aa17aae584f4e3d1865f6d975c02bba98da326d309bcc309496448713
+  build: ha251d5a_3
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 49005
+  timestamp: 1697283369764
+- platform: win-64
+  name: aws-checksums
+  version: 0.1.17
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-h85219b4_3.conda
+  hash:
+    md5: 2df2f1365d32e5b26bee1cbe783ddc61
+    sha256: 3609917ce1c3110446f27a85d6e6fcaf170f5c77620c3e368a8ef401c5f779cc
+  build: h85219b4_3
+  arch: x86_64
+  subdir: win-64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 52275
+  timestamp: 1697283441613
+- platform: linux-64
+  name: aws-crt-cpp
+  version: 0.24.4
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
+  - aws-c-s3 >=0.3.20,<0.3.21.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.24.4-h28e6ea9_2.conda
+  hash:
+    md5: 12fcf00d22c16ae8663d2f0fe0068d0e
+    sha256: 4dadb6145750e12262feb062af3079321c9a4cd630247cbad756b5ddf7876e43
+  build: h28e6ea9_2
+  arch: x86_64
+  subdir: linux-64
+  build_number: 2
+  license: Apache-2.0
+  license_family: Apache
+  size: 326808
+  timestamp: 1698624104882
+- platform: osx-64
+  name: aws-crt-cpp
+  version: 0.24.4
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
+  - aws-c-s3 >=0.3.20,<0.3.21.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libcxx >=16.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.24.4-hf472077_2.conda
+  hash:
+    md5: bb45e023e76aa19b7a0c7eac7736fbb5
+    sha256: de45d12d968fe171879fe1f742c6daf6e9dec4e711261c8f6e1d398a12523875
+  build: hf472077_2
+  arch: x86_64
+  subdir: osx-64
+  build_number: 2
+  license: Apache-2.0
+  license_family: Apache
+  size: 275113
+  timestamp: 1698624323027
+- platform: osx-arm64
+  name: aws-crt-cpp
+  version: 0.24.4
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
+  - aws-c-s3 >=0.3.20,<0.3.21.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libcxx >=16.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.24.4-h5f3d163_2.conda
+  hash:
+    md5: 12893eeabfb81d7d6270f3798aab2e49
+    sha256: aa4fc69fa3bc88db6e7e4356ece31010b8bb140da553dffbe3e20823322e9a06
+  build: h5f3d163_2
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 2
+  license: Apache-2.0
+  license_family: Apache
+  size: 212825
+  timestamp: 1698624312953
+- platform: win-64
+  name: aws-crt-cpp
+  version: 0.24.4
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-auth >=0.7.5,<0.7.6.0a0
+  - aws-c-cal >=0.6.7,<0.6.8.0a0
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.35,<0.13.36.0a0
+  - aws-c-mqtt >=0.9.8,<0.9.9.0a0
+  - aws-c-s3 >=0.3.20,<0.3.21.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.24.4-h4ff64ff_2.conda
+  hash:
+    md5: 79ecfe45f6ac81d0f15b0365a498a4e6
+    sha256: 05c4dec9623c5bf6c7d8a39988c829a3c276fe221f054f8d6e48d68029fed492
+  build: h4ff64ff_2
+  arch: x86_64
+  subdir: win-64
+  build_number: 2
+  license: Apache-2.0
+  license_family: Apache
+  size: 236773
+  timestamp: 1698624647282
+- platform: linux-64
+  name: aws-sdk-cpp
+  version: 1.11.182
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.4,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.182-hb97d603_2.conda
+  hash:
+    md5: 4b28dbada9459f1d89c77939b9284388
+    sha256: d82ab8ee4babb48879f1971d70a5e90926cf784ac6e403c580bc0eb315736d34
+  build: hb97d603_2
+  arch: x86_64
+  subdir: linux-64
+  build_number: 2
+  license: Apache-2.0
+  license_family: Apache
+  size: 3417377
+  timestamp: 1698317685523
+- platform: osx-64
+  name: aws-sdk-cpp
+  version: 1.11.182
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.4,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.182-hfd15655_2.conda
+  hash:
+    md5: 69c5f6c1887d69cee963d5c5ca5fca0d
+    sha256: 842ec140fb99701d90d32d3c022a9b75f2d611a8ba60dd40cfbb6838bc5eb407
+  build: hfd15655_2
+  arch: x86_64
+  subdir: osx-64
+  build_number: 2
+  license: Apache-2.0
+  license_family: Apache
+  size: 3167371
+  timestamp: 1698318222973
+- platform: osx-arm64
+  name: aws-sdk-cpp
+  version: 1.11.182
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libcxx >=16.0.6
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.4,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.182-hba14a0b_2.conda
+  hash:
+    md5: c33be64b53d699de9c70e046594d90fc
+    sha256: 3380106fedbea5bf17fd8fffa7b089b25c034d79d687505921a9c82fd8dbf726
+  build: hba14a0b_2
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 2
+  license: Apache-2.0
+  license_family: Apache
+  size: 3186581
+  timestamp: 1698318357494
+- platform: win-64
+  name: aws-sdk-cpp
+  version: 1.11.182
+  category: main
+  manager: conda
+  dependencies:
+  - aws-c-common >=0.9.4,<0.9.5.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.182-h9479ca2_2.conda
+  hash:
+    md5: 3aa4471fb89baca6d88330c7cf5e4d5f
+    sha256: 3fb838bd24c109bfff19f751df5beb8cfaf78d0ab5ea1d11b9bb9b25e3e56ada
+  build: h9479ca2_2
+  arch: x86_64
+  subdir: win-64
+  build_number: 2
+  license: Apache-2.0
+  license_family: Apache
+  size: 3253371
+  timestamp: 1698319242118
+- platform: linux-64
+  name: binutils
+  version: '2.40'
+  category: main
+  manager: conda
+  dependencies:
+  - binutils_impl_linux-64 >=2.40,<2.41.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
   hash:
     md5: ccc940fddbc3fcd3d79cd4c654c4b5c4
     sha256: 35f3b042f295fd7387de11cf426ca8ee5257e5c98b88560c6c5ad4ef3c85d38c
-  optional: false
-  category: main
   build: hdd6e379_0
   arch: x86_64
   subdir: linux-64
@@ -202,19 +1449,18 @@ package:
   license_family: GPL
   size: 30469
   timestamp: 1674833987166
-- name: binutils_impl_linux-64
+- platform: linux-64
+  name: binutils_impl_linux-64
   version: '2.40'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    ld_impl_linux-64: ==2.40 h41732ed_0
-    sysroot_linux-64: '*'
+  - ld_impl_linux-64 ==2.40 h41732ed_0
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
   hash:
     md5: 33084421a8c0af6aef1b439707f7662a
     sha256: a7e0ea2b71a5b03d82e5a58fb6b612ab1c44d72ce161f9aa441f7ba467cd4c8d
-  optional: false
-  category: main
   build: hf600244_0
   arch: x86_64
   subdir: linux-64
@@ -223,19 +1469,18 @@ package:
   license_family: GPL
   size: 5414922
   timestamp: 1674833958334
-- name: binutils_linux-64
+- platform: linux-64
+  name: binutils_linux-64
   version: '2.40'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_impl_linux-64: 2.40.*
-    sysroot_linux-64: '*'
+  - binutils_impl_linux-64 2.40.*
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
   hash:
     md5: adfebae9fdc63a598495dfe3b006973a
     sha256: 333f3339d94c93bcc02a723e3e460cb6ff6075e05f5247e15bef5dcdcec541a3
-  optional: false
-  category: main
   build: hbdbef99_2
   arch: x86_64
   subdir: linux-64
@@ -244,18 +1489,17 @@ package:
   license_family: BSD
   size: 28178
   timestamp: 1694604071236
-- name: bzip2
+- platform: linux-64
+  name: bzip2
   version: 1.0.8
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
   hash:
     md5: a1fd65c7ccbf10880423d82bca54eb54
     sha256: cb521319804640ff2ad6a9f118d972ed76d86bea44e5626c09a13d38f562e1fa
-  optional: false
-  category: main
   build: h7f98852_4
   arch: x86_64
   subdir: linux-64
@@ -264,17 +1508,16 @@ package:
   license_family: BSD
   size: 495686
   timestamp: 1606604745109
-- name: bzip2
+- platform: osx-64
+  name: bzip2
   version: 1.0.8
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
   hash:
     md5: 37edc4e6304ca87316e160f5ca0bd1b5
     sha256: 60ba4c64f5d0afca0d283c7addba577d3e2efc0db86002808dadb0498661b2f2
-  optional: false
-  category: main
   build: h0d85af4_4
   arch: x86_64
   subdir: osx-64
@@ -283,17 +1526,16 @@ package:
   license_family: BSD
   size: 158829
   timestamp: 1618862580095
-- name: bzip2
+- platform: osx-arm64
+  name: bzip2
   version: 1.0.8
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
   hash:
     md5: fc76ace7b94fb1f694988ab1b14dd248
     sha256: a3efbd06ad1432edb0163c48225421f34c2660f5cc002283a8d27e791320b549
-  optional: false
-  category: main
   build: h3422bc3_4
   arch: aarch64
   subdir: osx-arm64
@@ -302,19 +1544,18 @@ package:
   license_family: BSD
   size: 151850
   timestamp: 1618862645215
-- name: bzip2
+- platform: win-64
+  name: bzip2
   version: 1.0.8
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
   hash:
     md5: 7c03c66026944073040cb19a4f3ec3c9
     sha256: 5389dad4e73e4865bb485f460fc60b120bae74404003d457ecb1a62eb7abf0c1
-  optional: false
-  category: main
   build: h8ffe710_4
   arch: x86_64
   subdir: win-64
@@ -323,18 +1564,17 @@ package:
   license_family: BSD
   size: 152247
   timestamp: 1606605223049
-- name: c-ares
+- platform: linux-64
+  name: c-ares
   version: 1.20.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.20.1-hd590300_1.conda
   hash:
     md5: 2facbaf5ee1a56967aecaee89799160e
     sha256: 1700d9ebfd3b21c8b50e12a502f26e015719e1f3dbb5d491b5be061cf148ca7a
-  optional: false
-  category: main
   build: hd590300_1
   arch: x86_64
   subdir: linux-64
@@ -343,17 +1583,16 @@ package:
   license_family: MIT
   size: 115956
   timestamp: 1697955875024
-- name: c-ares
+- platform: osx-64
+  name: c-ares
   version: 1.20.1
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.20.1-h10d778d_1.conda
   hash:
     md5: 0f9fe8eb46d409939d9b2a7d90a52325
     sha256: 9e99ffb7e3376188c1e0c8037982a8fdc08c5736ea28f2314c20b8846179f0fe
-  optional: false
-  category: main
   build: h10d778d_1
   arch: x86_64
   subdir: osx-64
@@ -362,17 +1601,16 @@ package:
   license_family: MIT
   size: 103592
   timestamp: 1697955959402
-- name: c-ares
+- platform: osx-arm64
+  name: c-ares
   version: 1.20.1
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.20.1-h93a5062_1.conda
   hash:
     md5: 2bb255dbcb73d1986e03cc5a7767c0bf
     sha256: 9f588eb920a793c6501120ed198d34afba763b2b2c0ae6de518c3735aea21d5e
-  optional: false
-  category: main
   build: h93a5062_1
   arch: aarch64
   subdir: osx-arm64
@@ -381,20 +1619,40 @@ package:
   license_family: MIT
   size: 101995
   timestamp: 1697955983023
-- name: c-compiler
-  version: 1.6.0
+- platform: win-64
+  name: c-ares
+  version: 1.20.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils: '*'
-    gcc: '*'
-    gcc_linux-64: 12.*
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.20.1-hcfcfb64_1.conda
+  hash:
+    md5: 0a45278f9b791a68dbe4acc234fa8a26
+    sha256: 817b2733caef6f8513ed6dc9a1b5883ddc9ac303eaf1971e4d4ec73080f6ab99
+  build: hcfcfb64_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 112068
+  timestamp: 1697956205060
+- platform: linux-64
+  name: c-compiler
+  version: 1.6.0
+  category: main
+  manager: conda
+  dependencies:
+  - binutils *
+  - gcc *
+  - gcc_linux-64 12.*
   url: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.6.0-hd590300_0.conda
   hash:
     md5: ea6c792f792bdd7ae6e7e2dee32f0a48
     sha256: d741ff93d5f71a83a9be0f592682f31ca2d468c37177f18a8d1a2469bb821c05
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -402,21 +1660,20 @@ package:
   license: BSD
   size: 6184
   timestamp: 1689097480051
-- name: c-compiler
+- platform: osx-64
+  name: c-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    cctools: '>=949.0.1'
-    clang_osx-64: 15.*
-    ld64: '>=530'
-    llvm-openmp: '*'
+  - cctools >=949.0.1
+  - clang_osx-64 15.*
+  - ld64 >=530
+  - llvm-openmp *
   url: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.6.0-h63c33a9_0.conda
   hash:
     md5: d7f3b8d3a85b4e7eded31adb611bb665
     sha256: fe43bbe1b7c809b618808123a662333c20417bc98ffa5dc7d6da23c3c8ec236b
-  optional: false
-  category: main
   build: h63c33a9_0
   arch: x86_64
   subdir: osx-64
@@ -424,21 +1681,20 @@ package:
   license: BSD
   size: 6250
   timestamp: 1689097835926
-- name: c-compiler
+- platform: osx-arm64
+  name: c-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    cctools: '>=949.0.1'
-    clang_osx-arm64: 15.*
-    ld64: '>=530'
-    llvm-openmp: '*'
+  - cctools >=949.0.1
+  - clang_osx-arm64 15.*
+  - ld64 >=530
+  - llvm-openmp *
   url: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.6.0-hd291e01_0.conda
   hash:
     md5: 7d58fb216ad601b545826449d8d4c34e
     sha256: f2e837668ff628ef8b5d54fffbfe9596cdd3820f7c5a3fc5ad48b259ff99a501
-  optional: false
-  category: main
   build: hd291e01_0
   arch: aarch64
   subdir: osx-arm64
@@ -446,17 +1702,16 @@ package:
   license: BSD
   size: 6269
   timestamp: 1689097851052
-- name: ca-certificates
+- platform: linux-64
+  name: ca-certificates
   version: 2023.7.22
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
   hash:
     md5: a73ecd2988327ad4c8f2c331482917f2
     sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
-  optional: false
-  category: main
   build: hbcca054_0
   arch: x86_64
   subdir: linux-64
@@ -464,17 +1719,16 @@ package:
   license: ISC
   size: 149515
   timestamp: 1690026108541
-- name: ca-certificates
+- platform: osx-64
+  name: ca-certificates
   version: 2023.7.22
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
   hash:
     md5: bf2c54c18997bf3542af074c10191771
     sha256: 27de15e18a12117e83ac1eb8a8e52eb65731cc7f0b607a7922206a15e2460c7b
-  optional: false
-  category: main
   build: h8857fd0_0
   arch: x86_64
   subdir: osx-64
@@ -482,17 +1736,16 @@ package:
   license: ISC
   size: 149911
   timestamp: 1690026363769
-- name: ca-certificates
+- platform: osx-arm64
+  name: ca-certificates
   version: 2023.7.22
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
   hash:
     md5: e1b99ac4dbcee71a71682996f67f7965
     sha256: b220c001b0c1448a47cc49b42a622e06a540ec60b3f7a1e057fca1f37ce515e4
-  optional: false
-  category: main
   build: hf0a4a13_0
   arch: aarch64
   subdir: osx-arm64
@@ -500,17 +1753,16 @@ package:
   license: ISC
   size: 149918
   timestamp: 1690026385821
-- name: ca-certificates
+- platform: win-64
+  name: ca-certificates
   version: 2023.7.22
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
   hash:
     md5: b1c2327b36f1a25d96f2039b0d3e3739
     sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
-  optional: false
-  category: main
   build: h56e8100_0
   arch: x86_64
   subdir: win-64
@@ -518,34 +1770,33 @@ package:
   license: ISC
   size: 150013
   timestamp: 1690026269050
-- name: cairo
+- platform: linux-64
+  name: cairo
   version: 1.18.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pixman: '>=0.42.2,<1.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
-    xorg-libsm: '>=1.2.4,<2.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
-    zlib: '*'
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pixman >=0.42.2,<1.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
+  - zlib *
   url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
   hash:
     md5: f907bb958910dc404647326ca80c263e
     sha256: 142e2639a5bc0e99c44d76f4cc8dce9c6a2d87330c4beeabb128832cd871a86e
-  optional: false
-  category: main
   build: h3faef2a_0
   arch: x86_64
   subdir: linux-64
@@ -553,28 +1804,27 @@ package:
   license: LGPL-2.1-only or MPL-1.1
   size: 982351
   timestamp: 1697028423052
-- name: cairo
+- platform: osx-64
+  name: cairo
   version: 1.18.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=16.0.6'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pixman: '>=0.42.2,<1.0a0'
-    zlib: '*'
+  - __osx >=10.9
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pixman >=0.42.2,<1.0a0
+  - zlib *
   url: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
   hash:
     md5: 13f830b1bf46018f7062d1b798d53eca
     sha256: f8d1142cf244eadcbc44e8ca2266aa61a05b6cda5571f9b745ba32c7ebbfdfba
-  optional: false
-  category: main
   build: h99e66fa_0
   arch: x86_64
   subdir: osx-64
@@ -582,28 +1832,27 @@ package:
   license: LGPL-2.1-only or MPL-1.1
   size: 885311
   timestamp: 1697028802967
-- name: cairo
+- platform: osx-arm64
+  name: cairo
   version: 1.18.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=16.0.6'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pixman: '>=0.42.2,<1.0a0'
-    zlib: '*'
+  - __osx >=10.9
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pixman >=0.42.2,<1.0a0
+  - zlib *
   url: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
   hash:
     md5: 3fa6eebabb77f65e82f86b72b95482db
     sha256: 599f8820553b3a3405706d9cad390ac199e24515a0a82c87153c9b5b5fdba3b8
-  optional: false
-  category: main
   build: hd1e100b_0
   arch: aarch64
   subdir: osx-arm64
@@ -611,29 +1860,28 @@ package:
   license: LGPL-2.1-only or MPL-1.1
   size: 897919
   timestamp: 1697028755150
-- name: cairo
+- platform: win-64
+  name: cairo
   version: 1.18.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    icu: '>=73.2,<74.0a0'
-    libglib: '>=2.78.0,<3.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pixman: '>=0.42.2,<1.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    zlib: '*'
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - icu >=73.2,<74.0a0
+  - libglib >=2.78.0,<3.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pixman >=0.42.2,<1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib *
   url: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
   hash:
     md5: b3fe2c6381ec74afe8128e16a11eee02
     sha256: 451e714f065b5dd0c11169058be56b10973dfd7d9a0fccf9c6a05d1e09995730
-  optional: false
-  category: main
   build: h1fef639_0
   arch: x86_64
   subdir: win-64
@@ -641,20 +1889,19 @@ package:
   license: LGPL-2.1-only or MPL-1.1
   size: 1520159
   timestamp: 1697029136038
-- name: cctools
+- platform: osx-64
+  name: cctools
   version: 973.0.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    cctools_osx-64: ==973.0.1 habff3f6_15
-    ld64: ==609 ha91a046_15
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - cctools_osx-64 ==973.0.1 habff3f6_15
+  - ld64 ==609 ha91a046_15
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-hd9ad811_15.conda
   hash:
     md5: 00374d616829d1e4d2266e571147848a
     sha256: 6fc0e86e24687cde3476e04f001ac1edf5813c0caa15b72c913b660533428987
-  optional: false
-  category: main
   build: hd9ad811_15
   arch: x86_64
   subdir: osx-64
@@ -663,20 +1910,19 @@ package:
   license_family: Other
   size: 21917
   timestamp: 1697075797642
-- name: cctools
+- platform: osx-arm64
+  name: cctools
   version: 973.0.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    cctools_osx-arm64: ==973.0.1 h2a25c60_15
-    ld64: ==609 h89fa09d_15
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - cctools_osx-arm64 ==973.0.1 h2a25c60_15
+  - ld64 ==609 h89fa09d_15
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-hd1ac623_15.conda
   hash:
     md5: bea60d4b6c7112c9d906cd8380498c99
     sha256: 19355c566c376acba7beed4c6f68a2c09fa1b5bbbbcacc6375c2fcb90faf6063
-  optional: false
-  category: main
   build: hd1ac623_15
   arch: aarch64
   subdir: osx-arm64
@@ -685,22 +1931,21 @@ package:
   license_family: Other
   size: 21948
   timestamp: 1697075946023
-- name: cctools_osx-64
+- platform: osx-64
+  name: cctools_osx-64
   version: 973.0.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ld64_osx-64: '>=609,<610.0a0'
-    libcxx: '*'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    sigtool: '*'
+  - ld64_osx-64 >=609,<610.0a0
+  - libcxx *
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sigtool *
   url: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-habff3f6_15.conda
   hash:
     md5: 015a19b3900b9fce20a48551e66f7699
     sha256: ca00afdafb22d6c363921f1c81b35fabd9b7eefee7e1ea2ad4f0fe920b63d035
-  optional: false
-  category: main
   build: habff3f6_15
   arch: x86_64
   subdir: osx-64
@@ -713,22 +1958,21 @@ package:
   license_family: Other
   size: 1116869
   timestamp: 1697075736696
-- name: cctools_osx-arm64
+- platform: osx-arm64
+  name: cctools_osx-arm64
   version: 973.0.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ld64_osx-arm64: '>=609,<610.0a0'
-    libcxx: '*'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    sigtool: '*'
+  - ld64_osx-arm64 >=609,<610.0a0
+  - libcxx *
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - sigtool *
   url: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h2a25c60_15.conda
   hash:
     md5: e177015a6a6500334b9cac9144fc657d
     sha256: 723e1888736b0376b7ca16cc1a0e96a038aa92eabb6b15978cfa3ce7586767f0
-  optional: false
-  category: main
   build: h2a25c60_15
   arch: aarch64
   subdir: osx-arm64
@@ -741,18 +1985,17 @@ package:
   license_family: Other
   size: 1123180
   timestamp: 1697075906785
-- name: clang
+- platform: osx-64
+  name: clang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang-15: ==15.0.7 default_hdb78580_3
+  - clang-15 ==15.0.7 default_hdb78580_3
   url: https://conda.anaconda.org/conda-forge/osx-64/clang-15.0.7-h694c41f_3.conda
   hash:
     md5: 8a48d466e519b8db7dda7c5d27cc1d31
     sha256: 3eab054ba786b0b80609bea17342385dcbdce69c6158e6ec7443f4f940c92883
-  optional: false
-  category: main
   build: h694c41f_3
   arch: x86_64
   subdir: osx-64
@@ -766,18 +2009,17 @@ package:
   license_family: Apache
   size: 132843
   timestamp: 1690549855885
-- name: clang
+- platform: osx-arm64
+  name: clang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang-15: ==15.0.7 default_h5dc8d65_3
+  - clang-15 ==15.0.7 default_h5dc8d65_3
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-15.0.7-hce30654_3.conda
   hash:
     md5: 0871ba77c4bec31504b371a4f2525a7b
     sha256: 7eceef0863863c7e6c8752ca8359dedebc87cc9fba108856533115e2d9a8d9ba
-  optional: false
-  category: main
   build: hce30654_3
   arch: aarch64
   subdir: osx-arm64
@@ -791,20 +2033,19 @@ package:
   license_family: Apache
   size: 133018
   timestamp: 1690549798814
-- name: clang-15
+- platform: osx-64
+  name: clang-15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libclang-cpp15: ==15.0.7 default_hdb78580_3
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libclang-cpp15 ==15.0.7 default_hdb78580_3
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/clang-15-15.0.7-default_hdb78580_3.conda
   hash:
     md5: 688d6b9e178cb7786a07e3cfca2a8f09
     sha256: 686abd626e3fe42c040c77e38b5c07d4fe5cd6f1561feb4b92ffbbba6b36e262
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -818,20 +2059,19 @@ package:
   license_family: Apache
   size: 794748
   timestamp: 1690549737577
-- name: clang-15
+- platform: osx-arm64
+  name: clang-15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libclang-cpp15: ==15.0.7 default_h5dc8d65_3
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libclang-cpp15 ==15.0.7 default_h5dc8d65_3
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang-15-15.0.7-default_h5dc8d65_3.conda
   hash:
     md5: 3b214c8a23030d3a04389cbcd4bb84e4
     sha256: 92d974b4675fa1f56f5ba1f396cc811a830ecbba0195ef1697235298535fad39
-  optional: false
-  category: main
   build: default_h5dc8d65_3
   arch: aarch64
   subdir: osx-arm64
@@ -845,22 +2085,21 @@ package:
   license_family: Apache
   size: 795051
   timestamp: 1690549670667
-- name: clang_impl_osx-64
+- platform: osx-64
+  name: clang_impl_osx-64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    cctools_osx-64: '*'
-    clang: 15.0.7.*
-    compiler-rt: 15.0.7.*
-    ld64_osx-64: '*'
-    llvm-tools: 15.0.7.*
+  - cctools_osx-64 *
+  - clang 15.0.7.*
+  - compiler-rt 15.0.7.*
+  - ld64_osx-64 *
+  - llvm-tools 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-15.0.7-h03d6864_6.conda
   hash:
     md5: d48ec30d072d16029d56a2aa6e47b5a9
     sha256: b5f6643336b3c6ed7b0df47e50b1697a625a56c06fb365031f823e1f3072e293
-  optional: false
-  category: main
   build: h03d6864_6
   arch: x86_64
   subdir: osx-64
@@ -869,22 +2108,21 @@ package:
   license_family: BSD
   size: 17513
   timestamp: 1698100428923
-- name: clang_impl_osx-arm64
+- platform: osx-arm64
+  name: clang_impl_osx-arm64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    cctools_osx-arm64: '*'
-    clang: 15.0.7.*
-    compiler-rt: 15.0.7.*
-    ld64_osx-arm64: '*'
-    llvm-tools: 15.0.7.*
+  - cctools_osx-arm64 *
+  - clang 15.0.7.*
+  - compiler-rt 15.0.7.*
+  - ld64_osx-arm64 *
+  - llvm-tools 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-15.0.7-h77e971b_6.conda
   hash:
     md5: 9601e8b7f026068456c08a3eee9d453a
     sha256: 4100e7ad7d3932611a31b3b6cbc3c2340db580b1dfb8dc05d2c57681148739b2
-  optional: false
-  category: main
   build: h77e971b_6
   arch: aarch64
   subdir: osx-arm64
@@ -893,18 +2131,17 @@ package:
   license_family: BSD
   size: 17716
   timestamp: 1698100635950
-- name: clang_osx-64
+- platform: osx-64
+  name: clang_osx-64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang_impl_osx-64: ==15.0.7 h03d6864_6
+  - clang_impl_osx-64 ==15.0.7 h03d6864_6
   url: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-15.0.7-hb91bd55_6.conda
   hash:
     md5: acea2fd2b383c33e9b727b636b2672cb
     sha256: 8db9ad5876b5c3d12fa6e5c67dcd2dd11577e9aedf1f6db8b61860689c3a6356
-  optional: false
-  category: main
   build: hb91bd55_6
   arch: x86_64
   subdir: osx-64
@@ -913,18 +2150,17 @@ package:
   license_family: BSD
   size: 20598
   timestamp: 1698100444702
-- name: clang_osx-arm64
+- platform: osx-arm64
+  name: clang_osx-arm64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang_impl_osx-arm64: ==15.0.7 h77e971b_6
+  - clang_impl_osx-arm64 ==15.0.7 h77e971b_6
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-15.0.7-h54d7cd3_6.conda
   hash:
     md5: 1eacc867f5e1114eaff48e7d6c08007e
     sha256: e2e065818caf031a9241e92d189a8750d48028d8b3f0cfa92324d733adba614d
-  optional: false
-  category: main
   build: h54d7cd3_6
   arch: aarch64
   subdir: osx-arm64
@@ -933,18 +2169,17 @@ package:
   license_family: BSD
   size: 20662
   timestamp: 1698100648643
-- name: clangxx
+- platform: osx-64
+  name: clangxx
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang: ==15.0.7 h694c41f_3
+  - clang ==15.0.7 h694c41f_3
   url: https://conda.anaconda.org/conda-forge/osx-64/clangxx-15.0.7-default_hdb78580_3.conda
   hash:
     md5: 58df9ff86fefc7684670be729b41412f
     sha256: b68fbe1f7c401401622b61f9e65be6fffae4104727c2f39feacede5c393fa65e
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -953,18 +2188,17 @@ package:
   license_family: Apache
   size: 132973
   timestamp: 1690549872764
-- name: clangxx
+- platform: osx-arm64
+  name: clangxx
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang: ==15.0.7 hce30654_3
+  - clang ==15.0.7 hce30654_3
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-15.0.7-default_h610c423_3.conda
   hash:
     md5: 1919a441b26f5cd1181870be6b4ce31a
     sha256: 59e1545bac0207bb8b82c3718a16ec79dd9ac218eb00679f8cb5ed2cd115ffe3
-  optional: false
-  category: main
   build: default_h610c423_3
   arch: aarch64
   subdir: osx-arm64
@@ -973,22 +2207,21 @@ package:
   license_family: Apache
   size: 133212
   timestamp: 1690549817560
-- name: clangxx_impl_osx-64
+- platform: osx-64
+  name: clangxx_impl_osx-64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    clang_osx-64: ==15.0.7 hb91bd55_6
-    clangxx: 15.0.7.*
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - __osx >=10.9
+  - clang_osx-64 ==15.0.7 hb91bd55_6
+  - clangxx 15.0.7.*
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-15.0.7-h3d2d1bf_6.conda
   hash:
     md5: 078a573cbedf1e34e5966c8d867f7ba3
     sha256: dafe4db74b909964f13eb1870ec3c968e58eb7473f9c431bc459ff371facc5ea
-  optional: false
-  category: main
   build: h3d2d1bf_6
   arch: x86_64
   subdir: osx-64
@@ -997,21 +2230,20 @@ package:
   license_family: BSD
   size: 17696
   timestamp: 1698100460114
-- name: clangxx_impl_osx-arm64
+- platform: osx-arm64
+  name: clangxx_impl_osx-arm64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang_osx-arm64: ==15.0.7 h54d7cd3_6
-    clangxx: 15.0.7.*
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - clang_osx-arm64 ==15.0.7 h54d7cd3_6
+  - clangxx 15.0.7.*
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-15.0.7-h768a7fd_6.conda
   hash:
     md5: 914b24809e452f46891df028cdaad506
     sha256: 03318cce948fdd28762cdb1cd1a48edea40dc363ca64255bc8c21e5492a64bb8
-  optional: false
-  category: main
   build: h768a7fd_6
   arch: aarch64
   subdir: osx-arm64
@@ -1020,19 +2252,18 @@ package:
   license_family: BSD
   size: 17807
   timestamp: 1698100665707
-- name: clangxx_osx-64
+- platform: osx-64
+  name: clangxx_osx-64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang_osx-64: ==15.0.7 hb91bd55_6
-    clangxx_impl_osx-64: ==15.0.7 h3d2d1bf_6
+  - clang_osx-64 ==15.0.7 hb91bd55_6
+  - clangxx_impl_osx-64 ==15.0.7 h3d2d1bf_6
   url: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-15.0.7-h655633e_6.conda
   hash:
     md5: 4635902b855661470b43a7b48b5e55d6
     sha256: f3c59ff3285b98e4d1dc1dfd86eab0e3a6323608b12d12a4be5c1edd7e0ec7e7
-  optional: false
-  category: main
   build: h655633e_6
   arch: x86_64
   subdir: osx-64
@@ -1041,19 +2272,18 @@ package:
   license_family: BSD
   size: 19394
   timestamp: 1698100472970
-- name: clangxx_osx-arm64
+- platform: osx-arm64
+  name: clangxx_osx-arm64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang_osx-arm64: ==15.0.7 h54d7cd3_6
-    clangxx_impl_osx-arm64: ==15.0.7 h768a7fd_6
+  - clang_osx-arm64 ==15.0.7 h54d7cd3_6
+  - clangxx_impl_osx-arm64 ==15.0.7 h768a7fd_6
   url: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-15.0.7-h77e971b_6.conda
   hash:
     md5: 3f65a988ce3856c472136893d33ad776
     sha256: 7ec6ab7f5578e28a752acf806a24d503d171756f3c9795da88dd7829789e487f
-  optional: false
-  category: main
   build: h77e971b_6
   arch: aarch64
   subdir: osx-arm64
@@ -1062,28 +2292,27 @@ package:
   license_family: BSD
   size: 19459
   timestamp: 1698100680003
-- name: cmake
+- platform: linux-64
+  name: cmake
   version: 3.27.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libuv: '>=1.46.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    rhash: '>=1.4.4,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libuv >=1.46.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
   hash:
     md5: 4c0101485c452ea86f846523c4fae698
     sha256: 64e08c246195d6956f7a04fa7d96a53de696b26b1dae8b08cfe716950f696e12
-  optional: false
-  category: main
   build: hcfe8598_0
   arch: x86_64
   subdir: linux-64
@@ -1092,27 +2321,26 @@ package:
   license_family: BSD
   size: 18494905
   timestamp: 1695269729661
-- name: cmake
+- platform: osx-64
+  name: cmake
   version: 3.27.6
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libcxx: '>=15.0.7'
-    libexpat: '>=2.5.0,<3.0a0'
-    libuv: '>=1.46.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    rhash: '>=1.4.4,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=15.0.7
+  - libexpat >=2.5.0,<3.0a0
+  - libuv >=1.46.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
   hash:
     md5: 771da6a52aaf0f9d84114d0ed0d0299f
     sha256: 9216698f88b82e99db950f8c372038931c54ea3e0b0b05e2a3ce03ec4b405df7
-  optional: false
-  category: main
   build: hf40c264_0
   arch: x86_64
   subdir: osx-64
@@ -1121,27 +2349,26 @@ package:
   license_family: BSD
   size: 16525734
   timestamp: 1695270838345
-- name: cmake
+- platform: osx-arm64
+  name: cmake
   version: 3.27.6
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libcxx: '>=15.0.7'
-    libexpat: '>=2.5.0,<3.0a0'
-    libuv: '>=1.46.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    rhash: '>=1.4.4,<2.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=15.0.7
+  - libexpat >=2.5.0,<3.0a0
+  - libuv >=1.46.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - rhash >=1.4.4,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
   hash:
     md5: 3c0dd04401438fec44cd113247ba2852
     sha256: 31be31e358e6f6f8818d8f9c9086da4404f8c6fc89d71d55887bed11ce6d463e
-  optional: false
-  category: main
   build: h1c59155_0
   arch: aarch64
   subdir: osx-arm64
@@ -1150,26 +2377,25 @@ package:
   license_family: BSD
   size: 16007289
   timestamp: 1695270816826
-- name: cmake
+- platform: win-64
+  name: cmake
   version: 3.27.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.3.0,<9.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libuv: '>=1.44.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc14_runtime: '>=14.29.30139'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libuv >=1.44.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
   hash:
     md5: 4dc81f3bf26f0949fedd4e31cecea1d1
     sha256: 12b94bce6d7c76ff408f8ea240c7d78987b0bc3cb4f632f381c4b0efd30ebfe0
-  optional: false
-  category: main
   build: hf0feee3_0
   arch: x86_64
   subdir: win-64
@@ -1178,20 +2404,19 @@ package:
   license_family: BSD
   size: 13777396
   timestamp: 1695270971791
-- name: compiler-rt
+- platform: osx-64
+  name: compiler-rt
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang: 15.0.7.*
-    clangxx: 15.0.7.*
-    compiler-rt_osx-64: 15.0.7.*
+  - clang 15.0.7.*
+  - clangxx 15.0.7.*
+  - compiler-rt_osx-64 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-15.0.7-he1888fc_1.conda
   hash:
     md5: 8ec296a4b097aeb2d85eafaf745c770a
     sha256: 90a2dd7a9baf8d6ddde9d11ad682dbd74f74c1f40ce0e4e9df7c356b0275ca31
-  optional: false
-  category: main
   build: he1888fc_1
   arch: x86_64
   subdir: osx-64
@@ -1200,20 +2425,19 @@ package:
   license_family: APACHE
   size: 92129
   timestamp: 1684403261646
-- name: compiler-rt
+- platform: osx-arm64
+  name: compiler-rt
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang: 15.0.7.*
-    clangxx: 15.0.7.*
-    compiler-rt_osx-arm64: 15.0.7.*
+  - clang 15.0.7.*
+  - clangxx 15.0.7.*
+  - compiler-rt_osx-arm64 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-15.0.7-hf8d1dfb_1.conda
   hash:
     md5: 355703f3e33fd12037800d28680845cb
     sha256: d2ab8bc610038e40dafdb6b6172343553f1f3aba4e9a4c540e878474062b1b89
-  optional: false
-  category: main
   build: hf8d1dfb_1
   arch: aarch64
   subdir: osx-arm64
@@ -1222,19 +2446,18 @@ package:
   license_family: APACHE
   size: 92034
   timestamp: 1684403020973
-- name: compiler-rt_osx-64
+- platform: osx-64
+  name: compiler-rt_osx-64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    clang: 15.0.7.*
-    clangxx: 15.0.7.*
+  - clang 15.0.7.*
+  - clangxx 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-15.0.7-he1888fc_1.conda
   hash:
     md5: e1f93ea86259a549f2dcbfd245bf0422
     sha256: a2c19b4ec885e668266f5dd0e90193d9436c0be63c370c91ae1b840a19071159
-  optional: false
-  category: main
   build: he1888fc_1
   arch: x86_64
   subdir: osx-64
@@ -1246,19 +2469,18 @@ package:
   noarch: generic
   size: 11208907
   timestamp: 1684403213219
-- name: compiler-rt_osx-arm64
+- platform: osx-arm64
+  name: compiler-rt_osx-arm64
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    clang: 15.0.7.*
-    clangxx: 15.0.7.*
+  - clang 15.0.7.*
+  - clangxx 15.0.7.*
   url: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-15.0.7-hf8d1dfb_1.conda
   hash:
     md5: 0722cbdc69a52c82acc4e265913a21cd
     sha256: 5a801e344b2a18983199190cb34ad798e3ce5966a4a4031c74f7e395d8c38802
-  optional: false
-  category: main
   build: hf8d1dfb_1
   arch: aarch64
   subdir: osx-arm64
@@ -1270,20 +2492,19 @@ package:
   noarch: generic
   size: 11283089
   timestamp: 1684402974671
-- name: cxx-compiler
+- platform: linux-64
+  name: cxx-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    c-compiler: ==1.6.0 hd590300_0
-    gxx: '*'
-    gxx_linux-64: 12.*
+  - c-compiler ==1.6.0 hd590300_0
+  - gxx *
+  - gxx_linux-64 12.*
   url: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.6.0-h00ab1b0_0.conda
   hash:
     md5: 364c6ae36c4e36fcbd4d273cf4db78af
     sha256: 472b6b7f967df1db634c67d71c6b31cd186d18b5d0548196c2e426833ff17d99
-  optional: false
-  category: main
   build: h00ab1b0_0
   arch: x86_64
   subdir: linux-64
@@ -1291,19 +2512,18 @@ package:
   license: BSD
   size: 6179
   timestamp: 1689097484095
-- name: cxx-compiler
+- platform: osx-64
+  name: cxx-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    c-compiler: ==1.6.0 h63c33a9_0
-    clangxx_osx-64: 15.*
+  - c-compiler ==1.6.0 h63c33a9_0
+  - clangxx_osx-64 15.*
   url: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h1c7c39f_0.conda
   hash:
     md5: 9adaf7c9d4e1e15e70a8dd46befbbab2
     sha256: dc0860c05ef3083192b8ff4ac8242403f05a550cc42c7709ec8c9f4eaa88e993
-  optional: false
-  category: main
   build: h1c7c39f_0
   arch: x86_64
   subdir: osx-64
@@ -1311,19 +2531,18 @@ package:
   license: BSD
   size: 6258
   timestamp: 1689097854160
-- name: cxx-compiler
+- platform: osx-arm64
+  name: cxx-compiler
   version: 1.6.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    c-compiler: ==1.6.0 hd291e01_0
-    clangxx_osx-arm64: 15.*
+  - c-compiler ==1.6.0 hd291e01_0
+  - clangxx_osx-arm64 15.*
   url: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h1995070_0.conda
   hash:
     md5: 35c1be0a08578238276ca9417fc1615c
     sha256: f0a94c6312d0fd9e3d3c3546894bafa9f9b8b20a411bee0767ad4dac916f3eb5
-  optional: false
-  category: main
   build: h1995070_0
   arch: aarch64
   subdir: osx-arm64
@@ -1331,18 +2550,17 @@ package:
   license: BSD
   size: 6301
   timestamp: 1689097905706
-- name: dav1d
+- platform: linux-64
+  name: dav1d
   version: 1.2.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
   hash:
     md5: 418c6ca5929a611cbd69204907a83995
     sha256: 22053a5842ca8ee1cf8e1a817138cdb5e647eb2c46979f84153f6ad7bde73020
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -1351,17 +2569,16 @@ package:
   license_family: BSD
   size: 760229
   timestamp: 1685695754230
-- name: dav1d
+- platform: osx-64
+  name: dav1d
   version: 1.2.1
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
   hash:
     md5: 9d88733c715300a39f8ca2e936b7808d
     sha256: ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96
-  optional: false
-  category: main
   build: h0dc2134_0
   arch: x86_64
   subdir: osx-64
@@ -1370,17 +2587,16 @@ package:
   license_family: BSD
   size: 668439
   timestamp: 1685696184631
-- name: dav1d
+- platform: osx-arm64
+  name: dav1d
   version: 1.2.1
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
   hash:
     md5: 5a74cdee497e6b65173e10d94582fae6
     sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
-  optional: false
-  category: main
   build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
@@ -1389,20 +2605,19 @@ package:
   license_family: BSD
   size: 316394
   timestamp: 1685695959391
-- name: dav1d
+- platform: win-64
+  name: dav1d
   version: 1.2.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
   hash:
     md5: ed2c27bda330e3f0ab41577cf8b9b585
     sha256: 2aa2083c9c186da7d6f975ccfbef654ed54fff27f4bc321dbcd12cee932ec2c4
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -1411,20 +2626,19 @@ package:
   license_family: BSD
   size: 618643
   timestamp: 1685696352968
-- name: dbus
+- platform: linux-64
+  name: dbus
   version: 1.13.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    expat: '>=2.4.2,<3.0a0'
-    libgcc-ng: '>=9.4.0'
-    libglib: '>=2.70.2,<3.0a0'
+  - expat >=2.4.2,<3.0a0
+  - libgcc-ng >=9.4.0
+  - libglib >=2.70.2,<3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
   hash:
     md5: ecfff944ba3960ecb334b9a2663d708d
     sha256: 8f5f995699a2d9dbdd62c61385bfeeb57c82a681a7c8c5313c395aa0ccab68a5
-  optional: false
-  category: main
   build: h5008d03_3
   arch: x86_64
   subdir: linux-64
@@ -1433,19 +2647,18 @@ package:
   license_family: GPL
   size: 618596
   timestamp: 1640112124844
-- name: eigen
+- platform: linux-64
+  name: eigen
   version: 3.4.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
   hash:
     md5: b1b879d6d093f55dd40d58b5eb2f0699
     sha256: 53b15a98aadbe0704479bacaf7a5618fcb32d1577be320630674574241639b34
-  optional: false
-  category: main
   build: h00ab1b0_0
   arch: x86_64
   subdir: linux-64
@@ -1454,18 +2667,17 @@ package:
   license_family: MOZILLA
   size: 1088433
   timestamp: 1690272126173
-- name: eigen
+- platform: osx-64
+  name: eigen
   version: 3.4.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
   hash:
     md5: 5b2cfc277e3d42d84a2a648825761156
     sha256: 187c0677e0cdcdc39aed716687a6290dd5b7f52b49eedaef2ed76be6cd0a5a3d
-  optional: false
-  category: main
   build: h1c7c39f_0
   arch: x86_64
   subdir: osx-64
@@ -1474,18 +2686,17 @@ package:
   license_family: MOZILLA
   size: 1090184
   timestamp: 1690272503232
-- name: eigen
+- platform: osx-arm64
+  name: eigen
   version: 3.4.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
   hash:
     md5: 3691ea3ff568ba38826389bafc717909
     sha256: c20b3677b16d8907343fce68e7c437184fef7f5ed0a765c104b775f8a485c5c9
-  optional: false
-  category: main
   build: h1995070_0
   arch: aarch64
   subdir: osx-arm64
@@ -1494,20 +2705,19 @@ package:
   license_family: MOZILLA
   size: 1087751
   timestamp: 1690275869049
-- name: eigen
+- platform: win-64
+  name: eigen
   version: 3.4.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
   hash:
     md5: 305b3ca7023ac046b9a42a48661f6512
     sha256: 633a6a8db1f9a010cb0619f3446fb61f62dea348b09615ffae9744ab1001c24c
-  optional: false
-  category: main
   build: h91493d7_0
   arch: x86_64
   subdir: win-64
@@ -1516,19 +2726,18 @@ package:
   license_family: MOZILLA
   size: 1089706
   timestamp: 1690273089254
-- name: expat
+- platform: linux-64
+  name: expat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libexpat: ==2.5.0 hcb278e6_1
-    libgcc-ng: '>=12'
+  - libexpat ==2.5.0 hcb278e6_1
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
   hash:
     md5: 8b9b5aca60558d02ddaa09d599e55920
     sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
-  optional: false
-  category: main
   build: hcb278e6_1
   arch: x86_64
   subdir: linux-64
@@ -1537,18 +2746,17 @@ package:
   license_family: MIT
   size: 136778
   timestamp: 1680190541750
-- name: expat
+- platform: osx-64
+  name: expat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libexpat: ==2.5.0 hf0c8a7f_1
+  - libexpat ==2.5.0 hf0c8a7f_1
   url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
   hash:
     md5: e12630038077877cbb6c7851e139c17c
     sha256: 15c04a5a690b337b50fb7550cce057d843cf94dd0109d576ec9bc3448a8571d0
-  optional: false
-  category: main
   build: hf0c8a7f_1
   arch: x86_64
   subdir: osx-64
@@ -1557,18 +2765,17 @@ package:
   license_family: MIT
   size: 120323
   timestamp: 1680191057827
-- name: expat
+- platform: osx-arm64
+  name: expat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libexpat: ==2.5.0 hb7217d7_1
+  - libexpat ==2.5.0 hb7217d7_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
   hash:
     md5: 624fa0dd6fdeaa650b71a62296fdfedf
     sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
-  optional: false
-  category: main
   build: hb7217d7_1
   arch: aarch64
   subdir: osx-arm64
@@ -1577,18 +2784,17 @@ package:
   license_family: MIT
   size: 117851
   timestamp: 1680190940654
-- name: expat
+- platform: win-64
+  name: expat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libexpat: ==2.5.0 h63175ca_1
+  - libexpat ==2.5.0 h63175ca_1
   url: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
   hash:
     md5: 87c77fe1b445aedb5c6d207dd236fa3e
     sha256: 3bcd88290cd462d5573c2923c796599d0dece2ff9d9c9d6c914d31e9c5881aaf
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
@@ -1597,38 +2803,37 @@ package:
   license_family: MIT
   size: 226571
   timestamp: 1680190888036
-- name: ffmpeg
+- platform: linux-64
+  name: ffmpeg
   version: 6.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    aom: '>=3.6.1,<3.7.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    dav1d: '>=1.2.1,<1.2.2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    gmp: '>=6.2.1,<7.0a0'
-    gnutls: '>=3.7.8,<3.8.0a0'
-    lame: '>=3.100,<3.101.0a0'
-    libass: '>=0.17.1,<0.17.2.0a0'
-    libgcc-ng: '>=12'
-    libopus: '>=1.3.1,<2.0a0'
-    libstdcxx-ng: '>=12'
-    libva: '>=2.20.0,<3.0a0'
-    libvpx: '>=1.13.0,<1.14.0a0'
-    libxml2: '>=2.11.5,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openh264: '>=2.3.1,<2.3.2.0a0'
-    svt-av1: '>=1.7.0,<1.7.1.0a0'
-    x264: '>=1!164.3095,<1!165'
-    x265: '>=3.5,<3.6.0a0'
+  - aom >=3.6.1,<3.7.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.2.1,<7.0a0
+  - gnutls >=3.7.8,<3.8.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libgcc-ng >=12
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libva >=2.20.0,<3.0a0
+  - libvpx >=1.13.0,<1.14.0a0
+  - libxml2 >=2.11.5,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.3.1,<2.3.2.0a0
+  - svt-av1 >=1.7.0,<1.7.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.0.0-gpl_h334edf3_105.conda
   hash:
     md5: d47c3e10d2ca5fc07107d4ac640603da
     sha256: f1f9070190bc189b9ec9034e9d9adbbb530cd25b571c763b33585195c0e13813
-  optional: false
-  category: main
   build: gpl_h334edf3_105
   arch: x86_64
   subdir: linux-64
@@ -1637,37 +2842,36 @@ package:
   license_family: GPL
   size: 9863087
   timestamp: 1696214559606
-- name: ffmpeg
+- platform: osx-64
+  name: ffmpeg
   version: 6.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    aom: '>=3.6.1,<3.7.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    dav1d: '>=1.2.1,<1.2.2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    gmp: '>=6.2.1,<7.0a0'
-    gnutls: '>=3.7.8,<3.8.0a0'
-    lame: '>=3.100,<3.101.0a0'
-    libass: '>=0.17.1,<0.17.2.0a0'
-    libcxx: '>=15.0.7'
-    libiconv: '>=1.17,<2.0a0'
-    libopus: '>=1.3.1,<2.0a0'
-    libvpx: '>=1.13.0,<1.14.0a0'
-    libxml2: '>=2.11.5,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openh264: '>=2.3.1,<2.3.2.0a0'
-    svt-av1: '>=1.7.0,<1.7.1.0a0'
-    x264: '>=1!164.3095,<1!165'
-    x265: '>=3.5,<3.6.0a0'
+  - aom >=3.6.1,<3.7.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.2.1,<7.0a0
+  - gnutls >=3.7.8,<3.8.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libcxx >=15.0.7
+  - libiconv >=1.17,<2.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.13.0,<1.14.0a0
+  - libxml2 >=2.11.5,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.3.1,<2.3.2.0a0
+  - svt-av1 >=1.7.0,<1.7.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.0.0-gpl_h789aacd_105.conda
   hash:
     md5: d15fb0935b56b41d1510e3e749610426
     sha256: d0e8d127a3d3f9331bb82ee9a0c22870a6417c0cb568a834659473e7cf546894
-  optional: false
-  category: main
   build: gpl_h789aacd_105
   arch: x86_64
   subdir: osx-64
@@ -1676,37 +2880,36 @@ package:
   license_family: GPL
   size: 10026915
   timestamp: 1696215119867
-- name: ffmpeg
+- platform: osx-arm64
+  name: ffmpeg
   version: 6.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    aom: '>=3.6.1,<3.7.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    dav1d: '>=1.2.1,<1.2.2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    gmp: '>=6.2.1,<7.0a0'
-    gnutls: '>=3.7.8,<3.8.0a0'
-    lame: '>=3.100,<3.101.0a0'
-    libass: '>=0.17.1,<0.17.2.0a0'
-    libcxx: '>=15.0.7'
-    libiconv: '>=1.17,<2.0a0'
-    libopus: '>=1.3.1,<2.0a0'
-    libvpx: '>=1.13.0,<1.14.0a0'
-    libxml2: '>=2.11.5,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openh264: '>=2.3.1,<2.3.2.0a0'
-    svt-av1: '>=1.7.0,<1.7.1.0a0'
-    x264: '>=1!164.3095,<1!165'
-    x265: '>=3.5,<3.6.0a0'
+  - aom >=3.6.1,<3.7.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.2.1,<7.0a0
+  - gnutls >=3.7.8,<3.8.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libcxx >=15.0.7
+  - libiconv >=1.17,<2.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.13.0,<1.14.0a0
+  - libxml2 >=2.11.5,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.3.1,<2.3.2.0a0
+  - svt-av1 >=1.7.0,<1.7.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.0.0-gpl_h1ceb99f_105.conda
   hash:
     md5: ab473674ec333a0fec0de661107bc6c1
     sha256: 7d23734203eae2fd8cb1a22f6771664258e9d57c098f0ed45533717a836db209
-  optional: false
-  category: main
   build: gpl_h1ceb99f_105
   arch: aarch64
   subdir: osx-arm64
@@ -1715,33 +2918,32 @@ package:
   license_family: GPL
   size: 8643472
   timestamp: 1696215071693
-- name: ffmpeg
+- platform: win-64
+  name: ffmpeg
   version: 6.0.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    aom: '>=3.6.1,<3.7.0a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    dav1d: '>=1.2.1,<1.2.2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    libopus: '>=1.3.1,<2.0a0'
-    libxml2: '>=2.11.5,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openh264: '>=2.3.1,<2.3.2.0a0'
-    svt-av1: '>=1.7.0,<1.7.1.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    x264: '>=1!164.3095,<1!165'
-    x265: '>=3.5,<3.6.0a0'
+  - aom >=3.6.1,<3.7.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libxml2 >=2.11.5,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.3.1,<2.3.2.0a0
+  - svt-av1 >=1.7.0,<1.7.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.0.0-gpl_h1627b0f_105.conda
   hash:
     md5: f77a3331e513563b09d49c6a659da1c6
     sha256: 2afe22be1e563fdf668a263b780c6eb0553cd4b693fa3cfcb703425f898db544
-  optional: false
-  category: main
   build: gpl_h1627b0f_105
   arch: x86_64
   subdir: win-64
@@ -1750,17 +2952,16 @@ package:
   license_family: GPL
   size: 11547920
   timestamp: 1696215463384
-- name: font-ttf-dejavu-sans-mono
+- platform: linux-64
+  name: font-ttf-dejavu-sans-mono
   version: '2.37'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  optional: false
-  category: main
   build: hab24e00_0
   arch: x86_64
   subdir: linux-64
@@ -1770,17 +2971,16 @@ package:
   noarch: generic
   size: 397370
   timestamp: 1566932522327
-- name: font-ttf-dejavu-sans-mono
+- platform: osx-64
+  name: font-ttf-dejavu-sans-mono
   version: '2.37'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  optional: false
-  category: main
   build: hab24e00_0
   arch: x86_64
   subdir: osx-64
@@ -1790,17 +2990,16 @@ package:
   noarch: generic
   size: 397370
   timestamp: 1566932522327
-- name: font-ttf-dejavu-sans-mono
+- platform: osx-arm64
+  name: font-ttf-dejavu-sans-mono
   version: '2.37'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  optional: false
-  category: main
   build: hab24e00_0
   arch: aarch64
   subdir: osx-arm64
@@ -1810,17 +3009,16 @@ package:
   noarch: generic
   size: 397370
   timestamp: 1566932522327
-- name: font-ttf-dejavu-sans-mono
+- platform: win-64
+  name: font-ttf-dejavu-sans-mono
   version: '2.37'
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
   hash:
     md5: 0c96522c6bdaed4b1566d11387caaf45
     sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  optional: false
-  category: main
   build: hab24e00_0
   arch: x86_64
   subdir: win-64
@@ -1830,17 +3028,16 @@ package:
   noarch: generic
   size: 397370
   timestamp: 1566932522327
-- name: font-ttf-inconsolata
+- platform: linux-64
+  name: font-ttf-inconsolata
   version: '3.000'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  optional: false
-  category: main
   build: h77eed37_0
   arch: x86_64
   subdir: linux-64
@@ -1850,17 +3047,16 @@ package:
   noarch: generic
   size: 96530
   timestamp: 1620479909603
-- name: font-ttf-inconsolata
+- platform: osx-64
+  name: font-ttf-inconsolata
   version: '3.000'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  optional: false
-  category: main
   build: h77eed37_0
   arch: x86_64
   subdir: osx-64
@@ -1870,17 +3066,16 @@ package:
   noarch: generic
   size: 96530
   timestamp: 1620479909603
-- name: font-ttf-inconsolata
+- platform: osx-arm64
+  name: font-ttf-inconsolata
   version: '3.000'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  optional: false
-  category: main
   build: h77eed37_0
   arch: aarch64
   subdir: osx-arm64
@@ -1890,17 +3085,16 @@ package:
   noarch: generic
   size: 96530
   timestamp: 1620479909603
-- name: font-ttf-inconsolata
+- platform: win-64
+  name: font-ttf-inconsolata
   version: '3.000'
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
   hash:
     md5: 34893075a5c9e55cdafac56607368fc6
     sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  optional: false
-  category: main
   build: h77eed37_0
   arch: x86_64
   subdir: win-64
@@ -1910,17 +3104,16 @@ package:
   noarch: generic
   size: 96530
   timestamp: 1620479909603
-- name: font-ttf-source-code-pro
+- platform: linux-64
+  name: font-ttf-source-code-pro
   version: '2.038'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  optional: false
-  category: main
   build: h77eed37_0
   arch: x86_64
   subdir: linux-64
@@ -1930,17 +3123,16 @@ package:
   noarch: generic
   size: 700814
   timestamp: 1620479612257
-- name: font-ttf-source-code-pro
+- platform: osx-64
+  name: font-ttf-source-code-pro
   version: '2.038'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  optional: false
-  category: main
   build: h77eed37_0
   arch: x86_64
   subdir: osx-64
@@ -1950,17 +3142,16 @@ package:
   noarch: generic
   size: 700814
   timestamp: 1620479612257
-- name: font-ttf-source-code-pro
+- platform: osx-arm64
+  name: font-ttf-source-code-pro
   version: '2.038'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  optional: false
-  category: main
   build: h77eed37_0
   arch: aarch64
   subdir: osx-arm64
@@ -1970,17 +3161,16 @@ package:
   noarch: generic
   size: 700814
   timestamp: 1620479612257
-- name: font-ttf-source-code-pro
+- platform: win-64
+  name: font-ttf-source-code-pro
   version: '2.038'
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
   hash:
     md5: 4d59c254e01d9cde7957100457e2d5fb
     sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  optional: false
-  category: main
   build: h77eed37_0
   arch: x86_64
   subdir: win-64
@@ -1990,17 +3180,16 @@ package:
   noarch: generic
   size: 700814
   timestamp: 1620479612257
-- name: font-ttf-ubuntu
+- platform: linux-64
+  name: font-ttf-ubuntu
   version: '0.83'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
   hash:
     md5: 19410c3df09dfb12d1206132a1d357c5
     sha256: 470d5db54102bd51dbb0c5990324a2f4a0bc976faa493b22193338adb9882e2e
-  optional: false
-  category: main
   build: hab24e00_0
   arch: x86_64
   subdir: linux-64
@@ -2010,17 +3199,16 @@ package:
   noarch: generic
   size: 1961279
   timestamp: 1566932680646
-- name: font-ttf-ubuntu
+- platform: osx-64
+  name: font-ttf-ubuntu
   version: '0.83'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
   hash:
     md5: 19410c3df09dfb12d1206132a1d357c5
     sha256: 470d5db54102bd51dbb0c5990324a2f4a0bc976faa493b22193338adb9882e2e
-  optional: false
-  category: main
   build: hab24e00_0
   arch: x86_64
   subdir: osx-64
@@ -2030,17 +3218,16 @@ package:
   noarch: generic
   size: 1961279
   timestamp: 1566932680646
-- name: font-ttf-ubuntu
+- platform: osx-arm64
+  name: font-ttf-ubuntu
   version: '0.83'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
   hash:
     md5: 19410c3df09dfb12d1206132a1d357c5
     sha256: 470d5db54102bd51dbb0c5990324a2f4a0bc976faa493b22193338adb9882e2e
-  optional: false
-  category: main
   build: hab24e00_0
   arch: aarch64
   subdir: osx-arm64
@@ -2050,17 +3237,16 @@ package:
   noarch: generic
   size: 1961279
   timestamp: 1566932680646
-- name: font-ttf-ubuntu
+- platform: win-64
+  name: font-ttf-ubuntu
   version: '0.83'
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
   hash:
     md5: 19410c3df09dfb12d1206132a1d357c5
     sha256: 470d5db54102bd51dbb0c5990324a2f4a0bc976faa493b22193338adb9882e2e
-  optional: false
-  category: main
   build: hab24e00_0
   arch: x86_64
   subdir: win-64
@@ -2070,22 +3256,21 @@ package:
   noarch: generic
   size: 1961279
   timestamp: 1566932680646
-- name: fontconfig
+- platform: linux-64
+  name: fontconfig
   version: 2.14.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    expat: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libgcc-ng: '>=12'
-    libuuid: '>=2.32.1,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libgcc-ng >=12
+  - libuuid >=2.32.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
   hash:
     md5: 0f69b688f52ff6da70bccb7ff7001d1d
     sha256: 155d534c9037347ea7439a2c6da7c24ffec8e5dd278889b4c57274a1d91e0a83
-  optional: false
-  category: main
   build: h14ed4e7_0
   arch: x86_64
   subdir: linux-64
@@ -2094,20 +3279,19 @@ package:
   license_family: MIT
   size: 272010
   timestamp: 1674828850194
-- name: fontconfig
+- platform: osx-64
+  name: fontconfig
   version: 2.14.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    expat: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
   hash:
     md5: 86cc5867dfbee4178118392bae4a3c89
     sha256: f63e6d1d6aef8ba6de4fc54d3d7898a153479888d40ffdf2e4cfad6f92679d34
-  optional: false
-  category: main
   build: h5bb23bf_0
   arch: x86_64
   subdir: osx-64
@@ -2116,20 +3300,19 @@ package:
   license_family: MIT
   size: 237068
   timestamp: 1674829100063
-- name: fontconfig
+- platform: osx-arm64
+  name: fontconfig
   version: 2.14.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    expat: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
   hash:
     md5: f77d47ddb6d3cc5b39b9bdf65635afbb
     sha256: 7094917fc6758186e17c61d8ee8fd2bbbe9f303b4addac61d918fa415c497e2b
-  optional: false
-  category: main
   build: h82840c6_0
   arch: aarch64
   subdir: osx-arm64
@@ -2138,24 +3321,23 @@ package:
   license_family: MIT
   size: 237668
   timestamp: 1674829263740
-- name: fontconfig
+- platform: win-64
+  name: fontconfig
   version: 2.14.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    expat: '>=2.5.0,<3.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - expat >=2.5.0,<3.0a0
+  - freetype >=2.12.1,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
   hash:
     md5: 08767992f1a4f1336a257af1241034bd
     sha256: 643f2b95be68abeb130c53d543dcd0c1244bebabd58c774a21b31e4b51ac3c96
-  optional: false
-  category: main
   build: hbde0cde_0
   arch: x86_64
   subdir: win-64
@@ -2164,18 +3346,17 @@ package:
   license_family: MIT
   size: 190111
   timestamp: 1674829354122
-- name: fonts-conda-ecosystem
+- platform: linux-64
+  name: fonts-conda-ecosystem
   version: '1'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    fonts-conda-forge: '*'
+  - fonts-conda-forge *
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  optional: false
-  category: main
   build: '0'
   arch: x86_64
   subdir: linux-64
@@ -2185,18 +3366,17 @@ package:
   noarch: generic
   size: 3667
   timestamp: 1566974674465
-- name: fonts-conda-ecosystem
+- platform: osx-64
+  name: fonts-conda-ecosystem
   version: '1'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    fonts-conda-forge: '*'
+  - fonts-conda-forge *
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  optional: false
-  category: main
   build: '0'
   arch: x86_64
   subdir: osx-64
@@ -2206,18 +3386,17 @@ package:
   noarch: generic
   size: 3667
   timestamp: 1566974674465
-- name: fonts-conda-ecosystem
+- platform: osx-arm64
+  name: fonts-conda-ecosystem
   version: '1'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    fonts-conda-forge: '*'
+  - fonts-conda-forge *
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  optional: false
-  category: main
   build: '0'
   arch: aarch64
   subdir: osx-arm64
@@ -2227,18 +3406,17 @@ package:
   noarch: generic
   size: 3667
   timestamp: 1566974674465
-- name: fonts-conda-ecosystem
+- platform: win-64
+  name: fonts-conda-ecosystem
   version: '1'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    fonts-conda-forge: '*'
+  - fonts-conda-forge *
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
   hash:
     md5: fee5683a3f04bd15cbd8318b096a27ab
     sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  optional: false
-  category: main
   build: '0'
   arch: x86_64
   subdir: win-64
@@ -2248,21 +3426,20 @@ package:
   noarch: generic
   size: 3667
   timestamp: 1566974674465
-- name: fonts-conda-forge
+- platform: linux-64
+  name: fonts-conda-forge
   version: '1'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    font-ttf-dejavu-sans-mono: '*'
-    font-ttf-inconsolata: '*'
-    font-ttf-source-code-pro: '*'
-    font-ttf-ubuntu: '*'
+  - font-ttf-dejavu-sans-mono *
+  - font-ttf-inconsolata *
+  - font-ttf-source-code-pro *
+  - font-ttf-ubuntu *
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  optional: false
-  category: main
   build: '0'
   arch: x86_64
   subdir: linux-64
@@ -2272,21 +3449,20 @@ package:
   noarch: generic
   size: 4102
   timestamp: 1566932280397
-- name: fonts-conda-forge
+- platform: osx-64
+  name: fonts-conda-forge
   version: '1'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    font-ttf-dejavu-sans-mono: '*'
-    font-ttf-inconsolata: '*'
-    font-ttf-source-code-pro: '*'
-    font-ttf-ubuntu: '*'
+  - font-ttf-dejavu-sans-mono *
+  - font-ttf-inconsolata *
+  - font-ttf-source-code-pro *
+  - font-ttf-ubuntu *
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  optional: false
-  category: main
   build: '0'
   arch: x86_64
   subdir: osx-64
@@ -2296,21 +3472,20 @@ package:
   noarch: generic
   size: 4102
   timestamp: 1566932280397
-- name: fonts-conda-forge
+- platform: osx-arm64
+  name: fonts-conda-forge
   version: '1'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    font-ttf-dejavu-sans-mono: '*'
-    font-ttf-inconsolata: '*'
-    font-ttf-source-code-pro: '*'
-    font-ttf-ubuntu: '*'
+  - font-ttf-dejavu-sans-mono *
+  - font-ttf-inconsolata *
+  - font-ttf-source-code-pro *
+  - font-ttf-ubuntu *
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  optional: false
-  category: main
   build: '0'
   arch: aarch64
   subdir: osx-arm64
@@ -2320,21 +3495,20 @@ package:
   noarch: generic
   size: 4102
   timestamp: 1566932280397
-- name: fonts-conda-forge
+- platform: win-64
+  name: fonts-conda-forge
   version: '1'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    font-ttf-dejavu-sans-mono: '*'
-    font-ttf-inconsolata: '*'
-    font-ttf-source-code-pro: '*'
-    font-ttf-ubuntu: '*'
+  - font-ttf-dejavu-sans-mono *
+  - font-ttf-inconsolata *
+  - font-ttf-source-code-pro *
+  - font-ttf-ubuntu *
   url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
   hash:
     md5: f766549260d6815b0c52253f1fb1bb29
     sha256: 53f23a3319466053818540bcdf2091f253cbdbab1e0e9ae7b9e509dcaa2a5e38
-  optional: false
-  category: main
   build: '0'
   arch: x86_64
   subdir: win-64
@@ -2344,25 +3518,24 @@ package:
   noarch: generic
   size: 4102
   timestamp: 1566932280397
-- name: freeglut
+- platform: linux-64
+  name: freeglut
   version: 3.2.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xorg-libx11: '>=1.8.4,<2.0a0'
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxfixes: '*'
-    xorg-libxi: '*'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-libx11 >=1.8.4,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes *
+  - xorg-libxi *
   url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-hac7e632_2.conda
   hash:
     md5: 6e553df297f6e64668efb54302e0f139
     sha256: 6dc7be5d0853ea5bcbb2b1921baf7d069605594c207e8ce36a662f447cd81a3f
-  optional: false
-  category: main
   build: hac7e632_2
   arch: x86_64
   subdir: linux-64
@@ -2371,20 +3544,19 @@ package:
   license_family: MIT
   size: 142933
   timestamp: 1684688443008
-- name: freeglut
+- platform: win-64
+  name: freeglut
   version: 3.2.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-h63175ca_2.conda
   hash:
     md5: e2d290a0159d485932abed83878e6952
     sha256: 42fd40d97dab1adb63ff0bb001e4ed9b3eef377a2de5e572bf989c6db79262c8
-  optional: false
-  category: main
   build: h63175ca_2
   arch: x86_64
   subdir: win-64
@@ -2393,20 +3565,19 @@ package:
   license_family: MIT
   size: 111787
   timestamp: 1684688787619
-- name: freetype
+- platform: linux-64
+  name: freetype
   version: 2.12.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
   hash:
     md5: 9ae35c3d96db2c94ce0cef86efdfa2cb
     sha256: b2e3c449ec9d907dd4656cb0dc93e140f447175b125a3824b31368b06c666bb6
-  optional: false
-  category: main
   build: h267a509_2
   arch: x86_64
   subdir: linux-64
@@ -2414,19 +3585,18 @@ package:
   license: GPL-2.0-only OR FTL
   size: 634972
   timestamp: 1694615932610
-- name: freetype
+- platform: osx-64
+  name: freetype
   version: 2.12.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
   hash:
     md5: 25152fce119320c980e5470e64834b50
     sha256: b292cf5a25f094eeb4b66e37d99a97894aafd04a5683980852a8cbddccdc8e4e
-  optional: false
-  category: main
   build: h60636b9_2
   arch: x86_64
   subdir: osx-64
@@ -2434,19 +3604,18 @@ package:
   license: GPL-2.0-only OR FTL
   size: 599300
   timestamp: 1694616137838
-- name: freetype
+- platform: osx-arm64
+  name: freetype
   version: 2.12.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
   hash:
     md5: e6085e516a3e304ce41a8ee08b9b89ad
     sha256: 791673127e037a2dc0eebe122dc4f904cb3f6e635bb888f42cbe1a76b48748d9
-  optional: false
-  category: main
   build: hadb7bae_2
   arch: aarch64
   subdir: osx-arm64
@@ -2454,22 +3623,21 @@ package:
   license: GPL-2.0-only OR FTL
   size: 596430
   timestamp: 1694616332835
-- name: freetype
+- platform: win-64
+  name: freetype
   version: 2.12.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libpng: '>=1.6.39,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libpng >=1.6.39,<1.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
   hash:
     md5: 3761b23693f768dc75a8fd0a73ca053f
     sha256: 2c53ee8879e05e149a9e525481d36adfd660a6abda26fd731376fa64ff03e728
-  optional: false
-  category: main
   build: hdaf720e_2
   arch: x86_64
   subdir: win-64
@@ -2477,18 +3645,17 @@ package:
   license: GPL-2.0-only OR FTL
   size: 510306
   timestamp: 1694616398888
-- name: fribidi
+- platform: linux-64
+  name: fribidi
   version: 1.0.10
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
+  - libgcc-ng >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
   hash:
     md5: ac7bc6a654f8f41b352b38f4051135f8
     sha256: 5d7b6c0ee7743ba41399e9e05a58ccc1cfc903942e49ff6f677f6e423ea7a627
-  optional: false
-  category: main
   build: h36c2ea0_0
   arch: x86_64
   subdir: linux-64
@@ -2496,17 +3663,16 @@ package:
   license: LGPL-2.1
   size: 114383
   timestamp: 1604416621168
-- name: fribidi
+- platform: osx-64
+  name: fribidi
   version: 1.0.10
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
   hash:
     md5: f1c6b41e0f56998ecd9a3e210faa1dc0
     sha256: 4f6db86ecc4984cd4ac88ca52030726c3cfd11a64dfb15c8602025ee3001a2b5
-  optional: false
-  category: main
   build: hbcb3906_0
   arch: x86_64
   subdir: osx-64
@@ -2514,17 +3680,16 @@ package:
   license: LGPL-2.1
   size: 65388
   timestamp: 1604417213
-- name: fribidi
+- platform: osx-arm64
+  name: fribidi
   version: 1.0.10
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
   hash:
     md5: c64443234ff91d70cb9c7dc926c58834
     sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
-  optional: false
-  category: main
   build: h27ca646_0
   arch: aarch64
   subdir: osx-arm64
@@ -2532,18 +3697,17 @@ package:
   license: LGPL-2.1
   size: 60255
   timestamp: 1604417405528
-- name: gcc
+- platform: linux-64
+  name: gcc
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gcc_impl_linux-64: 12.3.0.*
+  - gcc_impl_linux-64 12.3.0.*
   url: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
   hash:
     md5: e2f2f81f367e14ca1f77a870bda2fe59
     sha256: 1bbf077688822993c39518056fb43d83ff0920eb42fef11e8714d2a298cc0f27
-  optional: false
-  category: main
   build: h8d2909c_2
   arch: x86_64
   subdir: linux-64
@@ -2552,24 +3716,23 @@ package:
   license_family: BSD
   size: 27086
   timestamp: 1694604171830
-- name: gcc_impl_linux-64
+- platform: linux-64
+  name: gcc_impl_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_impl_linux-64: '>=2.39'
-    libgcc-devel_linux-64: ==12.3.0 h8bca6fd_2
-    libgcc-ng: '>=12.3.0'
-    libgomp: '>=12.3.0'
-    libsanitizer: ==12.3.0 h0f45ef3_2
-    libstdcxx-ng: '>=12.3.0'
-    sysroot_linux-64: '*'
+  - binutils_impl_linux-64 >=2.39
+  - libgcc-devel_linux-64 ==12.3.0 h8bca6fd_2
+  - libgcc-ng >=12.3.0
+  - libgomp >=12.3.0
+  - libsanitizer ==12.3.0 h0f45ef3_2
+  - libstdcxx-ng >=12.3.0
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_2.conda
   hash:
     md5: 2f4d8677dc7dd87f93e9abfb2ce86808
     sha256: 62a897343229e6dc4a3ace4f419a30e60a0a22ce7d0eac0b9bfb8f0308cf3de5
-  optional: false
-  category: main
   build: he2b93b0_2
   arch: x86_64
   subdir: linux-64
@@ -2578,20 +3741,19 @@ package:
   license_family: GPL
   size: 51573870
   timestamp: 1695218760476
-- name: gcc_linux-64
+- platform: linux-64
+  name: gcc_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_linux-64: ==2.40 hbdbef99_2
-    gcc_impl_linux-64: 12.3.0.*
-    sysroot_linux-64: '*'
+  - binutils_linux-64 ==2.40 hbdbef99_2
+  - gcc_impl_linux-64 12.3.0.*
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
   hash:
     md5: 11517e7b5c910c5b5d6985c0c7eb7f50
     sha256: 86f6db7399ec0362e4c4025939debbfebc8ad9ccef75e3c0e4069f85b149f24d
-  optional: false
-  category: main
   build: h76fc315_2
   arch: x86_64
   subdir: linux-64
@@ -2600,18 +3762,17 @@ package:
   license_family: BSD
   size: 30351
   timestamp: 1694604476800
-- name: gettext
+- platform: linux-64
+  name: gettext
   version: 0.21.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
   hash:
     md5: 14947d8770185e5153fdd04d4673ed37
     sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
-  optional: false
-  category: main
   build: h27087fc_0
   arch: x86_64
   subdir: linux-64
@@ -2619,18 +3780,17 @@ package:
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
   size: 4320628
   timestamp: 1665673494324
-- name: gettext
+- platform: osx-64
+  name: gettext
   version: 0.21.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libiconv: '>=1.17,<2.0a0'
+  - libiconv >=1.17,<2.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
   hash:
     md5: 1e3aff29ce703d421c43f371ad676cc5
     sha256: 915d3cd2d777b9b3fc2e87a25901b8e4a6aa1b2b33cf2ba54e9e9ed4f6b67d94
-  optional: false
-  category: main
   build: h8a4c099_0
   arch: x86_64
   subdir: osx-64
@@ -2638,18 +3798,17 @@ package:
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
   size: 4153781
   timestamp: 1665674106245
-- name: gettext
+- platform: osx-arm64
+  name: gettext
   version: 0.21.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libiconv: '>=1.17,<2.0a0'
+  - libiconv >=1.17,<2.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
   hash:
     md5: 63d2ff6fddfa74e5458488fd311bf635
     sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
-  optional: false
-  category: main
   build: h0186832_0
   arch: aarch64
   subdir: osx-arm64
@@ -2657,18 +3816,17 @@ package:
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
   size: 4021036
   timestamp: 1665674192347
-- name: gettext
+- platform: win-64
+  name: gettext
   version: 0.21.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libiconv: '>=1.17,<2.0a0'
+  - libiconv >=1.17,<2.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
   hash:
     md5: 299d4fd6798a45337042ff5a48219e5f
     sha256: 71c75b0a4dc2cf95d2860ea0076edf9f5558baeb4dacaeecb32643b199074616
-  optional: false
-  category: main
   build: h5728263_0
   arch: x86_64
   subdir: win-64
@@ -2676,24 +3834,81 @@ package:
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
   size: 5579416
   timestamp: 1665676022441
-- name: glib
-  version: 2.78.0
+- platform: linux-64
+  name: gflags
+  version: 2.2.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    glib-tools: ==2.78.0 hfc55251_0
-    libgcc-ng: '>=12'
-    libglib: ==2.78.0 hebfc3b9_0
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    python: '*'
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+  hash:
+    md5: cddaf2c63ea4a5901cf09524c490ecdc
+    sha256: a853c0cacf53cfc59e1bca8d6e5cdfe9f38fce836f08c2a69e35429c2a492e77
+  build: he1b5a44_1004
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1004
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 116549
+  timestamp: 1594303828933
+- platform: osx-64
+  name: gflags
+  version: 2.2.2
+  category: main
+  manager: conda
+  dependencies:
+  - libcxx >=10.0.1
+  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+  hash:
+    md5: 3f59cc77a929537e42120faf104e0d16
+    sha256: 39540f879057ae529cad131644af111a8c3c48b384ec6212de6a5381e0863948
+  build: hb1e8313_1004
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1004
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 94612
+  timestamp: 1599590973213
+- platform: osx-arm64
+  name: gflags
+  version: 2.2.2
+  category: main
+  manager: conda
+  dependencies:
+  - libcxx >=11.0.0.rc1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+  hash:
+    md5: aab9ddfad863e9ef81229a1f8852211b
+    sha256: 25d4a20af2e5ace95fdec88970f6d190e77e20074d2f6d3cef766198b76a4289
+  build: hc88da5d_1004
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1004
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 86690
+  timestamp: 1599590990520
+- platform: linux-64
+  name: glib
+  version: 2.78.0
+  category: main
+  manager: conda
+  dependencies:
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools ==2.78.0 hfc55251_0
+  - libgcc-ng >=12
+  - libglib ==2.78.0 hebfc3b9_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - python *
   url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.0-hfc55251_0.conda
   hash:
     md5: 2f55a36b549f51a7e0c2b1e3c3f0ccd4
     sha256: b7fd5ef9aee4205e14105dc9f79b3de326af091c0253e1e52d3e4ee0d960851d
-  optional: false
-  category: main
   build: hfc55251_0
   arch: x86_64
   subdir: linux-64
@@ -2701,25 +3916,24 @@ package:
   license: LGPL-2.1-or-later
   size: 490912
   timestamp: 1694381302237
-- name: glib
+- platform: win-64
+  name: glib
   version: 2.78.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    glib-tools: ==2.78.0 h12be248_0
-    libglib: ==2.78.0 he8f3873_0
-    libzlib: '>=1.2.13,<1.3.0a0'
-    python: '*'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - gettext >=0.21.1,<1.0a0
+  - glib-tools ==2.78.0 h12be248_0
+  - libglib ==2.78.0 he8f3873_0
+  - libzlib >=1.2.13,<1.3.0a0
+  - python *
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.0-h12be248_0.conda
   hash:
     md5: 1ed98e4da48693079f2fe83298c5b0ac
     sha256: a9860e833d1ac9e2e87e5a0ae6863c819d893dac90aa1f6df9c06ab312d80170
-  optional: false
-  category: main
   build: h12be248_0
   arch: x86_64
   subdir: win-64
@@ -2727,21 +3941,20 @@ package:
   license: LGPL-2.1-or-later
   size: 509622
   timestamp: 1694381620175
-- name: glib-tools
+- platform: linux-64
+  name: glib-tools
   version: 2.78.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libglib: ==2.78.0 hebfc3b9_0
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libglib ==2.78.0 hebfc3b9_0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.0-hfc55251_0.conda
   hash:
     md5: e10134de3558dd95abda6987b5548f4f
     sha256: 991803ca90e6ba54568ff1bcb8a02f69a9beb8a09988d257fc21e1bbb3557d8c
-  optional: false
-  category: main
   build: hfc55251_0
   arch: x86_64
   subdir: linux-64
@@ -2749,22 +3962,21 @@ package:
   license: LGPL-2.1-or-later
   size: 112222
   timestamp: 1694381266818
-- name: glib-tools
+- platform: win-64
+  name: glib-tools
   version: 2.78.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libglib: ==2.78.0 he8f3873_0
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libglib ==2.78.0 he8f3873_0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.0-h12be248_0.conda
   hash:
     md5: 466538fb59949a3c015b55671dc7e52c
     sha256: 0781647629fdb9c88a2b1dc22bb845645d3365693f104374c7d9139bc59bd0ce
-  optional: false
-  category: main
   build: h12be248_0
   arch: x86_64
   subdir: win-64
@@ -2772,19 +3984,79 @@ package:
   license: LGPL-2.1-or-later
   size: 145796
   timestamp: 1694381570560
-- name: gmp
-  version: 6.2.1
+- platform: linux-64
+  name: glog
+  version: 0.6.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    libstdcxx-ng: '>=7.5.0'
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+  hash:
+    md5: b31f3565cb84435407594e548a2fb7b2
+    sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
+  build: h6f12383_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 114321
+  timestamp: 1649143789233
+- platform: osx-64
+  name: glog
+  version: 0.6.0
+  category: main
+  manager: conda
+  dependencies:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+  hash:
+    md5: 69eb97ca709a136c53fdca1f2fd33ddf
+    sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
+  build: h8ac2a54_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100624
+  timestamp: 1649143914155
+- platform: osx-arm64
+  name: glog
+  version: 0.6.0
+  category: main
+  manager: conda
+  dependencies:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+  hash:
+    md5: 5a570729c7709399cf8511aeeda6f989
+    sha256: 4d772c42477f64be708594ac45870feba3e838977871118eb25e00deb0e9a73c
+  build: h6da1cb0_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97658
+  timestamp: 1649144191039
+- platform: linux-64
+  name: gmp
+  version: 6.2.1
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.2.1-h58526e2_0.tar.bz2
   hash:
     md5: b94cf2db16066b242ebd26db2facbd56
     sha256: 07a5319e1ac54fe5d38f50c60f7485af7f830b036da56957d0bfb7558a886198
-  optional: false
-  category: main
   build: h58526e2_0
   arch: x86_64
   subdir: linux-64
@@ -2792,18 +4064,17 @@ package:
   license: GPL-2.0-or-later AND LGPL-3.0-or-later
   size: 825784
   timestamp: 1605751468661
-- name: gmp
+- platform: osx-64
+  name: gmp
   version: 6.2.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=10.0.1'
+  - libcxx >=10.0.1
   url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.2.1-h2e338ed_0.tar.bz2
   hash:
     md5: dedc96914428dae572a39e69ee2a392f
     sha256: d6386708f6b7bcf790c57e985a5ca5636ec6ccaed0493b8ddea231aaeb8bfb00
-  optional: false
-  category: main
   build: h2e338ed_0
   arch: x86_64
   subdir: osx-64
@@ -2811,18 +4082,17 @@ package:
   license: GPL-2.0-or-later AND LGPL-3.0-or-later
   size: 792127
   timestamp: 1605751675650
-- name: gmp
+- platform: osx-arm64
+  name: gmp
   version: 6.2.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=11.0.0'
+  - libcxx >=11.0.0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.2.1-h9f76cd9_0.tar.bz2
   hash:
     md5: f8140773b6ca51bf32feec9b4290a8c5
     sha256: 2fd12c3e78b6c632f7f34883b942b973bdd24302c74f2b9b78e776b654baf591
-  optional: false
-  category: main
   build: h9f76cd9_0
   arch: aarch64
   subdir: osx-arm64
@@ -2830,23 +4100,22 @@ package:
   license: GPL-2.0-or-later AND LGPL-3.0-or-later
   size: 570567
   timestamp: 1605751606013
-- name: gnutls
+- platform: linux-64
+  name: gnutls
   version: 3.7.8
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libidn2: '>=2,<3.0a0'
-    libstdcxx-ng: '>=12'
-    libtasn1: '>=4.19.0,<5.0a0'
-    nettle: '>=3.8.1,<3.9.0a0'
-    p11-kit: '>=0.24.1,<0.25.0a0'
+  - libgcc-ng >=12
+  - libidn2 >=2,<3.0a0
+  - libstdcxx-ng >=12
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.8.1,<3.9.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.8-hf3e180e_0.tar.bz2
   hash:
     md5: cbe8e27140d67c3f30e01cfb642a6e7c
     sha256: 4a47e4558395b98fff4c1c44ad358dade62b350a03b5a784d4bc589d6eb7ac9e
-  optional: false
-  category: main
   build: hf3e180e_0
   arch: x86_64
   subdir: linux-64
@@ -2855,23 +4124,22 @@ package:
   license_family: LGPL
   size: 2271927
   timestamp: 1664445361111
-- name: gnutls
+- platform: osx-64
+  name: gnutls
   version: 3.7.8
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    gettext: '>=0.19.8.1,<1.0a0'
-    libcxx: '>=14.0.4'
-    libidn2: '>=2,<3.0a0'
-    libtasn1: '>=4.19.0,<5.0a0'
-    nettle: '>=3.8.1,<3.9.0a0'
-    p11-kit: '>=0.24.1,<0.25.0a0'
+  - gettext >=0.19.8.1,<1.0a0
+  - libcxx >=14.0.4
+  - libidn2 >=2,<3.0a0
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.8.1,<3.9.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.8-h207c4f0_0.tar.bz2
   hash:
     md5: 3886476538060824c0258316fd5bb828
     sha256: dc309e4c24689deb19596a745e0a31519adcf65c16bc349e23c140ee6ffb8f94
-  optional: false
-  category: main
   build: h207c4f0_0
   arch: x86_64
   subdir: osx-64
@@ -2880,23 +4148,22 @@ package:
   license_family: LGPL
   size: 2228721
   timestamp: 1664446079954
-- name: gnutls
+- platform: osx-arm64
+  name: gnutls
   version: 3.7.8
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    gettext: '>=0.19.8.1,<1.0a0'
-    libcxx: '>=14.0.4'
-    libidn2: '>=2,<3.0a0'
-    libtasn1: '>=4.19.0,<5.0a0'
-    nettle: '>=3.8.1,<3.9.0a0'
-    p11-kit: '>=0.24.1,<0.25.0a0'
+  - gettext >=0.19.8.1,<1.0a0
+  - libcxx >=14.0.4
+  - libidn2 >=2,<3.0a0
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.8.1,<3.9.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.8-h9f1a10d_0.tar.bz2
   hash:
     md5: 2367cca5a0451a70d01cff2dd2ce7d3e
     sha256: 7b9b69cb2b3134e064b37948a4cd54dee2184a851c0cda5fe52efcfd90ae032d
-  optional: false
-  category: main
   build: h9f1a10d_0
   arch: aarch64
   subdir: osx-arm64
@@ -2905,19 +4172,18 @@ package:
   license_family: LGPL
   size: 2156057
   timestamp: 1664444818581
-- name: graphite2
+- platform: linux-64
+  name: graphite2
   version: 1.3.13
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    libstdcxx-ng: '>=7.5.0'
+  - libgcc-ng >=7.5.0
+  - libstdcxx-ng >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
   hash:
     md5: 8c54672728e8ec6aa6db90cf2806d220
     sha256: 65da967f3101b737b08222de6a6a14e20e480e7d523a5d1e19ace7b960b5d6b1
-  optional: false
-  category: main
   build: h58526e2_1001
   arch: x86_64
   subdir: linux-64
@@ -2925,18 +4191,17 @@ package:
   license: LGPLv2
   size: 104701
   timestamp: 1604365484436
-- name: graphite2
+- platform: osx-64
+  name: graphite2
   version: 1.3.13
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=10.0.1'
+  - libcxx >=10.0.1
   url: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h2e338ed_1001.tar.bz2
   hash:
     md5: 5f6e7f98caddd0fc2d345b207531814c
     sha256: 1dba68533e6888c5e2a7e37119a77d6f388fb82721c530ba3bd28d541828e59b
-  optional: false
-  category: main
   build: h2e338ed_1001
   arch: x86_64
   subdir: osx-64
@@ -2944,18 +4209,17 @@ package:
   license: LGPLv2
   size: 86556
   timestamp: 1604365555365
-- name: graphite2
+- platform: osx-arm64
+  name: graphite2
   version: 1.3.13
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=11.0.0'
+  - libcxx >=11.0.0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
   hash:
     md5: 288b591645cb9cb9c0af7309ac1114f5
     sha256: 57db1e563cdfe469cd453a2988039118e96ce4b77c9219e2f1022be0e1c2b03f
-  optional: false
-  category: main
   build: h9f76cd9_1001
   arch: aarch64
   subdir: osx-arm64
@@ -2963,18 +4227,17 @@ package:
   license: LGPLv2
   size: 83198
   timestamp: 1604365687923
-- name: graphite2
+- platform: win-64
+  name: graphite2
   version: 1.3.13
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: 14.*
+  - vc 14.*
   url: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-1000.tar.bz2
   hash:
     md5: 8fc0e04e5c852cadf2cad68b86a906ab
     sha256: ed47008df8e57a83f45112985b76ac4339177486bd4d1d1b305d685a832532aa
-  optional: false
-  category: main
   build: '1000'
   arch: x86_64
   subdir: win-64
@@ -2982,35 +4245,34 @@ package:
   license: LGPLv2
   size: 99391
   timestamp: 1545518639227
-- name: gst-plugins-base
+- platform: linux-64
+  name: gst-plugins-base
   version: 1.22.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    alsa-lib: '>=1.2.10,<1.2.11.0a0'
-    gettext: '>=0.21.1,<1.0a0'
-    gstreamer: ==1.22.6 h98fc4e7_2
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.0,<3.0a0'
-    libogg: '>=1.3.4,<1.4.0a0'
-    libopus: '>=1.3.1,<2.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libvorbis: '>=1.3.7,<1.4.0a0'
-    libxcb: '>=1.15,<1.16.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxrender: '>=0.9.11,<0.10.0a0'
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer ==1.22.6 h98fc4e7_2
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxrender >=0.9.11,<0.10.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.6-h8e1006c_2.conda
   hash:
     md5: 3d8e98279bad55287f2ef9047996f33c
     sha256: 07e71ef8ad4d1516695132ed142ef6bc6393243fee54f950aa0944561f2f277f
-  optional: false
-  category: main
   build: h8e1006c_2
   arch: x86_64
   subdir: linux-64
@@ -3019,26 +4281,25 @@ package:
   license_family: LGPL
   size: 2704605
   timestamp: 1696222053755
-- name: gst-plugins-base
+- platform: win-64
+  name: gst-plugins-base
   version: 1.22.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    gstreamer: ==1.22.6 hb4038d2_2
-    libglib: '>=2.78.0,<3.0a0'
-    libogg: '>=1.3.4,<1.4.0a0'
-    libvorbis: '>=1.3.7,<1.4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - gettext >=0.21.1,<1.0a0
+  - gstreamer ==1.22.6 hb4038d2_2
+  - libglib >=2.78.0,<3.0a0
+  - libogg >=1.3.4,<1.4.0a0
+  - libvorbis >=1.3.7,<1.4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.6-h001b923_2.conda
   hash:
     md5: 20e57b894392cb792cdf5c501b35a8f6
     sha256: 34816d0335e796ea3610022756b3b0832f5699007adc2819a08e068120dd3a8f
-  optional: false
-  category: main
   build: h001b923_2
   arch: x86_64
   subdir: win-64
@@ -3047,24 +4308,23 @@ package:
   license_family: LGPL
   size: 2032915
   timestamp: 1696222439891
-- name: gstreamer
+- platform: linux-64
+  name: gstreamer
   version: 1.22.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    gettext: '>=0.21.1,<1.0a0'
-    glib: '>=2.78.0,<3.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.0,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libstdcxx-ng: '>=12'
+  - __glibc >=2.17,<3.0.a0
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.6-h98fc4e7_2.conda
   hash:
     md5: 1c95f7c612f9121353c4ef764678113e
     sha256: 5578119cec4e86b7b607678781026ebe1170cb851b4f784c49b09bed1c92566c
-  optional: false
-  category: main
   build: h98fc4e7_2
   arch: x86_64
   subdir: linux-64
@@ -3073,24 +4333,23 @@ package:
   license_family: LGPL
   size: 1972133
   timestamp: 1696221935494
-- name: gstreamer
+- platform: win-64
+  name: gstreamer
   version: 1.22.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    glib: '>=2.78.0,<3.0a0'
-    libglib: '>=2.78.0,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.0,<3.0a0
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.6-hb4038d2_2.conda
   hash:
     md5: e6d2009457a1e5d9653fd06873a7a367
     sha256: 08600f04d220a43f0ef5c383bb586cdd05ec482aceadb397fcd43a233b946144
-  optional: false
-  category: main
   build: hb4038d2_2
   arch: x86_64
   subdir: win-64
@@ -3099,19 +4358,18 @@ package:
   license_family: LGPL
   size: 1939400
   timestamp: 1696222270363
-- name: gxx
+- platform: linux-64
+  name: gxx
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gcc: 12.3.0.*
-    gxx_impl_linux-64: 12.3.0.*
+  - gcc 12.3.0.*
+  - gxx_impl_linux-64 12.3.0.*
   url: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
   hash:
     md5: 673bac341be6b90ef9e8abae7e52ca46
     sha256: 5fd65768fb602fd21466831c96e7a2355a4df692507abbd481aa65a777151d85
-  optional: false
-  category: main
   build: h8d2909c_2
   arch: x86_64
   subdir: linux-64
@@ -3120,20 +4378,19 @@ package:
   license_family: BSD
   size: 26539
   timestamp: 1694604501713
-- name: gxx_impl_linux-64
+- platform: linux-64
+  name: gxx_impl_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gcc_impl_linux-64: ==12.3.0 he2b93b0_2
-    libstdcxx-devel_linux-64: ==12.3.0 h8bca6fd_2
-    sysroot_linux-64: '*'
+  - gcc_impl_linux-64 ==12.3.0 he2b93b0_2
+  - libstdcxx-devel_linux-64 ==12.3.0 h8bca6fd_2
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_2.conda
   hash:
     md5: f89b9916afc36fc5562fbfc11330a8a2
     sha256: 1ca91c1a3892b61da7efe150f9a1830e18aac82f563b27bf707520cb3297cc7a
-  optional: false
-  category: main
   build: he2b93b0_2
   arch: x86_64
   subdir: linux-64
@@ -3142,21 +4399,20 @@ package:
   license_family: GPL
   size: 12667490
   timestamp: 1695218983245
-- name: gxx_linux-64
+- platform: linux-64
+  name: gxx_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    binutils_linux-64: ==2.40 hbdbef99_2
-    gcc_linux-64: ==12.3.0 h76fc315_2
-    gxx_impl_linux-64: 12.3.0.*
-    sysroot_linux-64: '*'
+  - binutils_linux-64 ==2.40 hbdbef99_2
+  - gcc_linux-64 ==12.3.0 h76fc315_2
+  - gxx_impl_linux-64 12.3.0.*
+  - sysroot_linux-64 *
   url: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
   hash:
     md5: f517b1525e9783849bd56a5dc45a9960
     sha256: 9878771cf1316230150a795d213a2f1dd7dead07dc0bccafae20533d631d5e69
-  optional: false
-  category: main
   build: h8a814eb_2
   arch: x86_64
   subdir: linux-64
@@ -3165,24 +4421,23 @@ package:
   license_family: BSD
   size: 28640
   timestamp: 1694604524890
-- name: harfbuzz
+- platform: linux-64
+  name: harfbuzz
   version: 8.2.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    cairo: '>=1.16.0,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: '*'
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.0,<3.0a0'
-    libstdcxx-ng: '>=12'
+  - cairo >=1.16.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2 *
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.2.1-h3d44ed6_0.conda
   hash:
     md5: 98db5f8813f45e2b29766aff0e4a499c
     sha256: 5ca6585e6a4348bcbe214d57f5d6f560d15d23a6650770a2909475848b214edb
-  optional: false
-  category: main
   build: h3d44ed6_0
   arch: x86_64
   subdir: linux-64
@@ -3191,23 +4446,22 @@ package:
   license_family: MIT
   size: 1526592
   timestamp: 1695089914042
-- name: harfbuzz
+- platform: osx-64
+  name: harfbuzz
   version: 8.2.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    cairo: '>=1.16.0,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: '*'
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=15.0.7'
-    libglib: '>=2.78.0,<3.0a0'
+  - cairo >=1.16.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2 *
+  - icu >=73.2,<74.0a0
+  - libcxx >=15.0.7
+  - libglib >=2.78.0,<3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.2.1-h7666e2a_0.conda
   hash:
     md5: 81f8f2aaf6bd4b408a0a8823edf7ce3b
     sha256: ac6f5304fe824ef7a60c493b14b6aefbb0d6c7f55b49f30e53d5dff2c31ca876
-  optional: false
-  category: main
   build: h7666e2a_0
   arch: x86_64
   subdir: osx-64
@@ -3216,23 +4470,22 @@ package:
   license_family: MIT
   size: 1311638
   timestamp: 1695090449044
-- name: harfbuzz
+- platform: osx-arm64
+  name: harfbuzz
   version: 8.2.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    cairo: '>=1.16.0,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: '*'
-    icu: '>=73.2,<74.0a0'
-    libcxx: '>=15.0.7'
-    libglib: '>=2.78.0,<3.0a0'
+  - cairo >=1.16.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2 *
+  - icu >=73.2,<74.0a0
+  - libcxx >=15.0.7
+  - libglib >=2.78.0,<3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.2.1-hf1a6348_0.conda
   hash:
     md5: 001c9b64c94fb7066525bff0dc0f30c2
     sha256: 4f1a8d3f2968d9d76ae1b75e021426f7bc53e88bd1efab82b22eb7fff15ace81
-  optional: false
-  category: main
   build: hf1a6348_0
   arch: aarch64
   subdir: osx-arm64
@@ -3241,25 +4494,24 @@ package:
   license_family: MIT
   size: 1248412
   timestamp: 1695090912167
-- name: harfbuzz
+- platform: win-64
+  name: harfbuzz
   version: 8.2.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    cairo: '>=1.16.0,<2.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    graphite2: '*'
-    icu: '>=73.2,<74.0a0'
-    libglib: '>=2.78.0,<3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - cairo >=1.16.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2 *
+  - icu >=73.2,<74.0a0
+  - libglib >=2.78.0,<3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.2.1-h7ab893a_0.conda
   hash:
     md5: 4af536fe2938b1734c6378d765404598
     sha256: f85cbb3bd32a4fc0f417e23d10197b73de218c6ddcdd9eeae0f05f6bd2eaefaa
-  optional: false
-  category: main
   build: h7ab893a_0
   arch: x86_64
   subdir: win-64
@@ -3268,25 +4520,24 @@ package:
   license_family: MIT
   size: 1043707
   timestamp: 1695091629366
-- name: hdf5
+- platform: linux-64
+  name: hdf5
   version: 1.14.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libaec: '>=1.0.6,<2.0a0'
-    libcurl: '>=8.2.1,<9.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: '*'
-    libgfortran5: '>=12.3.0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng *
+  - libgfortran5 >=12.3.0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.2-nompi_h4f84152_100.conda
   hash:
     md5: 2de6a9bc8083b49f09b2f6eb28d3ba3c
     sha256: f70f18291f912ba019cbb736bb87b6487021154733cd109147a6d9672790b6b8
-  optional: false
-  category: main
   build: nompi_h4f84152_100
   arch: x86_64
   subdir: linux-64
@@ -3295,24 +4546,23 @@ package:
   license_family: BSD
   size: 3726636
   timestamp: 1692563074131
-- name: hdf5
+- platform: osx-64
+  name: hdf5
   version: 1.14.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libaec: '>=1.0.6,<2.0a0'
-    libcurl: '>=8.2.1,<9.0a0'
-    libcxx: '>=15.0.7'
-    libgfortran: 5.*
-    libgfortran5: '>=12.3.0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.2-nompi_hedada53_100.conda
   hash:
     md5: 2b1d4f355b60eb10c5cb435b9f0e664f
     sha256: 08ab97d63ab4be60c92d3f5931effc565ae6ee0cd686eba81b9d20daf5f181ff
-  optional: false
-  category: main
   build: nompi_hedada53_100
   arch: x86_64
   subdir: osx-64
@@ -3321,24 +4571,23 @@ package:
   license_family: BSD
   size: 3564108
   timestamp: 1692563939275
-- name: hdf5
+- platform: osx-arm64
+  name: hdf5
   version: 1.14.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libaec: '>=1.0.6,<2.0a0'
-    libcurl: '>=8.2.1,<9.0a0'
-    libcxx: '>=15.0.7'
-    libgfortran: 5.*
-    libgfortran5: '>=12.3.0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.2-nompi_h3aba7b3_100.conda
   hash:
     md5: 842c5b010b219058098ebfe5aa5891b9
     sha256: 2749910e21a7d1f88a81dc4709fc3565a4a3954eadb4409e7a5be1fc13a5b7ca
-  optional: false
-  category: main
   build: nompi_h3aba7b3_100
   arch: aarch64
   subdir: osx-arm64
@@ -3347,24 +4596,23 @@ package:
   license_family: BSD
   size: 3408759
   timestamp: 1692562818610
-- name: hdf5
+- platform: win-64
+  name: hdf5
   version: 1.14.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libaec: '>=1.0.6,<2.0a0'
-    libcurl: '>=8.2.1,<9.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.2,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libaec >=1.0.6,<2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.2-nompi_h73e8ff5_100.conda
   hash:
     md5: 7fc095c23e4519a8df15c09f3671d09a
     sha256: 86bab02f1dbc658a15719b27ca5dcd2b50c22905cc2296a31a0ed220dac746f9
-  optional: false
-  category: main
   build: nompi_h73e8ff5_100
   arch: x86_64
   subdir: win-64
@@ -3373,19 +4621,18 @@ package:
   license_family: BSD
   size: 2044096
   timestamp: 1692562772245
-- name: icu
+- platform: linux-64
+  name: icu
   version: '73.2'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
   hash:
     md5: cc47e1facc155f91abd89b11e48e72ff
     sha256: e12fd90ef6601da2875ebc432452590bc82a893041473bc1c13ef29001a73ea8
-  optional: false
-  category: main
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -3394,17 +4641,16 @@ package:
   license_family: MIT
   size: 12089150
   timestamp: 1692900650789
-- name: icu
+- platform: osx-64
+  name: icu
   version: '73.2'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
   hash:
     md5: 5cc301d759ec03f28328428e28f65591
     sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
-  optional: false
-  category: main
   build: hf5e326d_0
   arch: x86_64
   subdir: osx-64
@@ -3413,17 +4659,16 @@ package:
   license_family: MIT
   size: 11787527
   timestamp: 1692901622519
-- name: icu
+- platform: osx-arm64
+  name: icu
   version: '73.2'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
   hash:
     md5: 8521bd47c0e11c5902535bb1a17c565f
     sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
-  optional: false
-  category: main
   build: hc8870d7_0
   arch: aarch64
   subdir: osx-arm64
@@ -3432,20 +4677,19 @@ package:
   license_family: MIT
   size: 11997841
   timestamp: 1692902104771
-- name: icu
+- platform: win-64
+  name: icu
   version: '73.2'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
   hash:
     md5: 0f47d9e3192d9e09ae300da0d28e0f56
     sha256: 423aaa2b69d713520712f55c7c71994b7e6f967824bb39b59ad968e7b209ce8c
-  optional: false
-  category: main
   build: h63175ca_0
   arch: x86_64
   subdir: win-64
@@ -3454,17 +4698,16 @@ package:
   license_family: MIT
   size: 13422193
   timestamp: 1692901469029
-- name: intel-openmp
+- platform: win-64
+  name: intel-openmp
   version: 2023.2.0
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
   hash:
     md5: a401f3cae152deb75bbed766a90a6312
     sha256: dd9fded25ebe5c66af30ac6e3685146efdc2d7787035f01bfb546b347f138f6f
-  optional: false
-  category: main
   build: h57928b3_50497
   arch: x86_64
   subdir: win-64
@@ -3473,21 +4716,20 @@ package:
   license_family: Proprietary
   size: 2523079
   timestamp: 1698351323119
-- name: jasper
+- platform: linux-64
+  name: jasper
   version: 4.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    freeglut: '>=3.2.2,<4.0a0'
-    libgcc-ng: '>=12'
-    libglu: '>=9.0.0,<10.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
+  - freeglut >=3.2.2,<4.0a0
+  - libgcc-ng >=12
+  - libglu >=9.0.0,<10.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.0.0-he6dfbbe_2.conda
   hash:
     md5: f654581a7e1c5328e0b9bbe0a3e768e2
     sha256: 71be36da8a5836f2d03860fc1b75f25f33e9a5e0c9df5ca986aa7e38240acd5b
-  optional: false
-  category: main
   build: he6dfbbe_2
   arch: x86_64
   subdir: linux-64
@@ -3495,18 +4737,17 @@ package:
   license: JasPer-2.0
   size: 679132
   timestamp: 1695661355183
-- name: jasper
+- platform: osx-64
+  name: jasper
   version: 4.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
+  - libjpeg-turbo >=3.0.0,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.0.0-h6513c55_2.conda
   hash:
     md5: a8273b73455e4d820eb7656807cd3ca6
     sha256: 94b4a4607c142c832df5cb9040b3df3464e5745ec1eeacd5270f6c8d3ef4d45f
-  optional: false
-  category: main
   build: h6513c55_2
   arch: x86_64
   subdir: osx-64
@@ -3514,18 +4755,17 @@ package:
   license: JasPer-2.0
   size: 575867
   timestamp: 1695661668532
-- name: jasper
+- platform: osx-arm64
+  name: jasper
   version: 4.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
+  - libjpeg-turbo >=3.0.0,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.0.0-h6a52c50_2.conda
   hash:
     md5: 7b7d9ce2179d9084bcabc496456ff976
     sha256: 615b2e7c8b227af5fd920f1266f5f6553d278d05480337431f7f850b4c1da6b4
-  optional: false
-  category: main
   build: h6a52c50_2
   arch: aarch64
   subdir: osx-arm64
@@ -3533,22 +4773,21 @@ package:
   license: JasPer-2.0
   size: 603759
   timestamp: 1695661769126
-- name: jasper
+- platform: win-64
+  name: jasper
   version: 4.0.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    freeglut: '>=3.2.2,<4.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - freeglut >=3.2.2,<4.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.0.0-h28f2b1a_2.conda
   hash:
     md5: a6c16a1d54b6ec86e953545906dfc995
     sha256: 6ecc29a047be92390fb926160f85013d5ec869ce99ea9f8d154c8d500cca3334
-  optional: false
-  category: main
   build: h28f2b1a_2
   arch: x86_64
   subdir: win-64
@@ -3556,17 +4795,16 @@ package:
   license: JasPer-2.0
   size: 441838
   timestamp: 1695662132361
-- name: kernel-headers_linux-64
+- platform: linux-64
+  name: kernel-headers_linux-64
   version: 2.6.32
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
   hash:
     md5: 7ca122655873935e02c91279c5b03c8c
     sha256: aaa8aa6dc776d734a6702032588ff3c496721da905366d91162e3654c082aef0
-  optional: false
-  category: main
   build: he073ed8_16
   arch: x86_64
   subdir: linux-64
@@ -3578,18 +4816,17 @@ package:
   noarch: generic
   size: 709007
   timestamp: 1689214970644
-- name: keyutils
+- platform: linux-64
+  name: keyutils
   version: 1.6.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=10.3.0'
+  - libgcc-ng >=10.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
   hash:
     md5: 30186d27e2c9fa62b45fb1476b7200e3
     sha256: 150c05a6e538610ca7c43beb3a40d65c90537497a4f6a5f4d15ec0451b6f5ebb
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -3597,20 +4834,19 @@ package:
   license: LGPL-2.1-or-later
   size: 117831
   timestamp: 1646151697040
-- name: khronos-opencl-icd-loader
+- platform: win-64
+  name: khronos-opencl-icd-loader
   version: 2023.04.17
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2023.04.17-h64bf75a_0.conda
   hash:
     md5: 8c51fee1005a058dc96b1da5eba9b308
     sha256: aca20cb000427881e0b1eb5301568278650ca9f7b069fec0c7904cdf94b995e6
-  optional: false
-  category: main
   build: h64bf75a_0
   arch: x86_64
   subdir: win-64
@@ -3619,22 +4855,21 @@ package:
   license_family: APACHE
   size: 86302
   timestamp: 1681919883423
-- name: krb5
+- platform: linux-64
+  name: krb5
   version: 1.21.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    keyutils: '>=1.6.1,<2.0a0'
-    libedit: '>=3.1.20191231,<4.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.1.2,<4.0a0'
+  - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<4.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
   hash:
     md5: cd95826dbd331ed1be26bdf401432844
     sha256: 259bfaae731989b252b7d2228c1330ef91b641c9d68ff87dae02cbae682cb3e4
-  optional: false
-  category: main
   build: h659d440_0
   arch: x86_64
   subdir: linux-64
@@ -3643,20 +4878,19 @@ package:
   license_family: MIT
   size: 1371181
   timestamp: 1692097755782
-- name: krb5
+- platform: osx-64
+  name: krb5
   version: 1.21.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-    libedit: '>=3.1.20191231,<4.0a0'
-    openssl: '>=3.1.2,<4.0a0'
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
   hash:
     md5: 80505a68783f01dc8d7308c075261b2f
     sha256: 081ae2008a21edf57c048f331a17c65d1ccb52d6ca2f87ee031a73eff4dc0fc6
-  optional: false
-  category: main
   build: hb884880_0
   arch: x86_64
   subdir: osx-64
@@ -3665,20 +4899,19 @@ package:
   license_family: MIT
   size: 1183568
   timestamp: 1692098004387
-- name: krb5
+- platform: osx-arm64
+  name: krb5
   version: 1.21.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    libedit: '>=3.1.20191231,<4.0a0'
-    openssl: '>=3.1.2,<4.0a0'
+  - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<4.0a0
+  - openssl >=3.1.2,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
   hash:
     md5: 92f1cff174a538e0722bf2efb16fc0b2
     sha256: 70bdb9b4589ec7c7d440e485ae22b5a352335ffeb91a771d4c162996c3070875
-  optional: false
-  category: main
   build: h92f50d5_0
   arch: aarch64
   subdir: osx-arm64
@@ -3687,21 +4920,20 @@ package:
   license_family: MIT
   size: 1195575
   timestamp: 1692098070699
-- name: krb5
+- platform: win-64
+  name: krb5
   version: 1.21.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    openssl: '>=3.1.2,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - openssl >=3.1.2,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
   hash:
     md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
     sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
-  optional: false
-  category: main
   build: heb0366b_0
   arch: x86_64
   subdir: win-64
@@ -3710,18 +4942,17 @@ package:
   license_family: MIT
   size: 710894
   timestamp: 1692098129546
-- name: lame
+- platform: linux-64
+  name: lame
   version: '3.100'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
   hash:
     md5: a8832b479f93521a9e7b5b743803be51
     sha256: aad2a703b9d7b038c0f745b853c6bb5f122988fe1a7a096e0e606d9cbec4eaab
-  optional: false
-  category: main
   build: h166bdaf_1003
   arch: x86_64
   subdir: linux-64
@@ -3730,17 +4961,16 @@ package:
   license_family: LGPL
   size: 508258
   timestamp: 1664996250081
-- name: lame
+- platform: osx-64
+  name: lame
   version: '3.100'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
   hash:
     md5: 3342b33c9a0921b22b767ed68ee25861
     sha256: 0f943b08abb4c748d73207594321b53bad47eea3e7d06b6078e0f6c59ce6771e
-  optional: false
-  category: main
   build: hb7f2c08_1003
   arch: x86_64
   subdir: osx-64
@@ -3749,17 +4979,16 @@ package:
   license_family: LGPL
   size: 542681
   timestamp: 1664996421531
-- name: lame
+- platform: osx-arm64
+  name: lame
   version: '3.100'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
   hash:
     md5: bff0e851d66725f78dc2fd8b032ddb7e
     sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
-  optional: false
-  category: main
   build: h1a8c8d9_1003
   arch: aarch64
   subdir: osx-arm64
@@ -3768,19 +4997,102 @@ package:
   license_family: LGPL
   size: 528805
   timestamp: 1664996399305
-- name: ld64
-  version: '609'
+- platform: linux-64
+  name: lcms2
+  version: '2.15'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ld64_osx-64: ==609 h0fd476b_15
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.15-hb7c19ff_3.conda
+  hash:
+    md5: e96637dd92c5f340215c753a5c9a22d7
+    sha256: cc0b2ddab52b20698b26fe8622ebe37e0d462d8691a1f324e7b00f7d904765e3
+  build: hb7c19ff_3
+  arch: x86_64
+  subdir: linux-64
+  build_number: 3
+  license: MIT
+  license_family: MIT
+  size: 239723
+  timestamp: 1695969712554
+- platform: osx-64
+  name: lcms2
+  version: '2.15'
+  category: main
+  manager: conda
+  dependencies:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
+  hash:
+    md5: 8059507d52f477fbd4b81841e085e25b
+    sha256: b2234f24e3b0030762430ec3414410119d1129804a95ef65af50ad36cabd9bd5
+  build: hd6ba6f3_3
+  arch: x86_64
+  subdir: osx-64
+  build_number: 3
+  license: MIT
+  license_family: MIT
+  size: 224895
+  timestamp: 1695969874291
+- platform: osx-arm64
+  name: lcms2
+  version: '2.15'
+  category: main
+  manager: conda
+  dependencies:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.15-hf2736f0_3.conda
+  hash:
+    md5: bbaac531169fed3e09ae31aff80aa069
+    sha256: 3d07ba04602617c3084b302c8a6fa30b2e4b20511180f45992b289c312298018
+  build: hf2736f0_3
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 3
+  license: MIT
+  license_family: MIT
+  size: 215466
+  timestamp: 1695969888308
+- platform: win-64
+  name: lcms2
+  version: '2.15'
+  category: main
+  manager: conda
+  dependencies:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h67d730c_3.conda
+  hash:
+    md5: f92e86636451e3f6cea03e395346fa90
+    sha256: 8819d74571b6321e0ed93b07c19b4fd9a9b669df3fdd797ab4798ab7c684ae1d
+  build: h67d730c_3
+  arch: x86_64
+  subdir: win-64
+  build_number: 3
+  license: MIT
+  license_family: MIT
+  size: 498833
+  timestamp: 1695969944045
+- platform: osx-64
+  name: ld64
+  version: '609'
+  category: main
+  manager: conda
+  dependencies:
+  - ld64_osx-64 ==609 h0fd476b_15
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha91a046_15.conda
   hash:
     md5: 3c27099076bcf8fdde53785efb46dbf1
     sha256: 5c13ce2916f592adb29301dfbbcfe773437744f2890881615210b041b6276fc2
-  optional: false
-  category: main
   build: ha91a046_15
   arch: x86_64
   subdir: osx-64
@@ -3792,19 +5104,18 @@ package:
   license_family: Other
   size: 19091
   timestamp: 1697075759131
-- name: ld64
+- platform: osx-arm64
+  name: ld64
   version: '609'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ld64_osx-arm64: ==609 hc4dc95b_15
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - ld64_osx-arm64 ==609 hc4dc95b_15
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h89fa09d_15.conda
   hash:
     md5: 920d98b2054e806dbe4c5fb8f54cad31
     sha256: 6a4370f5984a429a8695bb4f87b879ec2a4af284b0859de863a938cc4a758b81
-  optional: false
-  category: main
   build: h89fa09d_15
   arch: aarch64
   subdir: osx-arm64
@@ -3816,21 +5127,20 @@ package:
   license_family: Other
   size: 19147
   timestamp: 1697075929066
-- name: ld64_osx-64
+- platform: osx-64
+  name: ld64_osx-64
   version: '609'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '*'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    sigtool: '*'
-    tapi: '>=1100.0.11,<1101.0a0'
+  - libcxx *
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - sigtool *
+  - tapi >=1100.0.11,<1101.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-h0fd476b_15.conda
   hash:
     md5: f98d11f8e568521e1e3f88cbe5a4d53c
     sha256: 6d793058554a46ffd4a059bf3bd33741856bfcbdaeab8e11cc1dc2df1137f7f0
-  optional: false
-  category: main
   build: h0fd476b_15
   arch: x86_64
   subdir: osx-64
@@ -3844,21 +5154,20 @@ package:
   license_family: Other
   size: 1062203
   timestamp: 1697075547194
-- name: ld64_osx-arm64
+- platform: osx-arm64
+  name: ld64_osx-arm64
   version: '609'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '*'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    sigtool: '*'
-    tapi: '>=1100.0.11,<1101.0a0'
+  - libcxx *
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - sigtool *
+  - tapi >=1100.0.11,<1101.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-hc4dc95b_15.conda
   hash:
     md5: 19220ad0db4efb72970ab401ebbd7c33
     sha256: 78696e68684c8f8e4507bcdf3e072b5c0f6eb7af58383eb339a5035999039cb2
-  optional: false
-  category: main
   build: hc4dc95b_15
   arch: aarch64
   subdir: osx-arm64
@@ -3872,17 +5181,16 @@ package:
   license_family: Other
   size: 1046454
   timestamp: 1697075685770
-- name: ld_impl_linux-64
+- platform: linux-64
+  name: ld_impl_linux-64
   version: '2.40'
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
   hash:
     md5: 7aca3059a1729aa76c597603f10b0dd3
     sha256: f6cc89d887555912d6c61b295d398cff9ec982a3417d38025c45d5dd9b9e79cd
-  optional: false
-  category: main
   build: h41732ed_0
   arch: x86_64
   subdir: linux-64
@@ -3893,19 +5201,18 @@ package:
   license_family: GPL
   size: 704696
   timestamp: 1674833944779
-- name: lerc
+- platform: linux-64
+  name: lerc
   version: 4.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
   hash:
     md5: 76bbff344f0134279f225174e9064c8f
     sha256: cb55f36dcd898203927133280ae1dc643368af041a48bcf7c026acb7c47b0c12
-  optional: false
-  category: main
   build: h27087fc_0
   arch: x86_64
   subdir: linux-64
@@ -3914,18 +5221,17 @@ package:
   license_family: Apache
   size: 281798
   timestamp: 1657977462600
-- name: lerc
+- platform: osx-64
+  name: lerc
   version: 4.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=13.0.1'
+  - libcxx >=13.0.1
   url: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
   hash:
     md5: f9d6a4c82889d5ecedec1d90eb673c55
     sha256: e41790fc0f4089726369b3c7f813117bbc14b533e0ed8b94cf75aba252e82497
-  optional: false
-  category: main
   build: hb486fe8_0
   arch: x86_64
   subdir: osx-64
@@ -3934,18 +5240,17 @@ package:
   license_family: Apache
   size: 290319
   timestamp: 1657977526749
-- name: lerc
+- platform: osx-arm64
+  name: lerc
   version: 4.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=13.0.1'
+  - libcxx >=13.0.1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
   hash:
     md5: de462d5aacda3b30721b512c5da4e742
     sha256: 6f068bb53dfb6147d3147d981bb851bb5477e769407ad4e6a68edf482fdcb958
-  optional: false
-  category: main
   build: h9a09cb3_0
   arch: aarch64
   subdir: osx-arm64
@@ -3954,19 +5259,18 @@ package:
   license_family: Apache
   size: 215721
   timestamp: 1657977558796
-- name: lerc
+- platform: win-64
+  name: lerc
   version: 4.0.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30037'
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30037
   url: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
   hash:
     md5: 1900cb3cab5055833cfddb0ba233b074
     sha256: f4f39d7f6a2f9b407f8fb567a6c25755270421731d70f0ff331f5de4fa367488
-  optional: false
-  category: main
   build: h63175ca_0
   arch: x86_64
   subdir: win-64
@@ -3975,19 +5279,18 @@ package:
   license_family: Apache
   size: 194365
   timestamp: 1657977692274
-- name: libabseil
+- platform: linux-64
+  name: libabseil
   version: '20230802.1'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
   hash:
     md5: 2785ddf4cb0e7e743477991d64353947
     sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
-  optional: false
-  category: main
   build: cxx17_h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -3999,18 +5302,17 @@ package:
   license_family: Apache
   size: 1263396
   timestamp: 1695063868515
-- name: libabseil
+- platform: osx-64
+  name: libabseil
   version: '20230802.1'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
   hash:
     md5: 6554f5fb47c025273268bcdb7bf3cd48
     sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
-  optional: false
-  category: main
   build: cxx17_h048a20a_0
   arch: x86_64
   subdir: osx-64
@@ -4023,18 +5325,17 @@ package:
   license_family: Apache
   size: 1148356
   timestamp: 1695064289396
-- name: libabseil
+- platform: osx-arm64
+  name: libabseil
   version: '20230802.1'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
   hash:
     md5: fb6dfadc1898666616dfda242d8aea10
     sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
-  optional: false
-  category: main
   build: cxx17_h13dd4ca_0
   arch: aarch64
   subdir: osx-arm64
@@ -4046,20 +5347,19 @@ package:
   license_family: Apache
   size: 1173407
   timestamp: 1695064439482
-- name: libabseil
+- platform: win-64
+  name: libabseil
   version: '20230802.1'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
   hash:
     md5: 02674c18394394ee4f76cdbd1012f526
     sha256: 8a016d49fad3d4216ce5ae4a60869b5384d31b2009e1ed9f445b6551ce7ef9e8
-  optional: false
-  category: main
   build: cxx17_h63175ca_0
   arch: x86_64
   subdir: win-64
@@ -4071,19 +5371,18 @@ package:
   license_family: Apache
   size: 1733638
   timestamp: 1695064265262
-- name: libaec
+- platform: linux-64
+  name: libaec
   version: 1.1.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
   hash:
     md5: 127b0be54c1c90760d7fe02ea7a56426
     sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
@@ -4092,18 +5391,17 @@ package:
   license_family: BSD
   size: 35228
   timestamp: 1696474021700
-- name: libaec
+- platform: osx-64
+  name: libaec
   version: 1.1.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
   hash:
     md5: faa179050abc6af1385e0fe9dd074f91
     sha256: 1b0a0b9b67e8f155ebdc7205a7421c7aff4850a740fc9f88b3fa23282c98ed72
-  optional: false
-  category: main
   build: he965462_1
   arch: x86_64
   subdir: osx-64
@@ -4112,18 +5410,17 @@ package:
   license_family: BSD
   size: 29027
   timestamp: 1696474151758
-- name: libaec
+- platform: osx-arm64
+  name: libaec
   version: 1.1.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
   hash:
     md5: b7962cdc2cedcc9f8d12928824c11fbd
     sha256: c9d6f01d511bd3686ce590addf829f34031b95e3feb34418496cbb45924c5d17
-  optional: false
-  category: main
   build: h13dd4ca_1
   arch: aarch64
   subdir: osx-arm64
@@ -4132,20 +5429,19 @@ package:
   license_family: BSD
   size: 29002
   timestamp: 1696474168895
-- name: libaec
+- platform: win-64
+  name: libaec
   version: 1.1.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
   hash:
     md5: 0b252d2bf460364bccb1523bcdbe4af6
     sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
@@ -4154,25 +5450,204 @@ package:
   license_family: BSD
   size: 33554
   timestamp: 1696474526588
-- name: libass
-  version: 0.17.1
+- platform: linux-64
+  name: libarrow
+  version: 10.0.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=8.1.1,<9.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc-ng >=12
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libstdcxx-ng >=12
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.4,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2
+  - snappy >=1.1.10,<2.0a0
+  - ucx >=1.15.0,<1.16.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-10.0.1-hecbb4c5_50_cpu.conda
+  hash:
+    md5: b5479b5c53c44fd2c924dc1b393d6c54
+    sha256: 106822679a3f76d60b36741b7e377547ead7adaceb8c144f692a48c16c375c5f
+  build: hecbb4c5_50_cpu
+  arch: x86_64
+  subdir: linux-64
+  build_number: 50
+  constrains:
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp =10.0.1
+  license: Apache-2.0
+  size: 27265549
+  timestamp: 1698343574909
+- platform: osx-64
+  name: libarrow
+  version: 10.0.1
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.13
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=14.0.6
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.4,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-10.0.1-h99c5134_50_cpu.conda
+  hash:
+    md5: f1c548c758e5ea66f064cdd0a71453ed
+    sha256: c3d859372a1174957f144aa3b9261d99e27e75e33f934aa0901661a753bf822d
+  build: h99c5134_50_cpu
+  arch: x86_64
+  subdir: osx-64
+  build_number: 50
+  constrains:
+  - arrow-cpp =10.0.1
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  size: 19403362
+  timestamp: 1698344177760
+- platform: osx-arm64
+  name: libarrow
+  version: 10.0.1
+  category: main
+  manager: conda
+  dependencies:
+  - aws-crt-cpp >=0.24.4,<0.24.5.0a0
+  - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - gflags >=2.2.2,<2.3.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=14.0.6
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.4,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-10.0.1-h8276777_50_cpu.conda
+  hash:
+    md5: 58d967e1c7d76e3dda613dd14e6eb644
+    sha256: f24caa6f0c9cf209be6eec530265576f5c7e0265caca9959ff1df7cc5cc9ebbe
+  build: h8276777_50_cpu
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 50
+  constrains:
+  - parquet-cpp <0.0a0
+  - arrow-cpp =10.0.1
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  size: 16945399
+  timestamp: 1698344384688
+- platform: win-64
+  name: libarrow
+  version: 10.0.1
+  category: main
+  manager: conda
+  dependencies:
+  - aws-sdk-cpp >=1.11.182,<1.11.183.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.4.0,<9.0a0
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.4,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2
+  - snappy >=1.1.10,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-10.0.1-hd2d01ff_50_cpu.conda
+  hash:
+    md5: b60e5b6a8def8b51d8822743c112fe95
+    sha256: 37db84b253d730942be81705ac648c6c6cbef48386703f850da05f6e09cc435a
+  build: hd2d01ff_50_cpu
+  arch: x86_64
+  subdir: win-64
+  build_number: 50
+  constrains:
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp =10.0.1
+  license: Apache-2.0
+  size: 15971089
+  timestamp: 1698343937840
+- platform: linux-64
+  name: libass
+  version: 0.17.1
+  category: main
+  manager: conda
+  dependencies:
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=8.1.1,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
   hash:
     md5: c306fd9cc90c0585171167d09135a827
     sha256: 1bc3e44239a11613627488b7a9b6c021ec6b52c5925abd666832db0cb2a59f05
-  optional: false
-  category: main
   build: h8fe9dca_1
   arch: x86_64
   subdir: linux-64
@@ -4181,24 +5656,23 @@ package:
   license_family: OTHER
   size: 126896
   timestamp: 1693027051367
-- name: libass
+- platform: osx-64
+  name: libass
   version: 0.17.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=8.1.1,<9.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=8.1.1,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.1-h80904bb_1.conda
   hash:
     md5: 9ccad0aebe916aa3715fda9eefe92584
     sha256: f97c70aa61ecc1b43907cf0322215a58f19e0723ee67b4ebd02146da24f03976
-  optional: false
-  category: main
   build: h80904bb_1
   arch: x86_64
   subdir: osx-64
@@ -4207,24 +5681,23 @@ package:
   license_family: OTHER
   size: 125235
   timestamp: 1693027259439
-- name: libass
+- platform: osx-arm64
+  name: libass
   version: 0.17.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    fribidi: '>=1.0.10,<2.0a0'
-    harfbuzz: '>=8.1.1,<9.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - fribidi >=1.0.10,<2.0a0
+  - harfbuzz >=8.1.1,<9.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
   hash:
     md5: 53fff6fc379154382f5121325c5fe2f5
     sha256: 31b17bebadd114c6c3e4a647245888fd83ec93533b6ee8f6bfca0bbbc3a95c35
-  optional: false
-  category: main
   build: hf7da4fe_1
   arch: aarch64
   subdir: osx-arm64
@@ -4233,18 +5706,17 @@ package:
   license_family: OTHER
   size: 110763
   timestamp: 1693027364342
-- name: libblas
+- platform: linux-64
+  name: libblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libopenblas: '>=0.3.24,<1.0a0'
+  - libopenblas >=0.3.24,<1.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
   hash:
     md5: 420f4e9be59d0dc9133a0f43f7bab3f3
     sha256: b1311b9414559c5760b08a32e0382ca27fa302c967968aa6f78e042519f728ce
-  optional: false
-  category: main
   build: 19_linux64_openblas
   arch: x86_64
   subdir: linux-64
@@ -4258,18 +5730,17 @@ package:
   license_family: BSD
   size: 14566
   timestamp: 1697484219912
-- name: libblas
+- platform: osx-64
+  name: libblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libopenblas: '>=0.3.24,<1.0a0'
+  - libopenblas >=0.3.24,<1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
   hash:
     md5: e932b99c38915fa2ee252cdff6ea1f01
     sha256: c2c96103aa23a65f45b76716df49940cb0722258d3e0416f8fa06ade02464b23
-  optional: false
-  category: main
   build: 19_osx64_openblas
   arch: x86_64
   subdir: osx-64
@@ -4283,18 +5754,17 @@ package:
   license_family: BSD
   size: 14812
   timestamp: 1697484725085
-- name: libblas
+- platform: osx-arm64
+  name: libblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libopenblas: '>=0.3.24,<1.0a0'
+  - libopenblas >=0.3.24,<1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
   hash:
     md5: f50b1fd98593278e18319653cff9c475
     sha256: 51e78e3c9fa57f3fec12936b760928715ba0ab5253d02815202f9ec4c2c9255d
-  optional: false
-  category: main
   build: 19_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
@@ -4308,18 +5778,17 @@ package:
   license_family: BSD
   size: 14817
   timestamp: 1697484577887
-- name: libblas
+- platform: win-64
+  name: libblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    mkl: ==2023.2.0 h6a75c08_50496
+  - mkl ==2023.2.0 h6a75c08_50496
   url: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
   hash:
     md5: 4f8a1a63cfbf74bc7b2813d9c6c205be
     sha256: 915eae5e0dedbf87733a0b8c6f410678c77111a3fb26ca0a272e11ff979e7ef2
-  optional: false
-  category: main
   build: 19_win64_mkl
   arch: x86_64
   subdir: win-64
@@ -4333,19 +5802,254 @@ package:
   license_family: BSD
   size: 4984180
   timestamp: 1697485304263
-- name: libcap
-  version: '2.69'
+- platform: linux-64
+  name: libbrotlicommon
+  version: 1.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    attr: '>=2.5.1,<2.6.0a0'
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+  hash:
+    md5: aec6c91c7371c26392a06708a73c70e5
+    sha256: 40f29d1fab92c847b083739af86ad2f36d8154008cf99b64194e4705a1725d78
+  build: hd590300_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 69403
+  timestamp: 1695990007212
+- platform: osx-64
+  name: libbrotlicommon
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 9e6c31441c9aa24e41ace40d6151aab6
+    sha256: f57c57c442ef371982619f82af8735f93a4f50293022cfd1ffaf2ff89c2e0b2a
+  build: h0dc2134_1
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 67476
+  timestamp: 1695990207321
+- platform: osx-arm64
+  name: libbrotlicommon
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+  hash:
+    md5: cd68f024df0304be41d29a9088162b02
+    sha256: 556f0fddf4bd4d35febab404d98cb6862ce3b7ca843e393da0451bfc4654cf07
+  build: hb547adb_1
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 68579
+  timestamp: 1695990426128
+- platform: win-64
+  name: libbrotlicommon
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+  hash:
+    md5: f77f319fb82980166569e1280d5b2864
+    sha256: f75fed29b0cc503d1b149a4945eaa32df56e19da5e2933de29e8f03947203709
+  build: hcfcfb64_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 70598
+  timestamp: 1695990405143
+- platform: linux-64
+  name: libbrotlidec
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - libbrotlicommon 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+  hash:
+    md5: f07002e225d7a60a694d42a7bf5ff53f
+    sha256: 86fc861246fbe5ad85c1b6b3882aaffc89590a48b42d794d3d5c8e6d99e5f926
+  build: hd590300_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 32775
+  timestamp: 1695990022788
+- platform: osx-64
+  name: libbrotlidec
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 9ee0bab91b2ca579e10353738be36063
+    sha256: b11939c4c93c29448660ab5f63273216969d1f2f315dd9be60f3c43c4e61a50c
+  build: h0dc2134_1
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 30327
+  timestamp: 1695990232422
+- platform: osx-arm64
+  name: libbrotlidec
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+  hash:
+    md5: ee1a519335cc10d0ec7e097602058c0a
+    sha256: c1c85937828ad3bc434ac60b7bcbde376f4d2ea4ee42d15d369bf2a591775b4a
+  build: hb547adb_1
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 28928
+  timestamp: 1695990463780
+- platform: win-64
+  name: libbrotlidec
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+  hash:
+    md5: 19ce3e1dacc7912b3d6ff40690ba9ae0
+    sha256: 1b352ee05931ea24c11cd4a994d673890fd1cc690c21e023e736bdaac2632e93
+  build: hcfcfb64_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 32788
+  timestamp: 1695990443165
+- platform: linux-64
+  name: libbrotlienc
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - libbrotlicommon 1.1.0 hd590300_1
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+  hash:
+    md5: 5fc11c6020d421960607d821310fcd4d
+    sha256: f751b8b1c4754a2a8dfdc3b4040fa7818f35bbf6b10e905a47d3a194b746b071
+  build: hd590300_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 282523
+  timestamp: 1695990038302
+- platform: osx-64
+  name: libbrotlienc
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+  hash:
+    md5: 8a421fe09c6187f0eb5e2338a8a8be6d
+    sha256: bc964c23e1a60ca1afe7bac38a9c1f2af3db4a8072c9f2eac4e4de537a844ac7
+  build: h0dc2134_1
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 299092
+  timestamp: 1695990259225
+- platform: osx-arm64
+  name: libbrotlienc
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - libbrotlicommon 1.1.0 hb547adb_1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+  hash:
+    md5: d7e077f326a98b2cc60087eaff7c730b
+    sha256: 690dfc98e891ee1871c54166d30f6e22edfc2d7d6b29e7988dde5f1ce271c81a
+  build: hb547adb_1
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 280943
+  timestamp: 1695990509392
+- platform: win-64
+  name: libbrotlienc
+  version: 1.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - libbrotlicommon 1.1.0 hcfcfb64_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+  hash:
+    md5: 71e890a0b361fd58743a13f77e1506b7
+    sha256: eae6b76154e594c6d211160c6d1aeed848672618152a562e0eabdfa641d34aca
+  build: hcfcfb64_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: MIT
+  license_family: MIT
+  size: 246515
+  timestamp: 1695990479484
+- platform: linux-64
+  name: libcap
+  version: '2.69'
+  category: main
+  manager: conda
+  dependencies:
+  - attr >=2.5.1,<2.6.0a0
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
   hash:
     md5: 25cb5999faa414e5ccb2c1388f62d3d5
     sha256: 942f9564b4228609f017b6617425d29a74c43b8a030e12239fa4458e5cb6323c
-  optional: false
-  category: main
   build: h0f662aa_0
   arch: x86_64
   subdir: linux-64
@@ -4354,18 +6058,17 @@ package:
   license_family: BSD
   size: 100582
   timestamp: 1684162447012
-- name: libcblas
+- platform: linux-64
+  name: libcblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libblas: ==3.9.0 19_linux64_openblas
+  - libblas ==3.9.0 19_linux64_openblas
   url: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
   hash:
     md5: d12374af44575413fbbd4a217d46ea33
     sha256: 84fddccaf58f42b07af7fb42512bd617efcb072f17bdef27f4c1884dbd33c86a
-  optional: false
-  category: main
   build: 19_linux64_openblas
   arch: x86_64
   subdir: linux-64
@@ -4378,18 +6081,17 @@ package:
   license_family: BSD
   size: 14458
   timestamp: 1697484230827
-- name: libcblas
+- platform: osx-64
+  name: libcblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libblas: ==3.9.0 19_osx64_openblas
+  - libblas ==3.9.0 19_osx64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
   hash:
     md5: 40e412c219ad8cf87ba664466071bcf6
     sha256: 70afde49736007bbb804d126a3983ba1fa04383006aae416a2971d538e274427
-  optional: false
-  category: main
   build: 19_osx64_openblas
   arch: x86_64
   subdir: osx-64
@@ -4402,18 +6104,17 @@ package:
   license_family: BSD
   size: 14717
   timestamp: 1697484740520
-- name: libcblas
+- platform: osx-arm64
+  name: libcblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libblas: ==3.9.0 19_osxarm64_openblas
+  - libblas ==3.9.0 19_osxarm64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-19_osxarm64_openblas.conda
   hash:
     md5: 5460a8d1beffd7f63994d891e6a20da4
     sha256: 19b1c5e3ddd383ec14540336f4704938218d3c1db4707ae10d5357afb22cccc1
-  optional: false
-  category: main
   build: 19_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
@@ -4426,18 +6127,17 @@ package:
   license_family: BSD
   size: 14738
   timestamp: 1697484590682
-- name: libcblas
+- platform: win-64
+  name: libcblas
   version: 3.9.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libblas: ==3.9.0 19_win64_mkl
+  - libblas ==3.9.0 19_win64_mkl
   url: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
   hash:
     md5: 1b9ede5cff953aa1a5f4d9f8ec644972
     sha256: 66c8934bf8ead1e3ab3653155697a7d70878e96115742b681aac16d9bd25dd3d
-  optional: false
-  category: main
   build: 19_win64_mkl
   arch: x86_64
   subdir: win-64
@@ -4450,22 +6150,21 @@ package:
   license_family: BSD
   size: 4984046
   timestamp: 1697485351545
-- name: libclang
+- platform: linux-64
+  name: libclang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libclang13: ==15.0.7 default_h9986a30_3
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libclang13 ==15.0.7 default_h9986a30_3
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h7634d5b_3.conda
   hash:
     md5: 0922208521c0463e690bbaebba7eb551
     sha256: c2b0c8dd675e30d86bad410679f258820bc36723fbadffc13c2f60249be91815
-  optional: false
-  category: main
   build: default_h7634d5b_3
   arch: x86_64
   subdir: linux-64
@@ -4474,22 +6173,21 @@ package:
   license_family: Apache
   size: 133162
   timestamp: 1690549855318
-- name: libclang
+- platform: win-64
+  name: libclang
   version: 15.0.7
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libclang13: ==15.0.7 default_h77d9078_3
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libclang13 ==15.0.7 default_h77d9078_3
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_h77d9078_3.conda
   hash:
     md5: 71c8b6249c9e9e18b3aec705e95c1040
     sha256: d54ad3cc60469f3c885cef45acd7216bab9d941dec8f37e75ece48b9baba145b
-  optional: false
-  category: main
   build: default_h77d9078_3
   arch: x86_64
   subdir: win-64
@@ -4498,19 +6196,18 @@ package:
   license_family: Apache
   size: 147881
   timestamp: 1690553583920
-- name: libclang-cpp15
+- platform: osx-64
+  name: libclang-cpp15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp15-15.0.7-default_hdb78580_3.conda
   hash:
     md5: 73639154fe4a7ca500d1361eef58fb65
     sha256: 413c923b922c6d440f5e10012b65a733ff53d00af01298935b31a1567af2cb12
-  optional: false
-  category: main
   build: default_hdb78580_3
   arch: x86_64
   subdir: osx-64
@@ -4519,19 +6216,18 @@ package:
   license_family: Apache
   size: 12426526
   timestamp: 1690549605370
-- name: libclang-cpp15
+- platform: osx-arm64
+  name: libclang-cpp15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    libllvm15: '>=15.0.7,<15.1.0a0'
+  - libcxx >=15.0.7
+  - libllvm15 >=15.0.7,<15.1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp15-15.0.7-default_h5dc8d65_3.conda
   hash:
     md5: 99c37593de0f76769f089218e493f083
     sha256: 33375e4e41f06c90c3a50f5efe15e9ad488243585a1dc994d3d9a897313d1cc4
-  optional: false
-  category: main
   build: default_h5dc8d65_3
   arch: aarch64
   subdir: osx-arm64
@@ -4540,21 +6236,20 @@ package:
   license_family: Apache
   size: 11402301
   timestamp: 1690549536998
-- name: libclang13
+- platform: linux-64
+  name: libclang13
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libllvm15 >=15.0.7,<15.1.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h9986a30_3.conda
   hash:
     md5: 1720df000b48e31842500323cb7be18c
     sha256: df1221a9a05b9bb3bd9b43c08a7e2fe57a0e15a0010ef26065f7ed7666083f45
-  optional: false
-  category: main
   build: default_h9986a30_3
   arch: x86_64
   subdir: linux-64
@@ -4563,21 +6258,20 @@ package:
   license_family: Apache
   size: 9557507
   timestamp: 1690549793486
-- name: libclang13
+- platform: win-64
+  name: libclang13
   version: 15.0.7
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_h77d9078_3.conda
   hash:
     md5: ba26634d038b91466bb4242c8b5e0cfa
     sha256: 9cff68d1bd3b1b956133f9f5f35d475014402f3f4e7956047bf3a70f2107f11c
-  optional: false
-  category: main
   build: default_h77d9078_3
   arch: x86_64
   subdir: win-64
@@ -4586,21 +6280,98 @@ package:
   license_family: Apache
   size: 21900199
   timestamp: 1690553341399
-- name: libcups
-  version: 2.3.3
+- platform: linux-64
+  name: libcrc32c
+  version: 1.1.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    krb5: '>=1.21.1,<1.22.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  hash:
+    md5: c965a5aa0d5c1c37ffc62dff36e28400
+    sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  build: h9c3ff4c_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- platform: osx-64
+  name: libcrc32c
+  version: 1.1.2
+  category: main
+  manager: conda
+  dependencies:
+  - libcxx >=11.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  hash:
+    md5: 23d6d5a69918a438355d7cbc4c3d54c9
+    sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  build: he49afe7_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- platform: osx-arm64
+  name: libcrc32c
+  version: 1.1.2
+  category: main
+  manager: conda
+  dependencies:
+  - libcxx >=11.1.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  hash:
+    md5: 32bd82a6a625ea6ce090a81c3d34edeb
+    sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  build: hbdafb3b_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- platform: win-64
+  name: libcrc32c
+  version: 1.1.2
+  category: main
+  manager: conda
+  dependencies:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  url: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  hash:
+    md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+    sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  build: h0e60522_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- platform: linux-64
+  name: libcups
+  version: 2.3.3
+  category: main
+  manager: conda
+  dependencies:
+  - krb5 >=1.21.1,<1.22.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
   hash:
     md5: d4529f4dff3057982a7617c7ac58fde3
     sha256: bc67b9b21078c99c6bd8595fe7e1ed6da1f721007726e717f0449de7032798c4
-  optional: false
-  category: main
   build: h4637d8d_4
   arch: x86_64
   subdir: linux-64
@@ -4609,24 +6380,23 @@ package:
   license_family: Apache
   size: 4519402
   timestamp: 1689195353551
-- name: libcurl
+- platform: linux-64
+  name: libcurl
   version: 8.4.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    libnghttp2: '>=1.52.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.4.0-hca28451_0.conda
   hash:
     md5: 1158ac1d2613b28685644931f11ee807
     sha256: 25f4b6a8827d7b17a66e0bd9b5d194bf9a9e4a46fb14e2ef472fdad4b39426a6
-  optional: false
-  category: main
   build: hca28451_0
   arch: x86_64
   subdir: linux-64
@@ -4635,23 +6405,22 @@ package:
   license_family: MIT
   size: 386160
   timestamp: 1697009208544
-- name: libcurl
+- platform: osx-64
+  name: libcurl
   version: 8.4.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libnghttp2: '>=1.52.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.4.0-h726d00d_0.conda
   hash:
     md5: 2c17b4dedf0039736951471f493353bd
     sha256: cd3400ecb42fc420acb18e2d836535c44ebd501ebeb4e0bf3830776e9b4ca650
-  optional: false
-  category: main
   build: h726d00d_0
   arch: x86_64
   subdir: osx-64
@@ -4660,23 +6429,22 @@ package:
   license_family: MIT
   size: 366039
   timestamp: 1697009485409
-- name: libcurl
+- platform: osx-arm64
+  name: libcurl
   version: 8.4.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libnghttp2: '>=1.52.0,<2.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.52.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.4.0-h2d989ff_0.conda
   hash:
     md5: afabb3372209028627ec03e206f4d967
     sha256: 5ca24ab030b1c56ce07921bf901ea99076e8b7e45586b4a04e5187cc67c87273
-  optional: false
-  category: main
   build: h2d989ff_0
   arch: aarch64
   subdir: osx-arm64
@@ -4685,23 +6453,22 @@ package:
   license_family: MIT
   size: 348974
   timestamp: 1697009607821
-- name: libcurl
+- platform: win-64
+  name: libcurl
   version: 8.4.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libssh2: '>=1.11.0,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - krb5 >=1.21.2,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
   hash:
     md5: 13e4e3824a0212103330f57058601c21
     sha256: f1367d8a3f115ee4c16ea4bcc313c21009decb0217f65d3bb94618939c518a71
-  optional: false
-  category: main
   build: hd5e4a3a_0
   arch: x86_64
   subdir: win-64
@@ -4710,17 +6477,16 @@ package:
   license_family: MIT
   size: 321118
   timestamp: 1697009866852
-- name: libcxx
+- platform: osx-64
+  name: libcxx
   version: 16.0.6
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
   hash:
     md5: 7d6972792161077908b62971802f289a
     sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
-  optional: false
-  category: main
   build: hd57cbcb_0
   arch: x86_64
   subdir: osx-64
@@ -4729,17 +6495,16 @@ package:
   license_family: Apache
   size: 1142172
   timestamp: 1686896907750
-- name: libcxx
+- platform: osx-arm64
+  name: libcxx
   version: 16.0.6
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
   hash:
     md5: 9d7d724faf0413bf1dbc5a85935700c8
     sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
-  optional: false
-  category: main
   build: h4653b0c_0
   arch: aarch64
   subdir: osx-arm64
@@ -4748,18 +6513,17 @@ package:
   license_family: Apache
   size: 1160232
   timestamp: 1686896993785
-- name: libdeflate
+- platform: linux-64
+  name: libdeflate
   version: '1.19'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
   hash:
     md5: 1635570038840ee3f9c71d22aa5b8b6d
     sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -4768,17 +6532,16 @@ package:
   license_family: MIT
   size: 67080
   timestamp: 1694922285678
-- name: libdeflate
+- platform: osx-64
+  name: libdeflate
   version: '1.19'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
   hash:
     md5: 6a45f543c2beb40023df5ee7e3cedfbd
     sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
-  optional: false
-  category: main
   build: ha4e1b8e_0
   arch: x86_64
   subdir: osx-64
@@ -4787,17 +6550,16 @@ package:
   license_family: MIT
   size: 68962
   timestamp: 1694922440450
-- name: libdeflate
+- platform: osx-arm64
+  name: libdeflate
   version: '1.19'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
   hash:
     md5: f8c1eb0e99e90b55965c6558578537cc
     sha256: 6a3d188a6ae845a742dc85c5fb3f7eb1e252726cd74f0b8a7fa25ec09db6b87a
-  optional: false
-  category: main
   build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
@@ -4806,20 +6568,19 @@ package:
   license_family: MIT
   size: 52841
   timestamp: 1694924330786
-- name: libdeflate
+- platform: win-64
+  name: libdeflate
   version: '1.19'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
   hash:
     md5: 002b1b723b44dbd286b9e3708762433c
     sha256: e2886a84eaa0fbeca1d1d810270f234431d190402b4a79acf756ca2d16000354
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -4828,19 +6589,18 @@ package:
   license_family: MIT
   size: 153203
   timestamp: 1694922596415
-- name: libdrm
+- platform: linux-64
+  name: libdrm
   version: 2.4.114
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libpciaccess: '>=0.17,<0.18.0a0'
+  - libgcc-ng >=12
+  - libpciaccess >=0.17,<0.18.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.114-h166bdaf_0.tar.bz2
   hash:
     md5: efb58e80f5d0179a783c4e76c3df3b9c
     sha256: 9316075084ad66f9f96d31836e83303a8199eec93c12d68661e41c44eed101e3
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -4849,19 +6609,18 @@ package:
   license_family: MIT
   size: 305197
   timestamp: 1667566354412
-- name: libedit
+- platform: linux-64
+  name: libedit
   version: 3.1.20191231
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
-    ncurses: '>=6.2,<7.0.0a0'
+  - libgcc-ng >=7.5.0
+  - ncurses >=6.2,<7.0.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
   hash:
     md5: 4d331e44109e3f0e19b4cb8f9b82f3e1
     sha256: a57d37c236d8f7c886e01656f4949d9dcca131d2a0728609c6f7fa338b65f1cf
-  optional: false
-  category: main
   build: he28a2e2_2
   arch: x86_64
   subdir: linux-64
@@ -4870,18 +6629,17 @@ package:
   license_family: BSD
   size: 123878
   timestamp: 1597616541093
-- name: libedit
+- platform: osx-64
+  name: libedit
   version: 3.1.20191231
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ncurses: '>=6.2,<7.0.0a0'
+  - ncurses >=6.2,<7.0.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
   hash:
     md5: 6016a8a1d0e63cac3de2c352cd40208b
     sha256: dbd3c3f2eca1d21c52e4c03b21930bbce414c4592f8ce805801575b9e9256095
-  optional: false
-  category: main
   build: h0678c8f_2
   arch: x86_64
   subdir: osx-64
@@ -4890,18 +6648,17 @@ package:
   license_family: BSD
   size: 105382
   timestamp: 1597616576726
-- name: libedit
+- platform: osx-arm64
+  name: libedit
   version: 3.1.20191231
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ncurses: '>=6.2,<7.0.0a0'
+  - ncurses >=6.2,<7.0.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
   hash:
     md5: 30e4362988a2623e9eb34337b83e01f9
     sha256: 3912636197933ecfe4692634119e8644904b41a58f30cad9d1fc02f6ba4d9fca
-  optional: false
-  category: main
   build: hc8eb9b7_2
   arch: aarch64
   subdir: osx-arm64
@@ -4910,18 +6667,17 @@ package:
   license_family: BSD
   size: 96607
   timestamp: 1597616630749
-- name: libev
+- platform: linux-64
+  name: libev
   version: '4.33'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
+  - libgcc-ng >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
   hash:
     md5: 6f8720dff19e17ce5d48cfe7f3d2f0a3
     sha256: 8c9635aa0ea28922877dc96358f9547f6a55fc7e2eb75a556b05f1725496baf9
-  optional: false
-  category: main
   build: h516909a_1
   arch: x86_64
   subdir: linux-64
@@ -4930,17 +6686,16 @@ package:
   license_family: BSD
   size: 106190
   timestamp: 1598867915
-- name: libev
+- platform: osx-64
+  name: libev
   version: '4.33'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
   hash:
     md5: 79dc2be110b2a3d1e97ec21f691c50ad
     sha256: c4154d424431898d84d6afb8b32e3ba749fe5d270d322bb0af74571a3cb09c6b
-  optional: false
-  category: main
   build: haf1e3a3_1
   arch: x86_64
   subdir: osx-64
@@ -4949,17 +6704,16 @@ package:
   license_family: BSD
   size: 101424
   timestamp: 1598868359024
-- name: libev
+- platform: osx-arm64
+  name: libev
   version: '4.33'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
   hash:
     md5: 566dbf70fe79eacdb3c3d3d195a27f55
     sha256: eb7325eb2e6bd4c291cb9682781b35b8c0f68cb72651c35a5b9dd22707ebd25c
-  optional: false
-  category: main
   build: h642e427_1
   arch: aarch64
   subdir: osx-arm64
@@ -4968,19 +6722,18 @@ package:
   license_family: BSD
   size: 100668
   timestamp: 1598868103393
-- name: libevent
+- platform: linux-64
+  name: libevent
   version: 2.1.12
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    openssl: '>=3.1.1,<4.0a0'
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
   hash:
     md5: a1cfcc585f0c42bf8d5546bb1dfb668d
     sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
-  optional: false
-  category: main
   build: hf998b51_1
   arch: x86_64
   subdir: linux-64
@@ -4989,18 +6742,77 @@ package:
   license_family: BSD
   size: 427426
   timestamp: 1685725977222
-- name: libexpat
-  version: 2.5.0
+- platform: osx-64
+  name: libevent
+  version: 2.1.12
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - openssl >=3.1.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  hash:
+    md5: e38e467e577bd193a7d5de7c2c540b04
+    sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  build: ha90c15b_1
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- platform: osx-arm64
+  name: libevent
+  version: 2.1.12
+  category: main
+  manager: conda
+  dependencies:
+  - openssl >=3.1.1,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  hash:
+    md5: 1a109764bff3bdc7bdd84088347d71dc
+    sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  build: h2757513_1
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- platform: win-64
+  name: libevent
+  version: 2.1.12
+  category: main
+  manager: conda
+  dependencies:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  hash:
+    md5: 25efbd786caceef438be46da78a7b5ef
+    sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  build: h3671451_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- platform: linux-64
+  name: libexpat
+  version: 2.5.0
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
   hash:
     md5: 6305a3dd2752c76335295da4e581f2fd
     sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  optional: false
-  category: main
   build: hcb278e6_1
   arch: x86_64
   subdir: linux-64
@@ -5011,17 +6823,16 @@ package:
   license_family: MIT
   size: 77980
   timestamp: 1680190528313
-- name: libexpat
+- platform: osx-64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
   hash:
     md5: 6c81cb022780ee33435cca0127dd43c9
     sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
-  optional: false
-  category: main
   build: hf0c8a7f_1
   arch: x86_64
   subdir: osx-64
@@ -5032,17 +6843,16 @@ package:
   license_family: MIT
   size: 69602
   timestamp: 1680191040160
-- name: libexpat
+- platform: osx-arm64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
   hash:
     md5: 5a097ad3d17e42c148c9566280481317
     sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
-  optional: false
-  category: main
   build: hb7217d7_1
   arch: aarch64
   subdir: osx-arm64
@@ -5053,17 +6863,16 @@ package:
   license_family: MIT
   size: 63442
   timestamp: 1680190916539
-- name: libexpat
+- platform: win-64
+  name: libexpat
   version: 2.5.0
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
   hash:
     md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
     sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
@@ -5074,18 +6883,17 @@ package:
   license_family: MIT
   size: 138689
   timestamp: 1680190844101
-- name: libffi
+- platform: linux-64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.4.0'
+  - libgcc-ng >=9.4.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
   hash:
     md5: d645c6d2ac96843a2bfaccd2d62b3ac3
     sha256: ab6e9856c21709b7b517e940ae7028ae0737546122f83c2aa5d692860c3b149e
-  optional: false
-  category: main
   build: h7f98852_5
   arch: x86_64
   subdir: linux-64
@@ -5094,17 +6902,16 @@ package:
   license_family: MIT
   size: 58292
   timestamp: 1636488182923
-- name: libffi
+- platform: osx-64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
   hash:
     md5: ccb34fb14960ad8b125962d3d79b31a9
     sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
-  optional: false
-  category: main
   build: h0d85af4_5
   arch: x86_64
   subdir: osx-64
@@ -5113,17 +6920,16 @@ package:
   license_family: MIT
   size: 51348
   timestamp: 1636488394370
-- name: libffi
+- platform: osx-arm64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
   hash:
     md5: 086914b672be056eb70fd4285b6783b6
     sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
-  optional: false
-  category: main
   build: h3422bc3_5
   arch: aarch64
   subdir: osx-arm64
@@ -5132,19 +6938,18 @@ package:
   license_family: MIT
   size: 39020
   timestamp: 1636488587153
-- name: libffi
+- platform: win-64
+  name: libffi
   version: 3.4.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
   hash:
     md5: 2c96d1b6915b408893f9472569dee135
     sha256: 1951ab740f80660e9bc07d2ed3aefb874d78c107264fd810f24a1a6211d4b1a5
-  optional: false
-  category: main
   build: h8ffe710_5
   arch: x86_64
   subdir: win-64
@@ -5153,21 +6958,20 @@ package:
   license_family: MIT
   size: 42063
   timestamp: 1636489106777
-- name: libflac
+- platform: linux-64
+  name: libflac
   version: 1.4.3
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libgcc-ng: '>=12'
-    libogg: '>=1.3.4,<1.4.0a0'
-    libstdcxx-ng: '>=12'
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
   hash:
     md5: ee48bf17cc83a00f59ca1494d5646869
     sha256: 65908b75fa7003167b8a8f0001e11e58ed5b1ef5e98b96ab2ba66d7c1b822c7d
-  optional: false
-  category: main
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -5176,17 +6980,16 @@ package:
   license_family: BSD
   size: 394383
   timestamp: 1687765514062
-- name: libgcc-devel_linux-64
+- platform: linux-64
+  name: libgcc-devel_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.3.0-h8bca6fd_2.conda
   hash:
     md5: ed613582de7b8569fdc53ca141be176a
     sha256: 7e12d0496389017ca526254913b24d9024e1728c849a0d6476a4b7fde9d03cba
-  optional: false
-  category: main
   build: h8bca6fd_2
   arch: x86_64
   subdir: linux-64
@@ -5195,19 +6998,18 @@ package:
   license_family: GPL
   size: 2405867
   timestamp: 1695218559716
-- name: libgcc-ng
+- platform: linux-64
+  name: libgcc-ng
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
-    _openmp_mutex: '>=4.5'
+  - _libgcc_mutex ==0.1 conda_forge
+  - _openmp_mutex >=4.5
   url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
   hash:
     md5: c28003b0be0494f9a7664389146716ff
     sha256: d361d3c87c376642b99c1fc25cddec4b9905d3d9b9203c1c545b8c8c1b04539a
-  optional: false
-  category: main
   build: h807b86a_2
   arch: x86_64
   subdir: linux-64
@@ -5218,19 +7020,18 @@ package:
   license_family: GPL
   size: 771133
   timestamp: 1695219384393
-- name: libgcrypt
+- platform: linux-64
+  name: libgcrypt
   version: 1.10.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=10.3.0'
-    libgpg-error: '>=1.44,<2.0a0'
+  - libgcc-ng >=10.3.0
+  - libgpg-error >=1.44,<2.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.1-h166bdaf_0.tar.bz2
   hash:
     md5: f967fc95089cd247ceed56eda31de3a9
     sha256: 8fd7e6db1021cd9298d9896233454de204116840eb66a06fcb712e1015ff132a
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -5239,18 +7040,17 @@ package:
   license_family: GPL
   size: 719561
   timestamp: 1649520091125
-- name: libgfortran
+- platform: osx-64
+  name: libgfortran
   version: 5.0.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libgfortran5: ==13.2.0 h2873a65_1
+  - libgfortran5 ==13.2.0 h2873a65_1
   url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
   hash:
     md5: b55fd11ab6318a6e67ac191309701d5a
     sha256: 5be1a59316e5063f4e6492ea86d692600a7b8e32caa25269f8a3b386a028e5f3
-  optional: false
-  category: main
   build: 13_2_0_h97931a8_1
   arch: x86_64
   subdir: osx-64
@@ -5259,18 +7059,17 @@ package:
   license_family: GPL
   size: 109855
   timestamp: 1694165674845
-- name: libgfortran
+- platform: osx-arm64
+  name: libgfortran
   version: 5.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libgfortran5: ==13.2.0 hf226fd6_1
+  - libgfortran5 ==13.2.0 hf226fd6_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
   hash:
     md5: 1ad37a5c60c250bb2b4a9f75563e181c
     sha256: bc8750e7893e693fa380bf2f342d4a5ce44995467cbdf72e56a00e5106b4892d
-  optional: false
-  category: main
   build: 13_2_0_hd922786_1
   arch: aarch64
   subdir: osx-arm64
@@ -5279,18 +7078,17 @@ package:
   license_family: GPL
   size: 110095
   timestamp: 1694172198016
-- name: libgfortran-ng
+- platform: linux-64
+  name: libgfortran-ng
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgfortran5: ==13.2.0 ha4646dd_2
+  - libgfortran5 ==13.2.0 ha4646dd_2
   url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
   hash:
     md5: e75a75a6eaf6f318dae2631158c46575
     sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
-  optional: false
-  category: main
   build: h69a702a_2
   arch: x86_64
   subdir: linux-64
@@ -5299,18 +7097,17 @@ package:
   license_family: GPL
   size: 23722
   timestamp: 1695219642066
-- name: libgfortran5
+- platform: linux-64
+  name: libgfortran5
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=13.2.0'
+  - libgcc-ng >=13.2.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
   hash:
     md5: 78fdab09d9138851dde2b5fe2a11019e
     sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
-  optional: false
-  category: main
   build: ha4646dd_2
   arch: x86_64
   subdir: linux-64
@@ -5321,18 +7118,17 @@ package:
   license_family: GPL
   size: 1441830
   timestamp: 1695219403435
-- name: libgfortran5
+- platform: osx-64
+  name: libgfortran5
   version: 13.2.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    llvm-openmp: '>=8.0.0'
+  - llvm-openmp >=8.0.0
   url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
   hash:
     md5: 3af564516b5163cd8cc08820413854bc
     sha256: 44de8930eef3b14d4d9fdfe419e6c909c13b7c859617d3616d5a5e964f3fcf63
-  optional: false
-  category: main
   build: h2873a65_1
   arch: x86_64
   subdir: osx-64
@@ -5343,18 +7139,17 @@ package:
   license_family: GPL
   size: 1571764
   timestamp: 1694165583047
-- name: libgfortran5
+- platform: osx-arm64
+  name: libgfortran5
   version: 13.2.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    llvm-openmp: '>=8.0.0'
+  - llvm-openmp >=8.0.0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
   hash:
     md5: 4480d71b98c87faafab132d33e23135e
     sha256: cb9cb11e49a6a8466ea7556a723080d3aeefd556df9b444b941afc5b54368b22
-  optional: false
-  category: main
   build: hf226fd6_1
   arch: aarch64
   subdir: osx-arm64
@@ -5365,24 +7160,23 @@ package:
   license_family: GPL
   size: 995733
   timestamp: 1694172076009
-- name: libglib
+- platform: linux-64
+  name: libglib
   version: 2.78.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
-    libiconv: '>=1.17,<2.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pcre2: '>=10.40,<10.41.0a0'
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.40,<10.41.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.0-hebfc3b9_0.conda
   hash:
     md5: e618003da3547216310088478e475945
     sha256: 96ec4dc5e38f434aa5862cb46d74923cce1445de3cd0b9d61e3e63102b163af6
-  optional: false
-  category: main
   build: hebfc3b9_0
   arch: x86_64
   subdir: linux-64
@@ -5392,23 +7186,22 @@ package:
   license: LGPL-2.1-or-later
   size: 2701539
   timestamp: 1694381226310
-- name: libglib
+- platform: osx-64
+  name: libglib
   version: 2.78.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libcxx: '>=15.0.7'
-    libffi: '>=3.4,<4.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pcre2: '>=10.40,<10.41.0a0'
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=15.0.7
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.40,<10.41.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.0-hc62aa5d_0.conda
   hash:
     md5: 2c70095fa74bf95a5fd5c830a1529a8b
     sha256: 06baed236c43bc225b76145da50caa61d9a36f919525d3e3ed4e59b0d9b7c78a
-  optional: false
-  category: main
   build: hc62aa5d_0
   arch: x86_64
   subdir: osx-64
@@ -5418,23 +7211,22 @@ package:
   license: LGPL-2.1-or-later
   size: 2482876
   timestamp: 1694381399072
-- name: libglib
+- platform: osx-arm64
+  name: libglib
   version: 2.78.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libcxx: '>=15.0.7'
-    libffi: '>=3.4,<4.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pcre2: '>=10.40,<10.41.0a0'
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=15.0.7
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.40,<10.41.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.0-h24e9cb9_0.conda
   hash:
     md5: 01c86aa032cbce6aff557de3b9948aa1
     sha256: bc2fb2e307889294c15fe4f1f61c2c92832c371781654c17c5483c9e8de14d2e
-  optional: false
-  category: main
   build: h24e9cb9_0
   arch: aarch64
   subdir: osx-arm64
@@ -5444,25 +7236,24 @@ package:
   license: LGPL-2.1-or-later
   size: 2550196
   timestamp: 1694381376914
-- name: libglib
+- platform: win-64
+  name: libglib
   version: 2.78.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    pcre2: '>=10.40,<10.41.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - gettext >=0.21.1,<1.0a0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.40,<10.41.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.0-he8f3873_0.conda
   hash:
     md5: 25f5b3502a82ac425c72c3bc0efbecb5
     sha256: 1417a309e40a2fae41e18170a74bface2ab67fb0d6905caeb34f91c6840edacc
-  optional: false
-  category: main
   build: he8f3873_0
   arch: x86_64
   subdir: win-64
@@ -5472,23 +7263,22 @@ package:
   license: LGPL-2.1-or-later
   size: 2637097
   timestamp: 1694381512139
-- name: libglu
+- platform: linux-64
+  name: libglu
   version: 9.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-xextproto: '>=7.3.0,<8.0a0'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xextproto >=7.3.0,<8.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
   hash:
     md5: 50c389a09b6b7babaef531eb7cb5e0ca
     sha256: 8368435c41105dc3e1c02896a02ecaa21b77d0b0d67fc8b06a16ba885c86f917
-  optional: false
-  category: main
   build: hac7e632_1003
   arch: x86_64
   subdir: linux-64
@@ -5496,18 +7286,17 @@ package:
   license: SGI-2
   size: 331249
   timestamp: 1694431884320
-- name: libgomp
+- platform: linux-64
+  name: libgomp
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    _libgcc_mutex: ==0.1 conda_forge
+  - _libgcc_mutex ==0.1 conda_forge
   url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
   hash:
     md5: e2042154faafe61969556f28bade94b9
     sha256: e1e82348f8296abfe344162b3b5f0ddc2f504759ebeb8b337ba99beaae583b15
-  optional: false
-  category: main
   build: h807b86a_2
   arch: x86_64
   subdir: linux-64
@@ -5516,20 +7305,137 @@ package:
   license_family: GPL
   size: 421133
   timestamp: 1695219303065
-- name: libgpg-error
-  version: '1.47'
+- platform: linux-64
+  name: libgoogle-cloud
+  version: 2.12.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libgcc-ng >=12
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libstdcxx-ng >=12
+  - openssl >=3.1.3,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h19a6dae_3.conda
+  hash:
+    md5: cb26f6b7184480053106ea4713a52daf
+    sha256: 8d03bf42a533783c692e2e4cd99be300e3f4b62508d7af44d58df19b12d1c37f
+  build: h19a6dae_3
+  arch: x86_64
+  subdir: linux-64
+  build_number: 3
+  constrains:
+  - google-cloud-cpp 2.12.0 *_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 43510735
+  timestamp: 1696837322140
+- platform: osx-64
+  name: libgoogle-cloud
+  version: 2.12.0
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.13
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=16.0.6
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - openssl >=3.1.3,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-h407922f_3.conda
+  hash:
+    md5: 9d9423eb233bbd6f82184eb9e2a95f2d
+    sha256: ad0dbbd851ec86974b239de1c800c8ef52d665ea90c4fdc2ea855c3dcbb34983
+  build: h407922f_3
+  arch: x86_64
+  subdir: osx-64
+  build_number: 3
+  constrains:
+  - google-cloud-cpp 2.12.0 *_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 30907199
+  timestamp: 1696838955088
+- platform: osx-arm64
+  name: libgoogle-cloud
+  version: 2.12.0
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=16.0.6
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - openssl >=3.1.3,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-h5a37b55_3.conda
+  hash:
+    md5: be90da76f8805ce8a138ac47b49fa4ce
+    sha256: 27e08d97642e5127eb774ff9d67efa995791d09674d5c6cdde158dfa321a0dc8
+  build: h5a37b55_3
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 3
+  constrains:
+  - google-cloud-cpp 2.12.0 *_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 31408040
+  timestamp: 1696838972502
+- platform: win-64
+  name: libgoogle-cloud
+  version: 2.12.0
+  category: main
+  manager: conda
+  dependencies:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libgrpc >=1.58.1,<1.59.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - openssl >=3.1.3,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-ha74b051_3.conda
+  hash:
+    md5: 5ed09a5cc8ac4f0b2f5a1aa17baaa79a
+    sha256: 1aa3c5471e21713cfd955d8643f47200eb4a2d5d60dc60c9f40f04fd1f91a3a1
+  build: ha74b051_3
+  arch: x86_64
+  subdir: win-64
+  build_number: 3
+  constrains:
+  - google-cloud-cpp 2.12.0 *_3
+  license: Apache-2.0
+  license_family: Apache
+  size: 13288
+  timestamp: 1696833991690
+- platform: linux-64
+  name: libgpg-error
+  version: '1.47'
+  category: main
+  manager: conda
+  dependencies:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.47-h71f35ed_0.conda
   hash:
     md5: c2097d0b46367996f09b4e8e4920384a
     sha256: 0306b3c2d65863048983a50bd8b86f6f26e457ef55d1da745a5796af25093f5a
-  optional: false
-  category: main
   build: h71f35ed_0
   arch: x86_64
   subdir: linux-64
@@ -5538,20 +7444,141 @@ package:
   license_family: GPL
   size: 260794
   timestamp: 1686979818648
-- name: libhwloc
-  version: 2.9.3
+- platform: linux-64
+  name: libgrpc
+  version: 1.58.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.11.5,<2.12.0a0'
+  - c-ares >=1.20.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libgcc-ng >=12
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - re2
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.58.1-he06187c_2.conda
+  hash:
+    md5: 42f5e2ba0d41ba270afd3eb5c725ccf5
+    sha256: c1b1324525df5376a5af8816a8174d9fcf0f748dd91fee89ecff8013fee5ec1c
+  build: he06187c_2
+  arch: x86_64
+  subdir: linux-64
+  build_number: 2
+  constrains:
+  - grpc-cpp =1.58.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 6573784
+  timestamp: 1697173649452
+- platform: osx-64
+  name: libgrpc
+  version: 1.58.1
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.13
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - re2
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.58.1-hecc90c7_2.conda
+  hash:
+    md5: 7df5b6ae27a2840ad847083aa74b2973
+    sha256: 3fcbe08bf42e972f39a435b291b4d6690040e2cea03714fd30f620ccdf7955a8
+  build: hecc90c7_2
+  arch: x86_64
+  subdir: osx-64
+  build_number: 2
+  constrains:
+  - grpc-cpp =1.58.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3979655
+  timestamp: 1697174609305
+- platform: osx-arm64
+  name: libgrpc
+  version: 1.58.1
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - re2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.58.1-h19be7b0_2.conda
+  hash:
+    md5: e95ae7accb4809d41906365fe97d8aa8
+    sha256: 3ee03d7a6725e043c904d6e8a94eef5bb9e28b685c3f37d13f00a7ca51273d15
+  build: h19be7b0_2
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 2
+  constrains:
+  - grpc-cpp =1.58.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4729822
+  timestamp: 1697174687252
+- platform: win-64
+  name: libgrpc
+  version: 1.58.1
+  category: main
+  manager: conda
+  dependencies:
+  - c-ares >=1.20.1,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libre2-11 >=2023.6.2,<2024.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - re2
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.58.1-h2a9c87f_2.conda
+  hash:
+    md5: 33c73f8c56247c07b1659a1358d94f9a
+    sha256: dcc1e3a5ccbf593c7217a39728f8f9bb495f807045f2cba22492bc3472cb6951
+  build: h2a9c87f_2
+  arch: x86_64
+  subdir: win-64
+  build_number: 2
+  constrains:
+  - grpc-cpp =1.58.1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 13141488
+  timestamp: 1697175379974
+- platform: linux-64
+  name: libhwloc
+  version: 2.9.3
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.5,<2.12.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
   hash:
     md5: f36ddc11ca46958197a45effdd286e45
     sha256: 6950fee24766d03406e0f6f965262a5d98829c71eed8d1004f313892423b559b
-  optional: false
-  category: main
   build: default_h554bfaf_1009
   arch: x86_64
   subdir: linux-64
@@ -5560,22 +7587,21 @@ package:
   license_family: BSD
   size: 2615665
   timestamp: 1694532603730
-- name: libhwloc
+- platform: win-64
+  name: libhwloc
   version: 2.9.3
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libxml2: '>=2.11.5,<2.12.0a0'
-    pthreads-win32: '*'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libxml2 >=2.11.5,<2.12.0a0
+  - pthreads-win32 *
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
   hash:
     md5: 87da045f6d26ce9fe20ad76a18f6a18a
     sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
-  optional: false
-  category: main
   build: default_haede6df_1009
   arch: x86_64
   subdir: win-64
@@ -5584,18 +7610,17 @@ package:
   license_family: BSD
   size: 2578462
   timestamp: 1694533393675
-- name: libiconv
+- platform: linux-64
+  name: libiconv
   version: '1.17'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=10.3.0'
+  - libgcc-ng >=10.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
   hash:
     md5: b62b52da46c39ee2bc3c162ac7f1804d
     sha256: 6a81ebac9f1aacdf2b4f945c87ad62b972f0f69c8e0981d68e111739e6720fd7
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -5603,17 +7628,16 @@ package:
   license: GPL and LGPL
   size: 1450368
   timestamp: 1652700749886
-- name: libiconv
+- platform: osx-64
+  name: libiconv
   version: '1.17'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
   hash:
     md5: 691d103d11180486154af49c037b7ed9
     sha256: 4a3294037d595754f7da7c11a41f3922f995aaa333f3cb66f02d8afa032a7bc2
-  optional: false
-  category: main
   build: hac89ed1_0
   arch: x86_64
   subdir: osx-64
@@ -5621,17 +7645,16 @@ package:
   license: GPL and LGPL
   size: 1378276
   timestamp: 1652702364402
-- name: libiconv
+- platform: osx-arm64
+  name: libiconv
   version: '1.17'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
   hash:
     md5: 686f9c755574aa221f29fbcf36a67265
     sha256: 2eb33065783b802f71d52bef6f15ce0fafea0adc8506f10ebd0d490244087bec
-  optional: false
-  category: main
   build: he4db4b2_0
   arch: aarch64
   subdir: osx-arm64
@@ -5639,19 +7662,18 @@ package:
   license: GPL and LGPL
   size: 1407036
   timestamp: 1652700956112
-- name: libiconv
+- platform: win-64
+  name: libiconv
   version: '1.17'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
   url: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
   hash:
     md5: 050119977a86e4856f0416e2edcf81bb
     sha256: 657c2a992c896475021a25faebd9ccfaa149c5d70c7dc824d4069784b686cea1
-  optional: false
-  category: main
   build: h8ffe710_0
   arch: x86_64
   subdir: win-64
@@ -5659,20 +7681,19 @@ package:
   license: GPL and LGPL
   size: 714518
   timestamp: 1652702326553
-- name: libidn2
+- platform: linux-64
+  name: libidn2
   version: 2.3.4
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libgcc-ng: '>=12'
-    libunistring: '>=0,<1.0a0'
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libunistring >=0,<1.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.4-h166bdaf_0.tar.bz2
   hash:
     md5: 7440fbafd870b8bab68f83a064875d34
     sha256: 888848ae85be9df86f56407639c63bdce8e7651f0b2517be9bc0ac6e38b2d21d
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -5680,19 +7701,18 @@ package:
   license: LGPLv2
   size: 160409
   timestamp: 1666574022481
-- name: libidn2
+- platform: osx-64
+  name: libidn2
   version: 2.3.4
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libunistring: '>=0,<1.0a0'
+  - gettext >=0.21.1,<1.0a0
+  - libunistring >=0,<1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.4-hb7f2c08_0.tar.bz2
   hash:
     md5: bd109fd705b4ce40a62759129bc4ef5a
     sha256: a85127270c37fe2046372d706c44b7c707605dc1f8b97f80e8a1e1978bd3f8f5
-  optional: false
-  category: main
   build: hb7f2c08_0
   arch: x86_64
   subdir: osx-64
@@ -5700,19 +7720,18 @@ package:
   license: LGPLv2
   size: 173894
   timestamp: 1666574251642
-- name: libidn2
+- platform: osx-arm64
+  name: libidn2
   version: 2.3.4
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
-    libunistring: '>=0,<1.0a0'
+  - gettext >=0.21.1,<1.0a0
+  - libunistring >=0,<1.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.4-h1a8c8d9_0.tar.bz2
   hash:
     md5: 7fdc11b6fd3ea4ce92886df855fc7085
     sha256: 3f2990c33c57559fbf03c5e5b3f3c8e95886548ab4c7fc10314e4514d6632703
-  optional: false
-  category: main
   build: h1a8c8d9_0
   arch: aarch64
   subdir: osx-arm64
@@ -5720,18 +7739,17 @@ package:
   license: LGPLv2
   size: 173494
   timestamp: 1666574243937
-- name: libjpeg-turbo
+- platform: linux-64
+  name: libjpeg-turbo
   version: 3.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
   hash:
     md5: ea25936bb4080d843790b586850f82b8
     sha256: b954e09b7e49c2f2433d6f3bb73868eda5e378278b0f8c1dd10a7ef090e14f2f
-  optional: false
-  category: main
   build: hd590300_1
   arch: x86_64
   subdir: linux-64
@@ -5741,17 +7759,16 @@ package:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 618575
   timestamp: 1694474974816
-- name: libjpeg-turbo
+- platform: osx-64
+  name: libjpeg-turbo
   version: 3.0.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
   hash:
     md5: 72507f8e3961bc968af17435060b6dd6
     sha256: d9572fd1024adc374aae7c247d0f29fdf4b122f1e3586fe62acc18067f40d02f
-  optional: false
-  category: main
   build: h0dc2134_1
   arch: x86_64
   subdir: osx-64
@@ -5761,17 +7778,16 @@ package:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 579748
   timestamp: 1694475265912
-- name: libjpeg-turbo
+- platform: osx-arm64
+  name: libjpeg-turbo
   version: 3.0.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
   hash:
     md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
     sha256: a42054eaa38e84fc1e5ab443facac4bbc9d1b6b6f23f54b7bf4f1eb687e1d993
-  optional: false
-  category: main
   build: hb547adb_1
   arch: aarch64
   subdir: osx-arm64
@@ -5781,20 +7797,19 @@ package:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 547541
   timestamp: 1694475104253
-- name: libjpeg-turbo
+- platform: win-64
+  name: libjpeg-turbo
   version: 3.0.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
   hash:
     md5: 3f1b948619c45b1ca714d60c7389092c
     sha256: 4e7808e3098b4b4ed7e287f63bb24f9045cc4d95bfd39f0db870fc2837d74dff
-  optional: false
-  category: main
   build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
@@ -5804,18 +7819,17 @@ package:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 822966
   timestamp: 1694475223854
-- name: liblapack
+- platform: linux-64
+  name: liblapack
   version: 3.9.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libblas: ==3.9.0 19_linux64_openblas
+  - libblas ==3.9.0 19_linux64_openblas
   url: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
   hash:
     md5: 9f100edf65436e3eabc2a51fc00b2c37
     sha256: 58f402aae605ebd0932e1cbbf855cd49dcdfa2fcb6aab790a4f6068ec5937878
-  optional: false
-  category: main
   build: 19_linux64_openblas
   arch: x86_64
   subdir: linux-64
@@ -5828,18 +7842,17 @@ package:
   license_family: BSD
   size: 14487
   timestamp: 1697484241613
-- name: liblapack
+- platform: osx-64
+  name: liblapack
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libblas: ==3.9.0 19_osx64_openblas
+  - libblas ==3.9.0 19_osx64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
   hash:
     md5: 2e714df18db99ee6d7b4ac728f53ca62
     sha256: 6a1704c43a03195fecbbb226be5c257b2e37621e793967c3f31c8521f19e18df
-  optional: false
-  category: main
   build: 19_osx64_openblas
   arch: x86_64
   subdir: osx-64
@@ -5852,18 +7865,17 @@ package:
   license_family: BSD
   size: 14724
   timestamp: 1697484756327
-- name: liblapack
+- platform: osx-arm64
+  name: liblapack
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libblas: ==3.9.0 19_osxarm64_openblas
+  - libblas ==3.9.0 19_osxarm64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
   hash:
     md5: 3638eacb084c374f41f9efa40d20a47b
     sha256: f19cff537403c9feed98c7e18259022102b087f2b72a757e8a417476b9cf30c1
-  optional: false
-  category: main
   build: 19_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
@@ -5876,18 +7888,17 @@ package:
   license_family: BSD
   size: 14721
   timestamp: 1697484603691
-- name: liblapack
+- platform: win-64
+  name: liblapack
   version: 3.9.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libblas: ==3.9.0 19_win64_mkl
+  - libblas ==3.9.0 19_win64_mkl
   url: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
   hash:
     md5: 574e6e8bcc85df2885eb2a87d31ae005
     sha256: e53093eab7674528e9eafbd5efa28f3170ec1388b8df6c9b8343760696f47907
-  optional: false
-  category: main
   build: 19_win64_mkl
   arch: x86_64
   subdir: win-64
@@ -5900,20 +7911,19 @@ package:
   license_family: BSD
   size: 4984073
   timestamp: 1697485397401
-- name: liblapacke
+- platform: linux-64
+  name: liblapacke
   version: 3.9.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libblas: ==3.9.0 19_linux64_openblas
-    libcblas: ==3.9.0 19_linux64_openblas
-    liblapack: ==3.9.0 19_linux64_openblas
+  - libblas ==3.9.0 19_linux64_openblas
+  - libcblas ==3.9.0 19_linux64_openblas
+  - liblapack ==3.9.0 19_linux64_openblas
   url: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-19_linux64_openblas.conda
   hash:
     md5: 685e99d3214f5ac9d1ec6b37983985a6
     sha256: 6008d560811e7b566e7dfddc2c2cfe8734fdf4408d7743ba8e2a4c00fb1d0a35
-  optional: false
-  category: main
   build: 19_linux64_openblas
   arch: x86_64
   subdir: linux-64
@@ -5924,20 +7934,19 @@ package:
   license_family: BSD
   size: 14504
   timestamp: 1697484252520
-- name: liblapacke
+- platform: osx-64
+  name: liblapacke
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libblas: ==3.9.0 19_osx64_openblas
-    libcblas: ==3.9.0 19_osx64_openblas
-    liblapack: ==3.9.0 19_osx64_openblas
+  - libblas ==3.9.0 19_osx64_openblas
+  - libcblas ==3.9.0 19_osx64_openblas
+  - liblapack ==3.9.0 19_osx64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-19_osx64_openblas.conda
   hash:
     md5: 101e3274a7b827d26f32811062d89d22
     sha256: c26dfe4a28c687330e98bffe0f285ba8862e02645703fdfedade5c452515f42e
-  optional: false
-  category: main
   build: 19_osx64_openblas
   arch: x86_64
   subdir: osx-64
@@ -5948,20 +7957,19 @@ package:
   license_family: BSD
   size: 14707
   timestamp: 1697484771705
-- name: liblapacke
+- platform: osx-arm64
+  name: liblapacke
   version: 3.9.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libblas: ==3.9.0 19_osxarm64_openblas
-    libcblas: ==3.9.0 19_osxarm64_openblas
-    liblapack: ==3.9.0 19_osxarm64_openblas
+  - libblas ==3.9.0 19_osxarm64_openblas
+  - libcblas ==3.9.0 19_osxarm64_openblas
+  - liblapack ==3.9.0 19_osxarm64_openblas
   url: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-19_osxarm64_openblas.conda
   hash:
     md5: 44323f13ba339b19ad7130a799c4316c
     sha256: df24e3e241521afea33a65d1c3085df350c4fc5c5ec3096c577da4b70687bb1d
-  optional: false
-  category: main
   build: 19_osxarm64_openblas
   arch: aarch64
   subdir: osx-arm64
@@ -5972,20 +7980,19 @@ package:
   license_family: BSD
   size: 14712
   timestamp: 1697484618051
-- name: liblapacke
+- platform: win-64
+  name: liblapacke
   version: 3.9.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libblas: ==3.9.0 19_win64_mkl
-    libcblas: ==3.9.0 19_win64_mkl
-    liblapack: ==3.9.0 19_win64_mkl
+  - libblas ==3.9.0 19_win64_mkl
+  - libcblas ==3.9.0 19_win64_mkl
+  - liblapack ==3.9.0 19_win64_mkl
   url: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-19_win64_mkl.conda
   hash:
     md5: c77175c01902a5a8eb9e5598bd9e7756
     sha256: 5fe8e60171e94735919cc8661aa20642f4b22e96c0dfb23badf4ce9aae85bcbe
-  optional: false
-  category: main
   build: 19_win64_mkl
   arch: x86_64
   subdir: win-64
@@ -5996,22 +8003,21 @@ package:
   license_family: BSD
   size: 4984065
   timestamp: 1697485443868
-- name: libllvm15
+- platform: linux-64
+  name: libllvm15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_3.conda
   hash:
     md5: 9efe82d44b76a7529a1d702e5a37752e
     sha256: bb94e7535a309c2a8d58585cb82bac954ed59f473eef2cac6ea677d6f576a3b6
-  optional: false
-  category: main
   build: h5cf9203_3
   arch: x86_64
   subdir: linux-64
@@ -6020,21 +8026,20 @@ package:
   license_family: Apache
   size: 33333655
   timestamp: 1690527825436
-- name: libllvm15
+- platform: osx-64
+  name: libllvm15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15'
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
+  - libcxx >=15
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-he4b1e75_3.conda
   hash:
     md5: ecc6df80c4b0445ac0de9cabae189db3
     sha256: 02c7f5fe1ae9cdf4b0152cc76fef0ccb26137075054bdd9336ebf956fd22d8c9
-  optional: false
-  category: main
   build: he4b1e75_3
   arch: x86_64
   subdir: osx-64
@@ -6043,20 +8048,19 @@ package:
   license_family: Apache
   size: 23877550
   timestamp: 1690533932497
-- name: libllvm15
+- platform: osx-arm64
+  name: libllvm15
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15'
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libcxx >=15
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h504e6bf_3.conda
   hash:
     md5: cef4a00532f06f6797fbe2425d4db2a7
     sha256: 8fbe19f2133c501a43a45f4dab701adf5206ed61f4bd6317f287a8d87409fdee
-  optional: false
-  category: main
   build: h504e6bf_3
   arch: aarch64
   subdir: osx-arm64
@@ -6065,23 +8069,22 @@ package:
   license_family: Apache
   size: 21956912
   timestamp: 1690530007064
-- name: libnghttp2
+- platform: linux-64
+  name: libnghttp2
   version: 1.55.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    c-ares: '>=1.20.1,<2.0a0'
-    libev: '>=4.33,<4.34.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.4,<4.0a0'
+  - c-ares >=1.20.1,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.4,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.55.1-h47da74e_0.conda
   hash:
     md5: a802251d1eaeeae041c867faf0f94fa8
     sha256: 5e60b852dbde156ef1fa939af2491fe0e9eb3000de146786dede7cda8991ae4c
-  optional: false
-  category: main
   build: h47da74e_0
   arch: x86_64
   subdir: linux-64
@@ -6090,23 +8093,22 @@ package:
   license_family: MIT
   size: 627864
   timestamp: 1698429073582
-- name: libnghttp2
+- platform: osx-64
+  name: libnghttp2
   version: 1.55.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    c-ares: '>=1.20.1,<2.0a0'
-    libcxx: '>=15.0.7'
-    libev: '>=4.33,<4.34.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.4,<4.0a0'
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libcxx >=15.0.7
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.4,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.55.1-hc0a10c5_0.conda
   hash:
     md5: a9269f10f70851af622c112d2956d544
     sha256: a0352eafcf148aa1dfa25f28cf30c80f70bc78c1e549fdec6b7aad100b865944
-  optional: false
-  category: main
   build: hc0a10c5_0
   arch: x86_64
   subdir: osx-64
@@ -6115,23 +8117,22 @@ package:
   license_family: MIT
   size: 602957
   timestamp: 1698429317306
-- name: libnghttp2
+- platform: osx-arm64
+  name: libnghttp2
   version: 1.55.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    c-ares: '>=1.20.1,<2.0a0'
-    libcxx: '>=15.0.7'
-    libev: '>=4.33,<4.34.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.4,<4.0a0'
+  - __osx >=10.9
+  - c-ares >=1.20.1,<2.0a0
+  - libcxx >=15.0.7
+  - libev >=4.33,<4.34.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.4,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.55.1-h2b02ca0_0.conda
   hash:
     md5: eabfa8f7d2b7751ee28dc6762bbbf168
     sha256: d30f26b57225609e1cd285921113bc634f008e83b1f2296245f468ca682e39a6
-  optional: false
-  category: main
   build: h2b02ca0_0
   arch: aarch64
   subdir: osx-arm64
@@ -6140,18 +8141,17 @@ package:
   license_family: MIT
   size: 590540
   timestamp: 1698429620051
-- name: libnsl
+- platform: linux-64
+  name: libnsl
   version: 2.0.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
   hash:
     md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
     sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -6160,18 +8160,35 @@ package:
   license_family: GPL
   size: 33408
   timestamp: 1697359010159
-- name: libogg
-  version: 1.3.4
+- platform: linux-64
+  name: libnuma
+  version: 2.0.16
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.16-h0b41bf4_1.conda
+  hash:
+    md5: 28bfe2cb11357ccc5be21101a6b7ce86
+    sha256: 814a50cba215548ec3ebfb53033ffb9b3b070b2966570ff44910b8d9ba1c359d
+  build: h0b41bf4_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: LGPL-2.1-only
+  size: 41107
+  timestamp: 1676004391774
+- platform: linux-64
+  name: libogg
+  version: 1.3.4
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
   hash:
     md5: 6e8cc2173440d77708196c5b93771680
     sha256: b88afeb30620b11bed54dac4295aa57252321446ba4e6babd7dce4b9ffde9b25
-  optional: false
-  category: main
   build: h7f98852_1
   arch: x86_64
   subdir: linux-64
@@ -6180,19 +8197,18 @@ package:
   license_family: BSD
   size: 210550
   timestamp: 1610382007814
-- name: libogg
+- platform: win-64
+  name: libogg
   version: 1.3.4
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.4-h8ffe710_1.tar.bz2
   hash:
     md5: 04286d905a0dcb7f7d4a12bdfe02516d
     sha256: ef20f04ad2121a07e074b34bfc211587df18180e680963f5c02c54d1951b9ee6
-  optional: false
-  category: main
   build: h8ffe710_1
   arch: x86_64
   subdir: win-64
@@ -6201,20 +8217,19 @@ package:
   license_family: BSD
   size: 35187
   timestamp: 1610382533961
-- name: libopenblas
+- platform: linux-64
+  name: libopenblas
   version: 0.3.24
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libgfortran-ng: '*'
-    libgfortran5: '>=12.3.0'
+  - libgcc-ng >=12
+  - libgfortran-ng *
+  - libgfortran5 >=12.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
   hash:
     md5: 6e4ef6ca28655124dcde9bd500e44c32
     sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
-  optional: false
-  category: main
   build: pthreads_h413a1c8_0
   arch: x86_64
   subdir: linux-64
@@ -6225,20 +8240,19 @@ package:
   license_family: BSD
   size: 5492091
   timestamp: 1693785223074
-- name: libopenblas
+- platform: osx-64
+  name: libopenblas
   version: 0.3.24
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libgfortran: 5.*
-    libgfortran5: '>=12.3.0'
-    llvm-openmp: '>=15.0.7'
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
   hash:
     md5: 077718837dd06cf0c3089070108869f6
     sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
-  optional: false
-  category: main
   build: openmp_h48a4ad5_0
   arch: x86_64
   subdir: osx-64
@@ -6249,20 +8263,19 @@ package:
   license_family: BSD
   size: 6157393
   timestamp: 1693785988209
-- name: libopenblas
+- platform: osx-arm64
+  name: libopenblas
   version: 0.3.24
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libgfortran: 5.*
-    libgfortran5: '>=12.3.0'
-    llvm-openmp: '>=15.0.7'
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
   hash:
     md5: aacb05989f358affe1bafd4ea7294db4
     sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
-  optional: false
-  category: main
   build: openmp_hd76b1f2_0
   arch: aarch64
   subdir: osx-arm64
@@ -6273,1183 +8286,1133 @@ package:
   license_family: BSD
   size: 2849225
   timestamp: 1693784744674
-- name: libopencv
+- platform: linux-64
+  name: libopencv
   version: 4.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-    ffmpeg: '>=6.0.0,<7.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    harfbuzz: '>=8.2.1,<9.0a0'
-    hdf5: '>=1.14.2,<1.14.3.0a0'
-    jasper: '>=4.0.0,<5.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.0,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    liblapacke: '>=3.9.0,<4.0a0'
-    libopenvino-auto-batch-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-auto-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-hetero-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-intel-cpu-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-intel-gpu-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-ir-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-onnx-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-paddle-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-pytorch-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-tensorflow-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-tensorflow-lite-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libprotobuf: '>=4.24.3,<4.24.4.0a0'
-    libstdcxx-ng: '>=12'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    numpy: '>=1.26.0,<2.0a0'
-    qt-main: '>=5.15.8,<5.16.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.8.1-py312hd874328_3.conda
-  hash:
-    md5: cd1cb5f2087b5a9fb8f65e7a0cfa06ee
-    sha256: 0864dc5feb70d4a83bf42e0d2d572f8b3006c8b1e097ecdc234d15d674708dc9
-  optional: false
   category: main
-  build: py312hd874328_3
+  manager: conda
+  dependencies:
+  - __glibc >=2.17,<3.0.a0
+  - _openmp_mutex >=4.5
+  - ffmpeg >=6.0.0,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.2.1,<9.0a0
+  - hdf5 >=1.14.2,<1.14.3.0a0
+  - jasper >=4.0.0,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino-auto-batch-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-auto-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-hetero-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-intel-cpu-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-intel-gpu-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-ir-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-onnx-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-paddle-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-pytorch-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.1.0,<2023.1.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.8.1-py311h60c0964_3.conda
+  hash:
+    md5: 15b934a291c1801d4b9040a14b39ff35
+    sha256: ae76ad7c324aae296acec398948cbe9dc8fafc564221252f906f30e817f561f3
+  build: py311h60c0964_3
   arch: x86_64
   subdir: linux-64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 30312374
-  timestamp: 1698365904746
-- name: libopencv
+  size: 30294048
+  timestamp: 1698365980754
+- platform: osx-64
+  name: libopencv
   version: 4.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.9'
-    ffmpeg: '>=6.0.0,<7.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    harfbuzz: '>=8.2.1,<9.0a0'
-    hdf5: '>=1.14.2,<1.14.3.0a0'
-    jasper: '>=4.0.0,<5.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=16.0.6'
-    libglib: '>=2.78.0,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    liblapacke: '>=3.9.0,<4.0a0'
-    libopenvino-auto-batch-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-auto-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-hetero-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-intel-cpu-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-ir-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-onnx-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-paddle-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-pytorch-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-tensorflow-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-tensorflow-lite-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libprotobuf: '>=4.24.3,<4.24.4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    numpy: '>=1.26.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.8.1-py312h086e99c_3.conda
-  hash:
-    md5: 23f1562bf51323ee2f5d14d15af49c4a
-    sha256: c434ea26db238fb2d250d8285c59472d244dd268b0d98f531ac30656769a0569
-  optional: false
   category: main
-  build: py312h086e99c_3
+  manager: conda
+  dependencies:
+  - __osx >=10.13
+  - __osx >=10.9
+  - ffmpeg >=6.0.0,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.2.1,<9.0a0
+  - hdf5 >=1.14.2,<1.14.3.0a0
+  - jasper >=4.0.0,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino-auto-batch-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-auto-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-hetero-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-intel-cpu-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-ir-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-onnx-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-paddle-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-pytorch-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.1.0,<2023.1.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.8.1-py311h0ef0a85_3.conda
+  hash:
+    md5: 04642a1be869b0777c9262ef5d051af8
+    sha256: 46566c466e1a488de5335ed8e6f87750562bb8de11e9aebdf02c546086528286
+  build: py311h0ef0a85_3
   arch: x86_64
   subdir: osx-64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 27041470
-  timestamp: 1698366544893
-- name: libopencv
+  size: 27110496
+  timestamp: 1698366453982
+- platform: osx-arm64
+  name: libopencv
   version: 4.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=10.9'
-    ffmpeg: '>=6.0.0,<7.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    harfbuzz: '>=8.2.1,<9.0a0'
-    hdf5: '>=1.14.2,<1.14.3.0a0'
-    jasper: '>=4.0.0,<5.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=16.0.6'
-    libglib: '>=2.78.0,<3.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    liblapacke: '>=3.9.0,<4.0a0'
-    libopenvino-arm-cpu-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-auto-batch-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-auto-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-hetero-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-ir-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-onnx-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-paddle-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-pytorch-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-tensorflow-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-tensorflow-lite-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libprotobuf: '>=4.24.3,<4.24.4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    numpy: '>=1.26.0,<2.0a0'
-    python: '>=3.12,<3.13.0a0 *_cpython'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.8.1-py312h494ba3b_3.conda
-  hash:
-    md5: dff2faeae5d89770f5fa7135cecc3983
-    sha256: 31b2f227c4123f5fcd4963275647de2e3c59a8b637fb2e5798ec60e940a3a5be
-  optional: false
   category: main
-  build: py312h494ba3b_3
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - ffmpeg >=6.0.0,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.2.1,<9.0a0
+  - hdf5 >=1.14.2,<1.14.3.0a0
+  - jasper >=4.0.0,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16.0.6
+  - libglib >=2.78.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino-arm-cpu-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-auto-batch-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-auto-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-hetero-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-ir-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-onnx-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-paddle-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-pytorch-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.1.0,<2023.1.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.8.1-py311h927bda1_3.conda
+  hash:
+    md5: b4868a015ed11ba9c7bf3c30213d5925
+    sha256: aa3707fd31e642092ae48362100819329f6778ea893214aad230c4f4138f60e2
+  build: py311h927bda1_3
   arch: aarch64
   subdir: osx-arm64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 16929602
-  timestamp: 1698366629356
-- name: libopencv
+  size: 16847986
+  timestamp: 1698366840836
+- platform: win-64
+  name: libopencv
   version: 4.8.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    ffmpeg: '>=6.0.0,<7.0a0'
-    freetype: '>=2.12.1,<3.0a0'
-    harfbuzz: '>=8.2.1,<9.0a0'
-    hdf5: '>=1.14.2,<1.14.3.0a0'
-    jasper: '>=4.0.0,<5.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    liblapacke: '>=3.9.0,<4.0a0'
-    libopenvino-auto-batch-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-auto-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-hetero-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-intel-cpu-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-intel-gpu-plugin: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-ir-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-onnx-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-paddle-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-pytorch-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-tensorflow-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libopenvino-tensorflow-lite-frontend: '>=2023.1.0,<2023.1.1.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libprotobuf: '>=4.24.3,<4.24.4.0a0'
-    libtiff: '>=4.6.0,<4.7.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    numpy: '>=1.26.0,<2.0a0'
-    qt-main: '>=5.15.8,<5.16.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.8.1-py312h55e7661_3.conda
-  hash:
-    md5: 3ac941de61c63e8073a9c02017ff5e5f
-    sha256: 4cd6fd97c581eda274fdf4692c285dc6d083d43993611e9357fa348f82a7d451
-  optional: false
   category: main
-  build: py312h55e7661_3
+  manager: conda
+  dependencies:
+  - ffmpeg >=6.0.0,<7.0a0
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.2.1,<9.0a0
+  - hdf5 >=1.14.2,<1.14.3.0a0
+  - jasper >=4.0.0,<5.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - liblapacke >=3.9.0,<4.0a0
+  - libopenvino-auto-batch-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-auto-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-hetero-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-intel-cpu-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-intel-gpu-plugin >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-ir-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-onnx-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-paddle-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-pytorch-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-tensorflow-frontend >=2023.1.0,<2023.1.1.0a0
+  - libopenvino-tensorflow-lite-frontend >=2023.1.0,<2023.1.1.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - numpy >=1.23.5,<2.0a0
+  - qt-main >=5.15.8,<5.16.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.8.1-py311h6be31c5_3.conda
+  hash:
+    md5: 2db0b9771f5844a9b99aa1d19d59d135
+    sha256: ddf48487d17d9cc059e35bb8ae28655c6bbdc6270311ab565ec5f82caadd33c5
+  build: py311h6be31c5_3
   arch: x86_64
   subdir: win-64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 32775237
-  timestamp: 1698366985659
-- name: libopenvino
+  size: 32744891
+  timestamp: 1698367509791
+- platform: linux-64
+  name: libopenvino
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2023.1.0-h59595ed_1.conda
   hash:
     md5: 1d0f509535585a98f8893acc5dbffad6
     sha256: ce0546d040fb5a90af5c40411f6227565e44f3fbdd4469662a21f0c674b035ed
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 5827640
   timestamp: 1698356485511
-- name: libopenvino
+- platform: osx-64
+  name: libopenvino
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2023.1.0-h93d8f39_1.conda
   hash:
     md5: 138fee4e793597c13e535f6150b99bfe
     sha256: 7f929081c8ffe495bafe01f1acea50382470c959b4010e04f6f1fe5985021cb3
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 4647944
   timestamp: 1698357525180
-- name: libopenvino
+- platform: osx-arm64
+  name: libopenvino
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2023.1.0-h965bd2d_1.conda
   hash:
     md5: 8c3ed0f46b0a2c7939e85cb80d2e6817
     sha256: 6ba2ed5ddb5e2df24d706528181f3ed03cbbf59793585c68d9c3dc59c4835c06
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 4195521
   timestamp: 1698367972660
-- name: libopenvino
+- platform: win-64
+  name: libopenvino
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2023.1.0-h63175ca_1.conda
   hash:
     md5: 5817a0b582382b9883c2924d5bd45f06
     sha256: 1799054270fbd4fe40bac0bb5e98f12495ef58315adf78484ab20407ee616d55
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 4108703
   timestamp: 1698383844182
-- name: libopenvino-arm-cpu-plugin
+- platform: osx-arm64
+  name: libopenvino-arm-cpu-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2023.1.0-h965bd2d_1.conda
   hash:
     md5: 3a2f0314cff88721679c1e8e866c1224
     sha256: 1e09770bb3d1d8b7e52aff2b0041b13706416df8398fda198475891a84bd0062
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 5543680
   timestamp: 1698368021404
-- name: libopenvino-auto-batch-plugin
+- platform: linux-64
+  name: libopenvino-auto-batch-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2023.1.0-h59595ed_1.conda
   hash:
     md5: 3dc8b7b05d7923efd43734341089fa6a
     sha256: 7a772376b6f397eba816c98a45d98ac26dcc9fef53238f48b6be5f59e0ed4d3c
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 111293
   timestamp: 1698356516435
-- name: libopenvino-auto-batch-plugin
+- platform: osx-64
+  name: libopenvino-auto-batch-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2023.1.0-h93d8f39_1.conda
   hash:
     md5: 73837f345efbc4723a54a0fde3ea5afd
     sha256: 126225a674c565586e2c73fbf60b6733beb3237bdd461f8aae07f6ba5262400a
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 107533
   timestamp: 1698357578246
-- name: libopenvino-auto-batch-plugin
+- platform: osx-arm64
+  name: libopenvino-auto-batch-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2023.1.0-h965bd2d_1.conda
   hash:
     md5: 30f846f3a07ca76223293046c9cd4f4e
     sha256: afef61949e1e685226e0d98e0a3efc24753dead2670200e776f508c0dfb3762d
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 105732
   timestamp: 1698368085173
-- name: libopenvino-auto-batch-plugin
+- platform: win-64
+  name: libopenvino-auto-batch-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2023.1.0-h63175ca_1.conda
   hash:
     md5: d9b41002f53d8aa60e55099d3ff2e8d4
     sha256: 74c50a6d433d814cf8efa3c9a6c3ff13747a6a28037e70ba7052c6b0cb97c7d3
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 101105
   timestamp: 1698383910460
-- name: libopenvino-auto-plugin
+- platform: linux-64
+  name: libopenvino-auto-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
-    tbb: '>=2021.5.0'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2023.1.0-h59595ed_1.conda
   hash:
     md5: cbc6b5ba7bf6e9f88db0418c0d7400c2
     sha256: c30c77ced283ac2a000999d4241e411a741f0251869929bc2c24854fb67f48d4
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 237344
   timestamp: 1698356533802
-- name: libopenvino-auto-plugin
+- platform: osx-64
+  name: libopenvino-auto-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
-    tbb: '>=2021.5.0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2023.1.0-h93d8f39_1.conda
   hash:
     md5: 0bf5033d0b1e350d163ce7e9b9138090
     sha256: cf15547e68bc7697838de49696752c796e0ae442d3504ec02f1afc464f6ddff9
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 214410
   timestamp: 1698357616789
-- name: libopenvino-auto-plugin
+- platform: osx-arm64
+  name: libopenvino-auto-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
-    tbb: '>=2021.5.0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2023.1.0-h965bd2d_1.conda
   hash:
     md5: be37231081fbf0c101fe3769ab350598
     sha256: 67a57af9a88b437d39055c2481c504b31be4986b92ac6084789f71a7335665b6
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 205997
   timestamp: 1698368121263
-- name: libopenvino-auto-plugin
+- platform: win-64
+  name: libopenvino-auto-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    tbb: '>=2021.5.0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - tbb >=2021.5.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2023.1.0-h63175ca_1.conda
   hash:
     md5: 2bd840b75d74ed25d5068192155e1375
     sha256: bfd70e6112cc51bb2a256fe7f9ec45167ed3a51c6dbbbe7f197e9c883f7781b9
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 191451
   timestamp: 1698383953671
-- name: libopenvino-hetero-plugin
+- platform: linux-64
+  name: libopenvino-hetero-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
-    pugixml: '>=1.14,<1.15.0a0'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2023.1.0-h59595ed_1.conda
   hash:
     md5: 3bb95d76f5d31b4346272b8cd83322ee
     sha256: 645b6cf56bfdc3bea21e9ed4d74b76398ded2f1a067597eb1ee6d194d6c070cb
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 151388
   timestamp: 1698356551655
-- name: libopenvino-hetero-plugin
+- platform: osx-64
+  name: libopenvino-hetero-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
-    pugixml: '>=1.14,<1.15.0a0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
+  - pugixml >=1.14,<1.15.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2023.1.0-h93d8f39_1.conda
   hash:
     md5: c823a61c48aa57ee81bb6af4559c0ff9
     sha256: 8ab197b78d9071cd281f834d55660bd63c5bbaa893833e85d926bb171b49bb3f
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 140736
   timestamp: 1698357654851
-- name: libopenvino-hetero-plugin
+- platform: osx-arm64
+  name: libopenvino-hetero-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
-    pugixml: '>=1.14,<1.15.0a0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
+  - pugixml >=1.14,<1.15.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2023.1.0-h965bd2d_1.conda
   hash:
     md5: b663c91b604a490c4d5a3ca1c119696f
     sha256: a6c354b12dd60d33aa541c4f5a13e8a64d7debe6644daa045e929f4780738522
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 133309
   timestamp: 1698368158696
-- name: libopenvino-hetero-plugin
+- platform: win-64
+  name: libopenvino-hetero-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    pugixml: '>=1.14,<1.15.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - pugixml >=1.14,<1.15.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2023.1.0-h63175ca_1.conda
   hash:
     md5: dfaf51827a4b1acc6eb0a7944a26cd7f
     sha256: a942e1d2a03604d2cde1a3e30b064e755e7dac44c9d393602e54ddab3d6de508
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 129467
   timestamp: 1698383998927
-- name: libopenvino-intel-cpu-plugin
+- platform: linux-64
+  name: libopenvino-intel-cpu-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2023.1.0-h59595ed_1.conda
   hash:
     md5: e200ba39666fc033bdd79f644f76760c
     sha256: e66b9324456818493fa58e0540f4144ebfb0673e0f2898a7f42c88101c657321
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 9775984
   timestamp: 1698356569602
-- name: libopenvino-intel-cpu-plugin
+- platform: osx-64
+  name: libopenvino-intel-cpu-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2023.1.0-h93d8f39_1.conda
   hash:
     md5: 59e09b9adab839720e304fda7a3cec1d
     sha256: a8bc240764f5cae3074aea21a0b3ce219e2c6df46d7ca87349962a3595e18585
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 9115817
   timestamp: 1698357694206
-- name: libopenvino-intel-cpu-plugin
+- platform: win-64
+  name: libopenvino-intel-cpu-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2023.1.0-h63175ca_1.conda
   hash:
     md5: cd139b8612d1be6dabf9024c90869f66
     sha256: e51d37d307a3afb79aa8647698841c4802315bfe284f9dfcfdd63e789c8bf132
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 6735827
   timestamp: 1698384050445
-- name: libopenvino-intel-gpu-plugin
+- platform: linux-64
+  name: libopenvino-intel-gpu-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
-    ocl-icd: '>=2.3.1,<3.0a0'
-    ocl-icd-system: '*'
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
+  - ocl-icd >=2.3.1,<3.0a0
+  - ocl-icd-system *
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2023.1.0-h59595ed_1.conda
   hash:
     md5: 2ef52575b2d22a98472dc7cb8fe9bfa1
     sha256: 3dcf8be7f45acb03318fe5ff3d41ac02c75916e57a6044f555ba49df83284e65
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 6513077
   timestamp: 1698356611916
-- name: libopenvino-intel-gpu-plugin
+- platform: win-64
+  name: libopenvino-intel-gpu-plugin
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    khronos-opencl-icd-loader: '>=2023.4.17'
-    libopenvino: ==2023.1.0 h63175ca_1
-    pugixml: '>=1.14,<1.15.0a0'
-    tbb: '>=2021.5.0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - khronos-opencl-icd-loader >=2023.4.17
+  - libopenvino ==2023.1.0 h63175ca_1
+  - pugixml >=1.14,<1.15.0a0
+  - tbb >=2021.5.0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2023.1.0-h63175ca_1.conda
   hash:
     md5: e7ffd9a6a29af89c7fe9ff4d465521cd
     sha256: 531b1d1ee3ca88ed8cd7bafb1667911c113cabb499f7b98a35c49549d24f73b6
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 5068572
   timestamp: 1698384117118
-- name: libopenvino-ir-frontend
+- platform: linux-64
+  name: libopenvino-ir-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
-    pugixml: '>=1.14,<1.15.0a0'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
+  - pugixml >=1.14,<1.15.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2023.1.0-h59595ed_1.conda
   hash:
     md5: d84b548bd1caed2f0ca2b61a8f08efd9
     sha256: d584797c88bdb3d4c1182ac048e9fc43b52cad7f6d4b9ccea906cb6ec85c9789
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 195443
   timestamp: 1698356646629
-- name: libopenvino-ir-frontend
+- platform: osx-64
+  name: libopenvino-ir-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
-    pugixml: '>=1.14,<1.15.0a0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
+  - pugixml >=1.14,<1.15.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2023.1.0-h93d8f39_1.conda
   hash:
     md5: 2d69207b546af34f02f065aeede08ff7
     sha256: 925a6c37a3acd33fff8e0e77ef95656b151ddcf232116f4ea10b52bddd316ebc
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 171367
   timestamp: 1698357777561
-- name: libopenvino-ir-frontend
+- platform: osx-arm64
+  name: libopenvino-ir-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
-    pugixml: '>=1.14,<1.15.0a0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
+  - pugixml >=1.14,<1.15.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2023.1.0-h965bd2d_1.conda
   hash:
     md5: 13dfdc6ee19e2477c260af4385899c0f
     sha256: 17cb3a7a4feb58f522452375c0ad0c254ff63a073e7ea8c26dd107efce6556fa
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 163361
   timestamp: 1698368194297
-- name: libopenvino-ir-frontend
+- platform: win-64
+  name: libopenvino-ir-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    pugixml: '>=1.14,<1.15.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - pugixml >=1.14,<1.15.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2023.1.0-h63175ca_1.conda
   hash:
     md5: 6cee85ca5565c0fb72e07aa27cc44663
     sha256: 401cf4786064867044521d32d2284c35c33883c457bb54a7a4fba3a06bd8c953
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 155324
   timestamp: 1698384186515
-- name: libopenvino-onnx-frontend
+- platform: linux-64
+  name: libopenvino-onnx-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2023.1.0-h59595ed_1.conda
   hash:
     md5: 1ad39e89e571be3958d150c576c21fd0
     sha256: 02f3c66c63943297a126037904b6b27e05a39586b77fe9e643bfc6b65f5057ba
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 1494753
   timestamp: 1698356664610
-- name: libopenvino-onnx-frontend
+- platform: osx-64
+  name: libopenvino-onnx-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2023.1.0-h93d8f39_1.conda
   hash:
     md5: 75a73d395e6f026669393392a8dbfd1b
     sha256: 14fe4e990da252915a4d2d7b07ce45f1d8f4bce31015e61fcbd7a81eb570bffc
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 1364239
   timestamp: 1698357817714
-- name: libopenvino-onnx-frontend
+- platform: osx-arm64
+  name: libopenvino-onnx-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2023.1.0-h965bd2d_1.conda
   hash:
     md5: f04ee2878dd0a3cf2ca481789f2d044a
     sha256: 074304c384cdd91fb68fc565799d2eccce1ca8d7bad4bca951984b39dc08a555
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 1282428
   timestamp: 1698368230829
-- name: libopenvino-onnx-frontend
+- platform: win-64
+  name: libopenvino-onnx-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2023.1.0-h63175ca_1.conda
   hash:
     md5: c49cbe60376d179110822e5ded0669a7
     sha256: cf7c9d24c36a0610b02426a61a94cdddb386cfc65eeafb17630eda002c725d83
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 975868
   timestamp: 1698384232522
-- name: libopenvino-paddle-frontend
+- platform: linux-64
+  name: libopenvino-paddle-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2023.1.0-h59595ed_1.conda
   hash:
     md5: 744b5f93c030dc69ca604b442876c48d
     sha256: 12554a1c9f9e83334681f6442c6279053e302dccb71634e43abafdeaa210888f
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 674872
   timestamp: 1698356685587
-- name: libopenvino-paddle-frontend
+- platform: osx-64
+  name: libopenvino-paddle-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2023.1.0-h93d8f39_1.conda
   hash:
     md5: aecf8903e96c8f9fcd9470765ab235cc
     sha256: 762b7b7b38117f16b535eb3c79e6d811e0d0ea35a0c0919cecd8322fee1ee104
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 564703
   timestamp: 1698357864032
-- name: libopenvino-paddle-frontend
+- platform: osx-arm64
+  name: libopenvino-paddle-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2023.1.0-h965bd2d_1.conda
   hash:
     md5: c0f65f867debc292c1003437742e74b5
     sha256: 1ece1932e4061c55fb66eab9cd341e7b8ab04940969240b68c63a227ef5793e0
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 538802
   timestamp: 1698368271058
-- name: libopenvino-paddle-frontend
+- platform: win-64
+  name: libopenvino-paddle-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2023.1.0-h63175ca_1.conda
   hash:
     md5: 64805d0de99aba6baceecba8728dbcfd
     sha256: 58a0d528f6cbdb5c000d5cb23f6c404cb6b3900aaf7f92690a6f16454a1021d5
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 427003
   timestamp: 1698384279518
-- name: libopenvino-pytorch-frontend
+- platform: linux-64
+  name: libopenvino-pytorch-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2023.1.0-h59595ed_1.conda
   hash:
     md5: bd2eefe106d5b74d4f70c57644cd1d24
     sha256: 55744a4c37313c194763337f5cf93276389f1fb239618f4b253fe702ab1bf25d
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 848343
   timestamp: 1698356704234
-- name: libopenvino-pytorch-frontend
+- platform: osx-64
+  name: libopenvino-pytorch-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2023.1.0-h93d8f39_1.conda
   hash:
     md5: 127e295cd28e8cc9970ca7e850e579db
     sha256: 6302b8b4c96ffab347a0c0f6c61d7451b0f6a765b057346cc1fd0f00cf18f5c8
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 616811
   timestamp: 1698357908733
-- name: libopenvino-pytorch-frontend
+- platform: osx-arm64
+  name: libopenvino-pytorch-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2023.1.0-h965bd2d_1.conda
   hash:
     md5: 1478a255b75d54b0a0fcbea40cf35cc0
     sha256: e3d6afd1e05e59ff96fe6844cd183c1c06eebf68c69da905997209cdc0c14c49
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 594052
   timestamp: 1698368308459
-- name: libopenvino-pytorch-frontend
+- platform: win-64
+  name: libopenvino-pytorch-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2023.1.0-h63175ca_1.conda
   hash:
     md5: 78f707c76008f71098341f9acf7ccb52
     sha256: 941c30d2644582df498697a9840d02a28f573e0b1dbcc0369da746635bd88c57
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 535366
   timestamp: 1698384326078
-- name: libopenvino-tensorflow-frontend
+- platform: linux-64
+  name: libopenvino-tensorflow-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
-    snappy: '>=1.1.10,<2.0a0'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
+  - snappy >=1.1.10,<2.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2023.1.0-h59595ed_1.conda
   hash:
     md5: d7db8df283c13eb0e95c6b27c9c0df75
     sha256: dad7783351be4fe0bbb1d8bff4967526f6e574471297477fdbbcf9ec1f89cee3
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 1456195
   timestamp: 1698356723360
-- name: libopenvino-tensorflow-frontend
+- platform: osx-64
+  name: libopenvino-tensorflow-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
-    snappy: '>=1.1.10,<2.0a0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
+  - snappy >=1.1.10,<2.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2023.1.0-h93d8f39_1.conda
   hash:
     md5: dec6b0eebc6b637d74e509b4d088585f
     sha256: 4561152df85a95c0401904744ad10ccbab9dd39f51bf5f8f7b997e5d74320fc3
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 1378277
   timestamp: 1698357945336
-- name: libopenvino-tensorflow-frontend
+- platform: osx-arm64
+  name: libopenvino-tensorflow-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
-    snappy: '>=1.1.10,<2.0a0'
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
+  - snappy >=1.1.10,<2.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2023.1.0-h965bd2d_1.conda
   hash:
     md5: 25dedab4d60764b5cdde0eb86214f747
     sha256: 278e827b29a9a0a998b6211010a651ffff01d9da5893abaa41308e3e6840a3cb
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 1271822
   timestamp: 1698368346095
-- name: libopenvino-tensorflow-frontend
+- platform: win-64
+  name: libopenvino-tensorflow-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    snappy: '>=1.1.10,<2.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - snappy >=1.1.10,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2023.1.0-h63175ca_1.conda
   hash:
     md5: 12821f16849ba42a9dfe889d56453645
     sha256: c38a43f64fda876d3b420078fe6b2e0b13eabc8417d1a8d93e0e5f591d23af26
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 1035526
   timestamp: 1698384373006
-- name: libopenvino-tensorflow-lite-frontend
+- platform: linux-64
+  name: libopenvino-tensorflow-lite-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libopenvino: ==2023.1.0 h59595ed_1
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libopenvino ==2023.1.0 h59595ed_1
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2023.1.0-h59595ed_1.conda
   hash:
     md5: d96ada2e4937b047f221aff61c5c84e5
     sha256: 43f3eca56ed8e0fb62468ee4f34f8dd3bdcc5a8661fb6a60ab11fe4c7fae64d9
-  optional: false
-  category: main
   build: h59595ed_1
   arch: x86_64
   subdir: linux-64
   build_number: 1
   size: 450424
   timestamp: 1698356743132
-- name: libopenvino-tensorflow-lite-frontend
+- platform: osx-64
+  name: libopenvino-tensorflow-lite-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h93d8f39_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h93d8f39_1
   url: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2023.1.0-h93d8f39_1.conda
   hash:
     md5: e6eaead86d6519a9f4df71792604f33b
     sha256: e23b9ed7e4da7eced3b93e2433dac59a3c5fe0e2b7dcd60c58a236c640aef339
-  optional: false
-  category: main
   build: h93d8f39_1
   arch: x86_64
   subdir: osx-64
   build_number: 1
   size: 362502
   timestamp: 1698357987052
-- name: libopenvino-tensorflow-lite-frontend
+- platform: osx-arm64
+  name: libopenvino-tensorflow-lite-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libopenvino: ==2023.1.0 h965bd2d_1
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libopenvino ==2023.1.0 h965bd2d_1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2023.1.0-h965bd2d_1.conda
   hash:
     md5: ac6bed6ebbef44d668693d77960e6440
     sha256: 5c036a40f7393005fbb2e36b596ef5dcebb3571dbbdc1db9d8d317ad30b2006c
-  optional: false
-  category: main
   build: h965bd2d_1
   arch: aarch64
   subdir: osx-arm64
   build_number: 1
   size: 360241
   timestamp: 1698368385379
-- name: libopenvino-tensorflow-lite-frontend
+- platform: win-64
+  name: libopenvino-tensorflow-lite-frontend
   version: 2023.1.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libopenvino: ==2023.1.0 h63175ca_1
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libopenvino ==2023.1.0 h63175ca_1
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2023.1.0-h63175ca_1.conda
   hash:
     md5: e8c11f3cec7638dad6a16149834347f1
     sha256: 17ab0ba7b456338542016377e6d9ba23ed83880b7583068b23f6ef620d8febc1
-  optional: false
-  category: main
   build: h63175ca_1
   arch: x86_64
   subdir: win-64
   build_number: 1
   size: 320162
   timestamp: 1698384419551
-- name: libopus
+- platform: linux-64
+  name: libopus
   version: 1.3.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
   hash:
     md5: 15345e56d527b330e1cacbdf58676e8f
     sha256: 0e1c2740ebd1c93226dc5387461bbcf8142c518f2092f3ea7551f77755decc8f
-  optional: false
-  category: main
   build: h7f98852_1
   arch: x86_64
   subdir: linux-64
@@ -7458,17 +9421,16 @@ package:
   license_family: BSD
   size: 260658
   timestamp: 1606823578035
-- name: libopus
+- platform: osx-64
+  name: libopus
   version: 1.3.1
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
   hash:
     md5: 380b9ea5f6a7a277e6c1ac27d034369b
     sha256: c126fc225bece591a8f010e95ca7d010ea2d02df9251830bec24a19bf823fc31
-  optional: false
-  category: main
   build: hc929b4f_1
   arch: x86_64
   subdir: osx-64
@@ -7477,17 +9439,16 @@ package:
   license_family: BSD
   size: 279983
   timestamp: 1606823633642
-- name: libopus
+- platform: osx-arm64
+  name: libopus
   version: 1.3.1
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
   hash:
     md5: 3d0dbee0ccd2f6d6781d270313627b62
     sha256: e9912101a58cbc609a1917c5289f3bd1f600c82ed3a1c90a6dd4ca02df77958a
-  optional: false
-  category: main
   build: h27ca646_1
   arch: aarch64
   subdir: osx-arm64
@@ -7496,19 +9457,18 @@ package:
   license_family: BSD
   size: 252854
   timestamp: 1606823635137
-- name: libopus
+- platform: win-64
+  name: libopus
   version: 1.3.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
   hash:
     md5: e35a6bcfeb20ea83aab21dfc50ae62a4
     sha256: b2e5ec193762a5b4f905f8100437370e164df3db0ea5c18b4ce09390f5d3d525
-  optional: false
-  category: main
   build: h8ffe710_1
   arch: x86_64
   subdir: win-64
@@ -7517,18 +9477,17 @@ package:
   license_family: BSD
   size: 260615
   timestamp: 1606824019288
-- name: libpciaccess
+- platform: linux-64
+  name: libpciaccess
   version: '0.17'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.17-h166bdaf_0.tar.bz2
   hash:
     md5: b7463391cf284065294e2941dd41ab95
     sha256: 9fe4aaf5629b4848d9407b9ed4da941ba7e5cebada63ee0becb9aa82259dc6e2
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -7537,19 +9496,18 @@ package:
   license_family: MIT
   size: 39750
   timestamp: 1666091838440
-- name: libpng
+- platform: linux-64
+  name: libpng
   version: 1.6.39
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.39-h753d276_0.conda
   hash:
     md5: e1c890aebdebbfbf87e2c917187b4416
     sha256: a32b36d34e4f2490b99bddbc77d01a674d304f667f0e62c89e02c961addef462
-  optional: false
-  category: main
   build: h753d276_0
   arch: x86_64
   subdir: linux-64
@@ -7557,18 +9515,17 @@ package:
   license: zlib-acknowledgement
   size: 282599
   timestamp: 1669075729952
-- name: libpng
+- platform: osx-64
+  name: libpng
   version: 1.6.39
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
   hash:
     md5: 35e4928794c5391aec14ffdf1deaaee5
     sha256: 5ad9f5e96e6770bfc8b0a826f48835e7f337c2d2e9512d76027a62f9c120b2a3
-  optional: false
-  category: main
   build: ha978bb4_0
   arch: x86_64
   subdir: osx-64
@@ -7576,18 +9533,17 @@ package:
   license: zlib-acknowledgement
   size: 271689
   timestamp: 1669075890643
-- name: libpng
+- platform: osx-arm64
+  name: libpng
   version: 1.6.39
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
   hash:
     md5: 0078e6327c13cfdeae6ff7601e360383
     sha256: 21ab8409a8e66f9408b96428c0a36a9768faee9fe623c56614576f9e12962981
-  optional: false
-  category: main
   build: h76d750c_0
   arch: aarch64
   subdir: osx-arm64
@@ -7595,21 +9551,20 @@ package:
   license: zlib-acknowledgement
   size: 259412
   timestamp: 1669075883972
-- name: libpng
+- platform: win-64
+  name: libpng
   version: 1.6.39
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
   hash:
     md5: ab6febdb2dbd9c00803609079db4de71
     sha256: 1f139a72109366ba1da69f5bdc569b0e6783f887615807c02d7bfcc2c7575067
-  optional: false
-  category: main
   build: h19919ed_0
   arch: x86_64
   subdir: win-64
@@ -7617,21 +9572,20 @@ package:
   license: zlib-acknowledgement
   size: 343883
   timestamp: 1669076173145
-- name: libpq
+- platform: linux-64
+  name: libpq
   version: '16.0'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    krb5: '>=1.21.2,<1.22.0a0'
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.0-hfc447b1_1.conda
   hash:
     md5: e4a9a5ba40123477db33e02a78dffb01
     sha256: 2eef51449f61f93579452715cda6b306f8e5107f9a5f8441365b8ad49095c37b
-  optional: false
-  category: main
   build: hfc447b1_1
   arch: x86_64
   subdir: linux-64
@@ -7639,21 +9593,20 @@ package:
   license: PostgreSQL
   size: 2570515
   timestamp: 1696003990258
-- name: libprotobuf
+- platform: linux-64
+  name: libprotobuf
   version: 4.24.3
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libabseil >=20230802.1,<20230803.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.3-hf27288f_1.conda
   hash:
     md5: 5097789a2bc83e697d7509df57f25bfd
     sha256: 911ad483f051d96c9f07ecd8177546763c2da601e26941b434c3a09fa9fcd8f8
-  optional: false
-  category: main
   build: hf27288f_1
   arch: x86_64
   subdir: linux-64
@@ -7662,21 +9615,20 @@ package:
   license_family: BSD
   size: 2667628
   timestamp: 1697157559259
-- name: libprotobuf
+- platform: osx-64
+  name: libprotobuf
   version: 4.24.3
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    __osx: '>=10.13'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcxx: '>=15.0.7'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - __osx >=10.13
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.3-he0c2237_1.conda
   hash:
     md5: 45b790be289d0759d1eb91283c98e95d
     sha256: 42426fb0dba77e8f8cdf7732e9ee5d1dbed6724d1d94c84deeb98376f4cdcadd
-  optional: false
-  category: main
   build: he0c2237_1
   arch: x86_64
   subdir: osx-64
@@ -7685,20 +9637,19 @@ package:
   license_family: BSD
   size: 2157294
   timestamp: 1697158160443
-- name: libprotobuf
+- platform: osx-arm64
+  name: libprotobuf
   version: 4.24.3
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcxx: '>=15.0.7'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.3-hf590ac1_1.conda
   hash:
     md5: e014b86bbcf828432fda839a4e714dc8
     sha256: d901263a547d38c65e54ff8fc53a08909ccd4b01aefa26acb68c51f7458ee54b
-  optional: false
-  category: main
   build: hf590ac1_1
   arch: aarch64
   subdir: osx-arm64
@@ -7707,22 +9658,21 @@ package:
   license_family: BSD
   size: 2167180
   timestamp: 1697157552725
-- name: libprotobuf
+- platform: win-64
+  name: libprotobuf
   version: 4.24.3
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libabseil >=20230802.1,<20230803.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.24.3-hb8276f3_1.conda
   hash:
     md5: dad0daf4a610f3c2ba3ef3325096c5e6
     sha256: dd0f3ef35ee2774db9ca5dfcba088636bf1f0b1d3cb2c4c35ff2a2ffdf01bf09
-  optional: false
-  category: main
   build: hb8276f3_1
   arch: x86_64
   subdir: win-64
@@ -7731,18 +9681,115 @@ package:
   license_family: BSD
   size: 5259129
   timestamp: 1697157938555
-- name: libsanitizer
-  version: 12.3.0
+- platform: linux-64
+  name: libre2-11
+  version: 2023.06.02
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12.3.0'
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.06.02-h7a70373_0.conda
+  hash:
+    md5: c0e7eacd9694db3ef5ef2979a7deea70
+    sha256: 22b0b2169c80b65665ba0d6418bd5d3d4c7d89915ee0f9613403efe871c27db8
+  build: h7a70373_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  constrains:
+  - re2 2023.06.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 232708
+  timestamp: 1697065825934
+- platform: osx-64
+  name: libre2-11
+  version: 2023.06.02
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.13
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.06.02-h4694dbf_0.conda
+  hash:
+    md5: d7c00395eaf2446eec6ce0f34cfd5b78
+    sha256: 73acd1ade87762c3f1aacf2a7c6271dd1e1c972d46ea7c44d8781595bca9218e
+  build: h4694dbf_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  constrains:
+  - re2 2023.06.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 182813
+  timestamp: 1697065869791
+- platform: osx-arm64
+  name: libre2-11
+  version: 2023.06.02
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - libcxx >=16.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
+  hash:
+    md5: 3b8652db4bf4e27fa1446526f7a78498
+    sha256: 8bafee8f8ef27f4cb0afffe5404dd1abfc5fd6eac1ee9b4847a756d440bd7aa7
+  build: h1753957_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  constrains:
+  - re2 2023.06.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 169587
+  timestamp: 1697065827986
+- platform: win-64
+  name: libre2-11
+  version: 2023.06.02
+  category: main
+  manager: conda
+  dependencies:
+  - libabseil * cxx17*
+  - libabseil >=20230802.1,<20230803.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.06.02-h8c5ae5e_0.conda
+  hash:
+    md5: b5c24e75399edf13660f317f5d7d751e
+    sha256: c468915951532d0455737e08e5fb2a4e2a862c123a13feeaa12fe72671070e13
+  build: h8c5ae5e_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  constrains:
+  - re2 2023.06.02.*
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 253568
+  timestamp: 1697066113767
+- platform: linux-64
+  name: libsanitizer
+  version: 12.3.0
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_2.conda
   hash:
     md5: 4655db64eca78a6fcc4fb654fc1f8d57
     sha256: a58add0b4477c59aee324b508d834267360b659f9c543f551ca4442196e656fe
-  optional: false
-  category: main
   build: h0f45ef3_2
   arch: x86_64
   subdir: linux-64
@@ -7751,25 +9798,24 @@ package:
   license_family: GPL
   size: 3910499
   timestamp: 1695218679356
-- name: libsndfile
+- platform: linux-64
+  name: libsndfile
   version: 1.2.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    lame: '>=3.100,<3.101.0a0'
-    libflac: '>=1.4.3,<1.5.0a0'
-    libgcc-ng: '>=12'
-    libogg: '>=1.3.4,<1.4.0a0'
-    libopus: '>=1.3.1,<2.0a0'
-    libstdcxx-ng: '>=12'
-    libvorbis: '>=1.3.7,<1.4.0a0'
-    mpg123: '>=1.32.1,<1.33.0a0'
+  - lame >=3.100,<3.101.0a0
+  - libflac >=1.4.3,<1.5.0a0
+  - libgcc-ng >=12
+  - libogg >=1.3.4,<1.4.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libvorbis >=1.3.7,<1.4.0a0
+  - mpg123 >=1.32.1,<1.33.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
   hash:
     md5: ef1910918dd895516a769ed36b5b3a4e
     sha256: f709cbede3d4f3aee4e2f8d60bd9e256057f410bd60b8964cb8cf82ec1457573
-  optional: false
-  category: main
   build: hc60ed4a_1
   arch: x86_64
   subdir: linux-64
@@ -7778,19 +9824,18 @@ package:
   license_family: LGPL
   size: 354372
   timestamp: 1695747735668
-- name: libsqlite
+- platform: linux-64
+  name: libsqlite
   version: 3.43.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.43.2-h2797004_0.conda
   hash:
     md5: 4b441a1ee22397d5a27dc1126b849edd
     sha256: b30279b67fce2382a93c638625ff2b284324e2347e30bd0acab813d89289c18a
-  optional: false
-  category: main
   build: h2797004_0
   arch: x86_64
   subdir: linux-64
@@ -7798,18 +9843,17 @@ package:
   license: Unlicense
   size: 839889
   timestamp: 1696958890942
-- name: libsqlite
+- platform: osx-64
+  name: libsqlite
   version: 3.43.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.43.2-h92b6c6a_0.conda
   hash:
     md5: 61b88c5f99f1537ed30b34758bd54d54
     sha256: e0ba6181738d5250213576167935a97dc3ee581032f716dd4e2acbc817c763dc
-  optional: false
-  category: main
   build: h92b6c6a_0
   arch: x86_64
   subdir: osx-64
@@ -7817,18 +9861,17 @@ package:
   license: Unlicense
   size: 885196
   timestamp: 1696959083399
-- name: libsqlite
+- platform: osx-arm64
+  name: libsqlite
   version: 3.43.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.43.2-h091b4b1_0.conda
   hash:
     md5: 1d8208ba1b6a8c61431e77dc4e5c8fb9
     sha256: 93bec176e05c15a126c1c1c50b3aaef224829b81062bfd48716c5affde950a3f
-  optional: false
-  category: main
   build: h091b4b1_0
   arch: aarch64
   subdir: osx-arm64
@@ -7836,20 +9879,19 @@ package:
   license: Unlicense
   size: 809129
   timestamp: 1696959090990
-- name: libsqlite
+- platform: win-64
+  name: libsqlite
   version: 3.43.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.43.2-hcfcfb64_0.conda
   hash:
     md5: a4a81906f6ce911113f672973777f305
     sha256: 54cc0f0591354e4f23395ee08ca44efe584ad6df57111358d5bcb4b10259cb2e
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -7857,20 +9899,19 @@ package:
   license: Unlicense
   size: 846363
   timestamp: 1696959271392
-- name: libssh2
+- platform: linux-64
+  name: libssh2
   version: 1.11.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.1,<4.0a0'
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
   hash:
     md5: 1f5a58e686b13bcfde88b93f547d23fe
     sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
-  optional: false
-  category: main
   build: h0841786_0
   arch: x86_64
   subdir: linux-64
@@ -7879,19 +9920,18 @@ package:
   license_family: BSD
   size: 271133
   timestamp: 1685837707056
-- name: libssh2
+- platform: osx-64
+  name: libssh2
   version: 1.11.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.1,<4.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
   hash:
     md5: ca3a72efba692c59a90d4b9fc0dfe774
     sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
-  optional: false
-  category: main
   build: hd019ec5_0
   arch: x86_64
   subdir: osx-64
@@ -7900,19 +9940,18 @@ package:
   license_family: BSD
   size: 259556
   timestamp: 1685837820566
-- name: libssh2
+- platform: osx-arm64
+  name: libssh2
   version: 1.11.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.1,<4.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
   hash:
     md5: 029f7dc931a3b626b94823bc77830b01
     sha256: bb57d0c53289721fff1eeb3103a1c6a988178e88d8a8f4345b0b91a35f0e0015
-  optional: false
-  category: main
   build: h7a5bd25_0
   arch: aarch64
   subdir: osx-arm64
@@ -7921,22 +9960,21 @@ package:
   license_family: BSD
   size: 255610
   timestamp: 1685837894256
-- name: libssh2
+- platform: win-64
+  name: libssh2
   version: 1.11.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.1,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
   hash:
     md5: dc262d03aae04fe26825062879141a41
     sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
-  optional: false
-  category: main
   build: h7dfc565_0
   arch: x86_64
   subdir: win-64
@@ -7945,17 +9983,16 @@ package:
   license_family: BSD
   size: 266806
   timestamp: 1685838242099
-- name: libstdcxx-devel_linux-64
+- platform: linux-64
+  name: libstdcxx-devel_linux-64
   version: 12.3.0
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_2.conda
   hash:
     md5: 7268a17e56eb099d1b8869bbbf46de4c
     sha256: e8483069599561ef24b884c898442eadc510190f978fa388db3281b10c3c084e
-  optional: false
-  category: main
   build: h8bca6fd_2
   arch: x86_64
   subdir: linux-64
@@ -7964,17 +10001,16 @@ package:
   license_family: GPL
   size: 8542654
   timestamp: 1695218598349
-- name: libstdcxx-ng
+- platform: linux-64
+  name: libstdcxx-ng
   version: 13.2.0
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
   hash:
     md5: 9172c297304f2a20134fc56c97fbe229
     sha256: ab22ecdc974cdbe148874ea876d9c564294d5eafa760f403ed4fd495307b4243
-  optional: false
-  category: main
   build: h7e041cc_2
   arch: x86_64
   subdir: linux-64
@@ -7983,24 +10019,23 @@ package:
   license_family: GPL
   size: 3842773
   timestamp: 1695219454837
-- name: libsystemd0
+- platform: linux-64
+  name: libsystemd0
   version: '254'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libcap: '>=2.69,<2.70.0a0'
-    libgcc-ng: '>=12'
-    libgcrypt: '>=1.10.1,<2.0a0'
-    lz4-c: '>=1.9.3,<1.10.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
+  - __glibc >=2.17,<3.0.a0
+  - libcap >=2.69,<2.70.0a0
+  - libgcc-ng >=12
+  - libgcrypt >=1.10.1,<2.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.2,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-254-h3516f8a_0.conda
   hash:
     md5: df4b1cd0c91b4234fb02b5701a4cdddc
     sha256: e4732b9bc6acbdd3308cd0abd0860c9ea44e37127cd78acb797c996c20e4f42f
-  optional: false
-  category: main
   build: h3516f8a_0
   arch: x86_64
   subdir: linux-64
@@ -8008,18 +10043,17 @@ package:
   license: LGPL-2.1-or-later
   size: 400372
   timestamp: 1690575436367
-- name: libtasn1
+- platform: linux-64
+  name: libtasn1
   version: 4.19.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
   hash:
     md5: 93840744a8552e9ebf6bb1a5dffc125a
     sha256: 5bfeada0e1c6ec2574afe2d17cdbc39994d693a41431338a6cb9dfa7c4d7bfc8
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -8028,17 +10062,16 @@ package:
   license_family: GPL
   size: 116878
   timestamp: 1661325701583
-- name: libtasn1
+- platform: osx-64
+  name: libtasn1
   version: 4.19.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libtasn1-4.19.0-hb7f2c08_0.tar.bz2
   hash:
     md5: 73f67fb011b4477b101a95a082c74f0a
     sha256: 4197c155fb460fae65288c6c098c39f22495a53838356d29b79b31b8e33486dc
-  optional: false
-  category: main
   build: hb7f2c08_0
   arch: x86_64
   subdir: osx-64
@@ -8047,17 +10080,16 @@ package:
   license_family: GPL
   size: 118785
   timestamp: 1661325967954
-- name: libtasn1
+- platform: osx-arm64
+  name: libtasn1
   version: 4.19.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
   hash:
     md5: c35bc17c31579789c76739486fc6d27a
     sha256: 912e96644ea22b49921c71c9c94bcdd2b6463e9313da895c2fcee298a8c0e44c
-  optional: false
-  category: main
   build: h1a8c8d9_0
   arch: aarch64
   subdir: osx-arm64
@@ -8066,26 +10098,116 @@ package:
   license_family: GPL
   size: 116745
   timestamp: 1661325945767
-- name: libtiff
-  version: 4.6.0
+- platform: linux-64
+  name: libthrift
+  version: 0.19.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.19,<1.20.0a0'
-    libgcc-ng: '>=12'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+  hash:
+    md5: 8cdb7d41faa0260875ba92414c487e2d
+    sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
+  build: hb90f79a_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 409409
+  timestamp: 1695958011498
+- platform: osx-64
+  name: libthrift
+  version: 0.19.0
+  category: main
+  manager: conda
+  dependencies:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+  hash:
+    md5: b152655bfad7c2374ff03be0596052b6
+    sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
+  build: h064b379_1
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 325415
+  timestamp: 1695958330036
+- platform: osx-arm64
+  name: libthrift
+  version: 0.19.0
+  category: main
+  manager: conda
+  dependencies:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
+  hash:
+    md5: 4b8b21eb00d9019e9fa351141da2a6ac
+    sha256: b2c1b30d36f0412c0c0313db76a0236d736f3a9b887b8ed16182f531e4b7cb80
+  build: h026a170_1
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 331154
+  timestamp: 1695958512679
+- platform: win-64
+  name: libthrift
+  version: 0.19.0
+  category: main
+  manager: conda
+  dependencies:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
+  hash:
+    md5: d3432b9d4950e91d2fdf3bed91248ee0
+    sha256: 89bbc59898c827429a52315c9c0dd888ea73ab1157a8c86098aeae7d13454ac4
+  build: ha2b3283_1
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  license: Apache-2.0
+  license_family: APACHE
+  size: 612342
+  timestamp: 1695958519927
+- platform: linux-64
+  name: libtiff
+  version: 4.6.0
+  category: main
+  manager: conda
+  dependencies:
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
   hash:
     md5: 55ed21669b2015f77c180feb1dd41930
     sha256: 45158f5fbee7ee3e257e6b9f51b9f1c919ed5518a94a9973fe7fa4764330473e
-  optional: false
-  category: main
   build: ha9c0a0a_2
   arch: x86_64
   subdir: linux-64
@@ -8093,25 +10215,24 @@ package:
   license: HPND
   size: 283198
   timestamp: 1695661593314
-- name: libtiff
+- platform: osx-64
+  name: libtiff
   version: 4.6.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    lerc: '>=4.0.0,<5.0a0'
-    libcxx: '>=15.0.7'
-    libdeflate: '>=1.19,<1.20.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.20.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
   hash:
     md5: 2ca10a325063e000ad6d2a5900061e0d
     sha256: 1ef5bd7295f4316b111f70ad21356fb9f0de50b85a341cac9e3a61ac6487fdf1
-  optional: false
-  category: main
   build: h684deea_2
   arch: x86_64
   subdir: osx-64
@@ -8119,25 +10240,24 @@ package:
   license: HPND
   size: 266501
   timestamp: 1695661828714
-- name: libtiff
+- platform: osx-arm64
+  name: libtiff
   version: 4.6.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    lerc: '>=4.0.0,<5.0a0'
-    libcxx: '>=15.0.7'
-    libdeflate: '>=1.19,<1.20.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libwebp-base: '>=1.3.2,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - lerc >=4.0.0,<5.0a0
+  - libcxx >=15.0.7
+  - libdeflate >=1.19,<1.20.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
   hash:
     md5: 596d6d949bab9a75a492d451f521f457
     sha256: b18ef36eb90f190db22c56ae5a080bccc16669c8f5b795a6211d7b0c00c18ff7
-  optional: false
-  category: main
   build: ha8a6c65_2
   arch: aarch64
   subdir: osx-arm64
@@ -8145,26 +10265,25 @@ package:
   license: HPND
   size: 246265
   timestamp: 1695661829324
-- name: libtiff
+- platform: win-64
+  name: libtiff
   version: 4.6.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.19,<1.20.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    xz: '>=5.2.6,<6.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - lerc >=4.0.0,<5.0a0
+  - libdeflate >=1.19,<1.20.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
   hash:
     md5: 08d653b74ee2dec0131ad4259ffbb126
     sha256: f7b50b71840a5d8edd74a8bccf0c173ca2599bd136e366c35722272b4afa0500
-  optional: false
-  category: main
   build: h6e2ebb7_2
   arch: x86_64
   subdir: win-64
@@ -8172,18 +10291,17 @@ package:
   license: HPND
   size: 787430
   timestamp: 1695662030293
-- name: libunistring
+- platform: linux-64
+  name: libunistring
   version: 0.9.10
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
   hash:
     md5: 7245a044b4a1980ed83196176b78b73a
     sha256: e88c45505921db29c08df3439ddb7f771bbff35f95e7d3103bf365d5d6ce2a6d
-  optional: false
-  category: main
   build: h7f98852_0
   arch: x86_64
   subdir: linux-64
@@ -8191,17 +10309,16 @@ package:
   license: GPL-3.0-only OR LGPL-3.0-only
   size: 1433436
   timestamp: 1626955018689
-- name: libunistring
+- platform: osx-64
+  name: libunistring
   version: 0.9.10
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libunistring-0.9.10-h0d85af4_0.tar.bz2
   hash:
     md5: 40f27dc16f73256d7b93e53c4f03d92f
     sha256: c5805a58cd2b211bffdc8b7cdeba9af3cee456196ab52ab9a30e0353bc95beb7
-  optional: false
-  category: main
   build: h0d85af4_0
   arch: x86_64
   subdir: osx-64
@@ -8209,17 +10326,16 @@ package:
   license: GPL-3.0-only OR LGPL-3.0-only
   size: 1392865
   timestamp: 1626955817826
-- name: libunistring
+- platform: osx-arm64
+  name: libunistring
   version: 0.9.10
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
   hash:
     md5: d88e77a4861e20bd96bde6628ee7a5ae
     sha256: a1afe12ab199f82f339eae83405d293d197f2485d45346a709703bc7e8299949
-  optional: false
-  category: main
   build: h3422bc3_0
   arch: aarch64
   subdir: osx-arm64
@@ -8227,18 +10343,93 @@ package:
   license: GPL-3.0-only OR LGPL-3.0-only
   size: 1577561
   timestamp: 1626955172521
-- name: libuuid
-  version: 2.38.1
+- platform: linux-64
+  name: libutf8proc
+  version: 2.8.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+  hash:
+    md5: ede4266dc02e875fe1ea77b25dd43747
+    sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  build: h166bdaf_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 101070
+  timestamp: 1667316029302
+- platform: osx-64
+  name: libutf8proc
+  version: 2.8.0
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  hash:
+    md5: db98dc3e58cbc11583180609c429c17d
+    sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+  build: hb7f2c08_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 98942
+  timestamp: 1667316472080
+- platform: osx-arm64
+  name: libutf8proc
+  version: 2.8.0
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+  hash:
+    md5: f8c9c41a122ab3abdf8943b13f4957ee
+    sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
+  build: h1a8c8d9_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 103492
+  timestamp: 1667316405233
+- platform: win-64
+  name: libutf8proc
+  version: 2.8.0
+  category: main
+  manager: conda
+  dependencies:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+  hash:
+    md5: 076894846fe9f068f91c57d158c90cba
+    sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
+  build: h82a8f57_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 104389
+  timestamp: 1667316359211
+- platform: linux-64
+  name: libuuid
+  version: 2.38.1
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
   hash:
     md5: 40b61aab5c7ba9ff276c41cfffe6b80b
     sha256: 787eb542f055a2b3de553614b25f09eefb0a0931b0c87dbcce6efdfd92f04f18
-  optional: false
-  category: main
   build: h0b41bf4_0
   arch: x86_64
   subdir: linux-64
@@ -8247,18 +10438,17 @@ package:
   license_family: BSD
   size: 33601
   timestamp: 1680112270483
-- name: libuv
+- platform: linux-64
+  name: libuv
   version: 1.46.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.46.0-hd590300_0.conda
   hash:
     md5: d23c76f7e6dcd6243d1b6ef5e62d17d2
     sha256: 4bc4c946e9a532c066442714eeeeb1ffbd03cd89789c4047293f5e782b5fedd7
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -8267,17 +10457,16 @@ package:
   license_family: MIT
   size: 893348
   timestamp: 1693539405436
-- name: libuv
+- platform: osx-64
+  name: libuv
   version: 1.46.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.46.0-h0c2f820_0.conda
   hash:
     md5: 27664a5d39d9c32ae38880fec2b33b36
     sha256: e51667c756f15580d3ce131d6157f0238d931c05af118c89f019854f2a7c125e
-  optional: false
-  category: main
   build: h0c2f820_0
   arch: x86_64
   subdir: osx-64
@@ -8286,17 +10475,16 @@ package:
   license_family: MIT
   size: 396101
   timestamp: 1693539567563
-- name: libuv
+- platform: osx-arm64
+  name: libuv
   version: 1.46.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.46.0-hb547adb_0.conda
   hash:
     md5: 5f1d535f82e8210ac80d191610b92325
     sha256: f2fe8e22a99f91761c16dc7b00408bff0f5c30d4cccc6ea562db00a4041c5579
-  optional: false
-  category: main
   build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
@@ -8305,20 +10493,19 @@ package:
   license_family: MIT
   size: 402723
   timestamp: 1693539587068
-- name: libuv
+- platform: win-64
+  name: libuv
   version: 1.44.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.44.2-hcfcfb64_1.conda
   hash:
     md5: db1816a489a1b69dd1fd93e523cf026a
     sha256: d602dc13e1b0a955aa5f14772a3b8dc5ee72a4f68a4d63adb82a1ee105ffe4b2
-  optional: false
-  category: main
   build: hcfcfb64_1
   arch: x86_64
   subdir: win-64
@@ -8327,22 +10514,21 @@ package:
   license_family: MIT
   size: 285183
   timestamp: 1690371821520
-- name: libva
+- platform: linux-64
+  name: libva
   version: 2.20.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libdrm: '>=2.4.114,<2.5.0a0'
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxfixes: '*'
+  - libdrm >=2.4.114,<2.5.0a0
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes *
   url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.20.0-hd590300_0.conda
   hash:
     md5: 933bcea637569c6cea6084957028cb53
     sha256: 972d6f67d854d0f0fc2593f8bddc8d411859437ace7248c374e1a85a9ea9d410
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -8351,20 +10537,19 @@ package:
   license_family: MIT
   size: 188151
   timestamp: 1694689905260
-- name: libvorbis
+- platform: linux-64
+  name: libvorbis
   version: 1.3.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    libogg: '>=1.3.4,<1.4.0a0'
-    libstdcxx-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
+  - libogg >=1.3.4,<1.4.0a0
+  - libstdcxx-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
   hash:
     md5: 309dec04b70a3cc0f1e84a4013683bc0
     sha256: 53080d72388a57b3c31ad5805c93a7328e46ff22fab7c44ad2a86d712740af33
-  optional: false
-  category: main
   build: h9c3ff4c_0
   arch: x86_64
   subdir: linux-64
@@ -8373,20 +10558,19 @@ package:
   license_family: BSD
   size: 286280
   timestamp: 1610609811627
-- name: libvorbis
+- platform: win-64
+  name: libvorbis
   version: 1.3.7
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libogg: '>=1.3.4,<1.4.0a0'
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
+  - libogg >=1.3.4,<1.4.0a0
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
   url: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
   hash:
     md5: e1a22282de0169c93e4ffe6ce6acc212
     sha256: 6cdc018a024908270205d8512d92f92cf0adaaa5401c2b403757189b138bf56a
-  optional: false
-  category: main
   build: h0e60522_0
   arch: x86_64
   subdir: win-64
@@ -8395,19 +10579,18 @@ package:
   license_family: BSD
   size: 273721
   timestamp: 1610610022421
-- name: libvpx
+- platform: linux-64
+  name: libvpx
   version: 1.13.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
   hash:
     md5: 0974a6d3432e10bae02bcab0cce1b308
     sha256: 8067e73d6e4f82eae158cb86acdc2d1cf18dd7f13807f0b93e13a07ee4c04b79
-  optional: false
-  category: main
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -8416,18 +10599,17 @@ package:
   license_family: BSD
   size: 1006029
   timestamp: 1696342275863
-- name: libvpx
+- platform: osx-64
+  name: libvpx
   version: 1.13.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.13.1-he965462_0.conda
   hash:
     md5: 217e20148014ce0118f7d10852ac2fec
     sha256: cc3d921861e4ac760b1f54caef0fae7ce2e94faca51bcb438696bfbf16e42b54
-  optional: false
-  category: main
   build: he965462_0
   arch: x86_64
   subdir: osx-64
@@ -8436,18 +10618,17 @@ package:
   license_family: BSD
   size: 1285936
   timestamp: 1696342600631
-- name: libvpx
+- platform: osx-arm64
+  name: libvpx
   version: 1.13.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
   hash:
     md5: d62a0d3d8c01bd9fad3fd17d720d0cf5
     sha256: 3a9c5e903cc212f426bb4515293b45c84cb6173fd9ecc5bdba144e07c817d84c
-  optional: false
-  category: main
   build: hb765f3a_0
   arch: aarch64
   subdir: osx-arm64
@@ -8456,18 +10637,17 @@ package:
   license_family: BSD
   size: 1134986
   timestamp: 1696342737036
-- name: libwebp-base
+- platform: linux-64
+  name: libwebp-base
   version: 1.3.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
   hash:
     md5: 30de3fd9b3b602f7473f30e684eeea8c
     sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -8478,17 +10658,16 @@ package:
   license_family: BSD
   size: 401830
   timestamp: 1694709121323
-- name: libwebp-base
+- platform: osx-64
+  name: libwebp-base
   version: 1.3.2
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
   hash:
     md5: 4e7e9d244e87d66c18d36894fd6a8ae5
     sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
-  optional: false
-  category: main
   build: h0dc2134_0
   arch: x86_64
   subdir: osx-64
@@ -8499,17 +10678,16 @@ package:
   license_family: BSD
   size: 346599
   timestamp: 1694709233836
-- name: libwebp-base
+- platform: osx-arm64
+  name: libwebp-base
   version: 1.3.2
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
   hash:
     md5: 85dbc11098cdbe4244cd73f29a3ab795
     sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
-  optional: false
-  category: main
   build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
@@ -8520,20 +10698,19 @@ package:
   license_family: BSD
   size: 273844
   timestamp: 1694709510635
-- name: libwebp-base
+- platform: win-64
+  name: libwebp-base
   version: 1.3.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
   hash:
     md5: dcde8820959e64378d4e06147ffecfdd
     sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -8544,21 +10721,20 @@ package:
   license_family: BSD
   size: 268870
   timestamp: 1694709461733
-- name: libxcb
+- platform: linux-64
+  name: libxcb
   version: '1.15'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    pthread-stubs: '*'
-    xorg-libxau: '*'
-    xorg-libxdmcp: '*'
+  - libgcc-ng >=12
+  - pthread-stubs *
+  - xorg-libxau *
+  - xorg-libxdmcp *
   url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
   hash:
     md5: 33277193f5b92bad9fdd230eb700929c
     sha256: a670902f0a3173a466c058d2ac22ca1dd0df0453d3a80e0212815c20a16b0485
-  optional: false
-  category: main
   build: h0b41bf4_0
   arch: x86_64
   subdir: linux-64
@@ -8567,23 +10743,87 @@ package:
   license_family: MIT
   size: 384238
   timestamp: 1682082368177
-- name: libxkbcommon
-  version: 1.6.0
+- platform: osx-64
+  name: libxcb
+  version: '1.15'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    libxml2: '>=2.11.5,<2.12.0a0'
-    xkeyboard-config: '*'
-    xorg-libxau: '>=1.0.11,<2.0a0'
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+  hash:
+    md5: 5513f57e0238c87c12dffedbcc9c1a4a
+    sha256: f41904f466acc8b3197f37f2dd3a08da75720c7f7464d9267635debc4ac1902b
+  build: hb7f2c08_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 313793
+  timestamp: 1682083036825
+- platform: osx-arm64
+  name: libxcb
+  version: '1.15'
+  category: main
+  manager: conda
+  dependencies:
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+  hash:
+    md5: 988d5f86ab60fa6de91b3ee3a88a3af9
+    sha256: 6eaa87760ff3e91bb5524189700139db46f8946ff6331f4e571e4a9356edbb0d
+  build: hf346824_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 334770
+  timestamp: 1682082734262
+- platform: win-64
+  name: libxcb
+  version: '1.15'
+  category: main
+  manager: conda
+  dependencies:
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
+  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+  hash:
+    md5: 090d91b69396f14afef450c285f9758c
+    sha256: d01322c693580f53f8d07a7420cd6879289f5ddad5531b372c3efd1c37cac3bf
+  build: hcd874cb_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 969788
+  timestamp: 1682083087243
+- platform: linux-64
+  name: libxkbcommon
+  version: 1.6.0
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.11.5,<2.12.0a0
+  - xkeyboard-config *
+  - xorg-libxau >=1.0.11,<2.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-h5d7e998_0.conda
   hash:
     md5: d8edd0e29db6fb6b6988e1a28d35d994
     sha256: 6cd22602fe1517af411cfbf65babf1d6aad276100c2bce90d5e316214a602bbb
-  optional: false
-  category: main
   build: h5d7e998_0
   arch: x86_64
   subdir: linux-64
@@ -8592,22 +10832,21 @@ package:
   license_family: MIT
   size: 573385
   timestamp: 1696808339408
-- name: libxml2
+- platform: linux-64
+  name: libxml2
   version: 2.11.5
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libgcc-ng: '>=12'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
+  - icu >=73.2,<74.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
   hash:
     md5: f3858448893839820d4bcfb14ad3ecdf
     sha256: 1b3cb6864de1a558ea5fb144c780121d52507837d15df0600491d8ed92cff90c
-  optional: false
-  category: main
   build: h232c23b_1
   arch: x86_64
   subdir: linux-64
@@ -8616,21 +10855,20 @@ package:
   license_family: MIT
   size: 705542
   timestamp: 1692960341690
-- name: libxml2
+- platform: osx-64
+  name: libxml2
   version: 2.11.5
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
   hash:
     md5: 7584dee6af7de378aed0ae49aebedb8a
     sha256: d901fab32e57a43c44e630fb1c4d0a163d23b109eecd6c68b9ee371800760bca
-  optional: false
-  category: main
   build: h3346baf_1
   arch: x86_64
   subdir: osx-64
@@ -8639,21 +10877,20 @@ package:
   license_family: MIT
   size: 623399
   timestamp: 1692960844532
-- name: libxml2
+- platform: osx-arm64
+  name: libxml2
   version: 2.11.5
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    icu: '>=73.2,<74.0a0'
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    xz: '>=5.2.6,<6.0a0'
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
   hash:
     md5: 627b5d1377536b5b632ba53cd1455555
     sha256: 8291549b87aca48e9cd4aec124af01b5037acd16f8ad14083d7af23c8bb6bebe
-  optional: false
-  category: main
   build: h25269f3_1
   arch: aarch64
   subdir: osx-arm64
@@ -8662,22 +10899,21 @@ package:
   license_family: MIT
   size: 614831
   timestamp: 1692960705224
-- name: libxml2
+- platform: win-64
+  name: libxml2
   version: 2.11.5
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libiconv: '>=1.17,<2.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
   hash:
     md5: 27974f880a010b1441093d9f737a949f
     sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
-  optional: false
-  category: main
   build: hc3477c8_1
   arch: x86_64
   subdir: win-64
@@ -8686,18 +10922,17 @@ package:
   license_family: MIT
   size: 1600640
   timestamp: 1692960798126
-- name: libzlib
+- platform: linux-64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
   hash:
     md5: f36c115f1ee199da648e0597ec2047ad
     sha256: 370c7c5893b737596fd6ca0d9190c9715d89d888b8c88537ae1ef168c25e82e4
-  optional: false
-  category: main
   build: hd590300_5
   arch: x86_64
   subdir: linux-64
@@ -8708,17 +10943,16 @@ package:
   license_family: Other
   size: 61588
   timestamp: 1686575217516
-- name: libzlib
+- platform: osx-64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
   hash:
     md5: 4a3ad23f6e16f99c04e166767193d700
     sha256: fc58ad7f47ffea10df1f2165369978fba0a1cc32594aad778f5eec725f334867
-  optional: false
-  category: main
   build: h8a1eda9_5
   arch: x86_64
   subdir: osx-64
@@ -8729,17 +10963,16 @@ package:
   license_family: Other
   size: 59404
   timestamp: 1686575566695
-- name: libzlib
+- platform: osx-arm64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
   hash:
     md5: 1a47f5236db2e06a320ffa0392f81bd8
     sha256: ab1c8aefa2d54322a63aaeeefe9cf877411851738616c4068e0dccc66b9c758a
-  optional: false
-  category: main
   build: h53f4e23_5
   arch: aarch64
   subdir: osx-arm64
@@ -8750,20 +10983,19 @@ package:
   license_family: Other
   size: 48102
   timestamp: 1686575426584
-- name: libzlib
+- platform: win-64
+  name: libzlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
   hash:
     md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
     sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
-  optional: false
-  category: main
   build: hcfcfb64_5
   arch: x86_64
   subdir: win-64
@@ -8774,17 +11006,16 @@ package:
   license_family: Other
   size: 55800
   timestamp: 1686575452215
-- name: llvm-openmp
+- platform: osx-64
+  name: llvm-openmp
   version: 17.0.3
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.3-hb6ac08f_0.conda
   hash:
     md5: b70adc70bc7527a207c81c2e6b43532c
     sha256: 5bded7aa593e4d5dea89fc19ef2aa48b531cbe455452877ef9bd5a698cf35e53
-  optional: false
-  category: main
   build: hb6ac08f_0
   arch: x86_64
   subdir: osx-64
@@ -8795,17 +11026,16 @@ package:
   license_family: APACHE
   size: 299798
   timestamp: 1697651995182
-- name: llvm-openmp
+- platform: osx-arm64
+  name: llvm-openmp
   version: 17.0.3
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.3-hcd81f8e_0.conda
   hash:
     md5: bc4b8795976aae9c1ea5eb4ba26eafd8
     sha256: e744ecb793c1e991e93855b6e6b26c43b2b6fef2ecc340f9f54f7a650ed5e41a
-  optional: false
-  category: main
   build: hcd81f8e_0
   arch: aarch64
   subdir: osx-arm64
@@ -8816,21 +11046,20 @@ package:
   license_family: APACHE
   size: 274678
   timestamp: 1697652011036
-- name: llvm-tools
+- platform: osx-64
+  name: llvm-tools
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libllvm15: ==15.0.7 he4b1e75_3
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    zstd: '>=1.5.2,<1.6.0a0'
+  - libllvm15 ==15.0.7 he4b1e75_3
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - zstd >=1.5.2,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-15.0.7-he4b1e75_3.conda
   hash:
     md5: 7177e9334a86af1b1581f14607ced61c
     sha256: 93bf3db0bb0db82d91be7226374c239e88d885b850ab9791ec6755c63ffecc82
-  optional: false
-  category: main
   build: he4b1e75_3
   arch: x86_64
   subdir: osx-64
@@ -8844,20 +11073,19 @@ package:
   license_family: Apache
   size: 11380889
   timestamp: 1690534088911
-- name: llvm-tools
+- platform: osx-arm64
+  name: llvm-tools
   version: 15.0.7
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libllvm15: ==15.0.7 h504e6bf_3
-    libxml2: '>=2.11.4,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libllvm15 ==15.0.7 h504e6bf_3
+  - libxml2 >=2.11.4,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-15.0.7-h504e6bf_3.conda
   hash:
     md5: 56a351b4eba7ce574fa2702770e74252
     sha256: 102c7da379f508e55b60a24625a3174b85d7e716ead452c1d7c88f84174b7a99
-  optional: false
-  category: main
   build: h504e6bf_3
   arch: aarch64
   subdir: osx-arm64
@@ -8871,19 +11099,18 @@ package:
   license_family: Apache
   size: 10034129
   timestamp: 1690530165545
-- name: lz4-c
+- platform: linux-64
+  name: lz4-c
   version: 1.9.4
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
   hash:
     md5: 318b08df404f9c9be5712aaa5a6f0bb0
     sha256: 1b4c105a887f9b2041219d57036f72c4739ab9e9fe5a1486f094e58c76b31f5f
-  optional: false
-  category: main
   build: hcb278e6_0
   arch: x86_64
   subdir: linux-64
@@ -8892,19 +11119,174 @@ package:
   license_family: BSD
   size: 143402
   timestamp: 1674727076728
-- name: mkl
-  version: 2023.2.0
+- platform: osx-64
+  name: lz4-c
+  version: 1.9.4
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    intel-openmp: 2023.*
-    tbb: 2021.*
+  - libcxx >=14.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+  hash:
+    md5: aa04f7143228308662696ac24023f991
+    sha256: 39aa0c01696e4e202bf5e337413de09dfeec061d89acd5f28e9968b4e93c3f48
+  build: hf0c8a7f_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 156415
+  timestamp: 1674727335352
+- platform: osx-arm64
+  name: lz4-c
+  version: 1.9.4
+  category: main
+  manager: conda
+  dependencies:
+  - libcxx >=14.0.6
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+  hash:
+    md5: 45505bec548634f7d05e02fb25262cb9
+    sha256: fc343b8c82efe40819b986e29ba748366514e5ab94a1e1138df195af5f45fa24
+  build: hb7217d7_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 141188
+  timestamp: 1674727268278
+- platform: win-64
+  name: lz4-c
+  version: 1.9.4
+  category: main
+  manager: conda
+  dependencies:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+  hash:
+    md5: e34720eb20a33fc3bfb8451dd837ab7a
+    sha256: a0954b4b1590735ea5f3d0f4579c3883f8ac837387afd5b398b241fda85124ab
+  build: hcfcfb64_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 134235
+  timestamp: 1674728465431
+- platform: win-64
+  name: m2w64-gcc-libgfortran
+  version: 5.3.0
+  category: main
+  manager: conda
+  dependencies:
+  - m2w64-gcc-libs-core
+  - msys2-conda-epoch ==20160418
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+  hash:
+    md5: 066552ac6b907ec6d72c0ddab29050dc
+    sha256: 9de95a7996d5366ae0808eef2acbc63f9b11b874aa42375f55379e6715845dc6
+  build: '6'
+  arch: x86_64
+  subdir: win-64
+  build_number: 6
+  license: GPL, LGPL, FDL, custom
+  size: 350687
+  timestamp: 1608163451316
+- platform: win-64
+  name: m2w64-gcc-libs
+  version: 5.3.0
+  category: main
+  manager: conda
+  dependencies:
+  - m2w64-gcc-libgfortran
+  - m2w64-gcc-libs-core
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+  hash:
+    md5: fe759119b8b3bfa720b8762c6fdc35de
+    sha256: 3bd1ab02b7c89a5b153a17be03b36d833f1517ff2a6a77ead7c4a808b88196aa
+  build: '7'
+  arch: x86_64
+  subdir: win-64
+  build_number: 7
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 532390
+  timestamp: 1608163512830
+- platform: win-64
+  name: m2w64-gcc-libs-core
+  version: 5.3.0
+  category: main
+  manager: conda
+  dependencies:
+  - m2w64-gmp
+  - m2w64-libwinpthread-git
+  - msys2-conda-epoch ==20160418
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+  hash:
+    md5: 4289d80fb4d272f1f3b56cfe87ac90bd
+    sha256: 58afdfe859ed2e9a9b1cc06bc408720cb2c3a6a132e59d4805b090d7574f4ee0
+  build: '7'
+  arch: x86_64
+  subdir: win-64
+  build_number: 7
+  license: GPL3+, partial:GCCRLE, partial:LGPL2+
+  size: 219240
+  timestamp: 1608163481341
+- platform: win-64
+  name: m2w64-gmp
+  version: 6.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - msys2-conda-epoch ==20160418
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+  hash:
+    md5: 53a1c73e1e3d185516d7e3af177596d9
+    sha256: 7e3cd95f554660de45f8323fca359e904e8d203efaf07a4d311e46d611481ed1
+  build: '2'
+  arch: x86_64
+  subdir: win-64
+  build_number: 2
+  license: LGPL3
+  size: 743501
+  timestamp: 1608163782057
+- platform: win-64
+  name: m2w64-libwinpthread-git
+  version: 5.0.0.4634.697f757
+  category: main
+  manager: conda
+  dependencies:
+  - msys2-conda-epoch ==20160418
+  url: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+  hash:
+    md5: 774130a326dee16f1ceb05cc687ee4f0
+    sha256: f63a09b2cae7defae0480f1740015d6235f1861afa6fe2e2d3e10bd0d1314ee0
+  build: '2'
+  arch: x86_64
+  subdir: win-64
+  build_number: 2
+  license: MIT, BSD
+  size: 31928
+  timestamp: 1608166099896
+- platform: win-64
+  name: mkl
+  version: 2023.2.0
+  category: main
+  manager: conda
+  dependencies:
+  - intel-openmp 2023.*
+  - tbb 2021.*
   url: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
   hash:
     md5: 03da367d935ecf4d3e4005cf705d0e21
     sha256: 40dc6ac2aa071ca248223de7cdbdfdb216bc8632a17104b1507bcbf9276265d4
-  optional: false
-  category: main
   build: h6a75c08_50496
   arch: x86_64
   subdir: win-64
@@ -8913,19 +11295,18 @@ package:
   license_family: Proprietary
   size: 144749783
   timestamp: 1695995252418
-- name: mpg123
+- platform: linux-64
+  name: mpg123
   version: 1.32.3
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.3-h59595ed_0.conda
   hash:
     md5: bdadff838d5437aea83607ced8b37f75
     sha256: f02b8ed16b3a488938b5f9453d19ea315ce6ed0d46cc389ecfaa28f2a4c3cb16
-  optional: false
-  category: main
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -8934,61 +11315,74 @@ package:
   license_family: LGPL
   size: 491969
   timestamp: 1696265613952
-- name: mysql-common
-  version: 8.0.33
+- platform: win-64
+  name: msys2-conda-epoch
+  version: '20160418'
+  category: main
   manager: conda
-  platform: linux-64
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+  hash:
+    md5: b0309b72560df66f71a9d5e34a5efdfa
+    sha256: 99358d58d778abee4dca82ad29fb58058571f19b0f86138363c260049d4ac7f1
+  build: '1'
+  arch: x86_64
+  subdir: win-64
+  build_number: 1
+  size: 3227
+  timestamp: 1608166968312
+- platform: linux-64
+  name: mysql-common
+  version: 8.0.33
+  category: main
+  manager: conda
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    openssl: '>=3.1.3,<4.0a0'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - openssl >=3.1.3,<4.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_5.conda
   hash:
     md5: 1e8ef4090ca4f0d66404a7441e1dbf3c
     sha256: 1b5114244f28e416d42e9ac0c61dfdabdfd7255b9fe752a07ca157a3e3893d2a
-  optional: false
-  category: main
   build: hf1915f5_5
   arch: x86_64
   subdir: linux-64
   build_number: 5
   size: 757936
   timestamp: 1696767534589
-- name: mysql-libs
+- platform: linux-64
+  name: mysql-libs
   version: 8.0.33
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    mysql-common: ==8.0.33 hf1915f5_5
-    openssl: '>=3.1.3,<4.0a0'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-common ==8.0.33 hf1915f5_5
+  - openssl >=3.1.3,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_5.conda
   hash:
     md5: b72f016c910ff9295b1377d3e17da3f2
     sha256: 90a5c105e35990cac53f45366c256d88f4c8f66a360afd37dcae1357e370ade6
-  optional: false
-  category: main
   build: hca2cd23_5
   arch: x86_64
   subdir: linux-64
   build_number: 5
   size: 1529906
   timestamp: 1696767629434
-- name: ncurses
+- platform: linux-64
+  name: ncurses
   version: '6.4'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
   hash:
     md5: 681105bccc2a3f7f1a837d47d39c9179
     sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
-  optional: false
-  category: main
   build: hcb278e6_0
   arch: x86_64
   subdir: linux-64
@@ -8996,17 +11390,16 @@ package:
   license: X11 AND BSD-3-Clause
   size: 880967
   timestamp: 1686076725450
-- name: ncurses
+- platform: osx-64
+  name: ncurses
   version: '6.4'
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
   hash:
     md5: c3dbae2411164d9b02c69090a9a91857
     sha256: 7841b1fce1ffb0bfb038f9687b92f04d64acab1f7cb96431972386ea98c7b2fd
-  optional: false
-  category: main
   build: hf0c8a7f_0
   arch: x86_64
   subdir: osx-64
@@ -9014,17 +11407,16 @@ package:
   license: X11 AND BSD-3-Clause
   size: 828118
   timestamp: 1686077056765
-- name: ncurses
+- platform: osx-arm64
+  name: ncurses
   version: '6.4'
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
   hash:
     md5: 318337fb9d0c53ba635efb7888242373
     sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
-  optional: false
-  category: main
   build: h7ea286d_0
   arch: aarch64
   subdir: osx-arm64
@@ -9032,18 +11424,17 @@ package:
   license: X11 AND BSD-3-Clause
   size: 799196
   timestamp: 1686077139703
-- name: nettle
+- platform: linux-64
+  name: nettle
   version: 3.8.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.8.1-hc379101_1.tar.bz2
   hash:
     md5: 3cb2c7df59990bd37c2ce27fd906de68
     sha256: 49c569a69608eee784e815179a70c6ae4d088dac42b7df999044f68058d593bb
-  optional: false
-  category: main
   build: hc379101_1
   arch: x86_64
   subdir: linux-64
@@ -9052,17 +11443,16 @@ package:
   license_family: GPL
   size: 1195508
   timestamp: 1659085101126
-- name: nettle
+- platform: osx-64
+  name: nettle
   version: 3.8.1
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.8.1-h96f3785_1.tar.bz2
   hash:
     md5: 99558b9df4c337a0bf82bc8e0090533a
     sha256: d8b3ffa9595e04a28c7cecb482548c868ec1d5d1937a40ac508ff97d0343d3dc
-  optional: false
-  category: main
   build: h96f3785_1
   arch: x86_64
   subdir: osx-64
@@ -9071,17 +11461,16 @@ package:
   license_family: GPL
   size: 547875
   timestamp: 1659085424759
-- name: nettle
+- platform: osx-arm64
+  name: nettle
   version: 3.8.1
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.8.1-h63371fa_1.tar.bz2
   hash:
     md5: 0da3266889a3febbb9840a7a89d29da9
     sha256: 712b4e836060ab26772c343a05d243e7486bb44a39bb5b35f3371e72d7b38a24
-  optional: false
-  category: main
   build: h63371fa_1
   arch: aarch64
   subdir: osx-arm64
@@ -9090,19 +11479,18 @@ package:
   license_family: GPL
   size: 537453
   timestamp: 1659085354893
-- name: ninja
+- platform: linux-64
+  name: ninja
   version: 1.11.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
   hash:
     md5: 73a4953a2d9c115bdc10ff30a52f675f
     sha256: b555247ac8859b4ff311e3d708a0640f1bfe9fae7125c485b444072474a84c41
-  optional: false
-  category: main
   build: h924138e_0
   arch: x86_64
   subdir: linux-64
@@ -9111,18 +11499,17 @@ package:
   license_family: Apache
   size: 2251263
   timestamp: 1676837602636
-- name: ninja
+- platform: osx-64
+  name: ninja
   version: 1.11.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
   hash:
     md5: 49ad513efe39447aa51affd47e3aa68f
     sha256: 6f738d9a26fa275317b95b2b96832daab9059ef64af9a338f904a3cb684ae426
-  optional: false
-  category: main
   build: hb8565cd_0
   arch: x86_64
   subdir: osx-64
@@ -9131,18 +11518,17 @@ package:
   license_family: Apache
   size: 121284
   timestamp: 1676837793132
-- name: ninja
+- platform: osx-arm64
+  name: ninja
   version: 1.11.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
   hash:
     md5: fdecec4002f41cf6ea1eea5b52947ee0
     sha256: a594e90b0ed8202c280fff4a008f6a355d0db54a62b17067dc4a950370ddffc0
-  optional: false
-  category: main
   build: hffc8910_0
   arch: aarch64
   subdir: osx-arm64
@@ -9151,19 +11537,18 @@ package:
   license_family: Apache
   size: 107047
   timestamp: 1676837935565
-- name: nspr
+- platform: linux-64
+  name: nspr
   version: '4.35'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
   hash:
     md5: da0ec11a6454ae19bff5b02ed881a2b1
     sha256: 8fadeebb2b7369a4f3b2c039a980d419f65c7b18267ba0c62588f9f894396d0c
-  optional: false
-  category: main
   build: h27087fc_0
   arch: x86_64
   subdir: linux-64
@@ -9172,23 +11557,22 @@ package:
   license_family: MOZILLA
   size: 226848
   timestamp: 1669784948267
-- name: nss
+- platform: linux-64
+  name: nss
   version: '3.94'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc-ng: '>=12'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    nspr: '>=4.35,<5.0a0'
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libsqlite >=3.43.0,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - nspr >=4.35,<5.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.94-h1d7d5a4_0.conda
   hash:
     md5: 7caef74bbfa730e014b20f0852068509
     sha256: c9b7910fc554c6550905b9150f4c8230e973ca63f41b42f2c18a49e8aa458e78
-  optional: false
-  category: main
   build: h1d7d5a4_0
   arch: x86_64
   subdir: linux-64
@@ -9197,25 +11581,24 @@ package:
   license_family: MOZILLA
   size: 2003539
   timestamp: 1696290024389
-- name: numpy
+- platform: linux-64
+  name: numpy
   version: 1.26.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libgcc-ng: '>=12'
-    liblapack: '>=3.9.0,<4.0a0'
-    libstdcxx-ng: '>=12'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py312heda63a1_0.conda
-  hash:
-    md5: 9b4f35e4d83e2a8b17868b65beb438d9
-    sha256: 83c8770959c096639973dd91dae7001adf8ec4cea374c125388c22314e92cf3a
-  optional: false
   category: main
-  build: py312heda63a1_0
+  manager: conda
+  dependencies:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=12
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py311h64a7726_0.conda
+  hash:
+    md5: bf16a9f625126e378302f08e7ed67517
+    sha256: 0aab5cef67cc2a1cd584f6e9cc6f2065c7a28c142d7defcb8096e8f719d9b3bf
+  build: py311h64a7726_0
   arch: x86_64
   subdir: linux-64
   build_number: 0
@@ -9223,26 +11606,25 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7452952
-  timestamp: 1695291296202
-- name: numpy
+  size: 8039946
+  timestamp: 1694920380273
+- platform: osx-64
+  name: numpy
   version: 1.26.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=15.0.7'
-    liblapack: '>=3.9.0,<4.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py312h5df92dc_0.conda
-  hash:
-    md5: aec65f472e6633e23844b555bf640a3f
-    sha256: 537ad31f441b60e6f7f8776a5b6b6a2158b051a6d423b84b6aa3bf75bed35d33
-  optional: false
   category: main
-  build: py312h5df92dc_0
+  manager: conda
+  dependencies:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py311hc44ba51_0.conda
+  hash:
+    md5: f95605c5b73f5f6a0f5f1b0aabfc2f39
+    sha256: 517cb22d5594fdb934523dd1951929961f686b5d994c684201acbf282433ec9b
+  build: py311hc44ba51_0
   arch: x86_64
   subdir: osx-64
   build_number: 0
@@ -9250,26 +11632,26 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 7010122
-  timestamp: 1695291869411
-- name: numpy
+  size: 7616817
+  timestamp: 1694920728660
+- platform: osx-arm64
+  name: numpy
   version: 1.26.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    libcxx: '>=15.0.7'
-    liblapack: '>=3.9.0,<4.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0 *_cpython'
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.0-py312h696b312_0.conda
-  hash:
-    md5: 6281cf23af141e1bc06f6c705e4cc281
-    sha256: 3cdffc4a7775a0159f4e259814dfc86e80590ddd13114468e1abe5b0bcada96a
-  optional: false
   category: main
-  build: py312h696b312_0
+  manager: conda
+  dependencies:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=15.0.7
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.0-py311hb8f3215_0.conda
+  hash:
+    md5: 97f8632bf2ad5c179ff68fc90c71c2ae
+    sha256: fca5ee1363f22a160c97e92d6400d4636f4b05987b08085e4f79fb6efb75fd0a
+  build: py311hb8f3215_0
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
@@ -9277,28 +11659,27 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6149084
-  timestamp: 1695291913048
-- name: numpy
+  size: 6780798
+  timestamp: 1694920700859
+- platform: win-64
+  name: numpy
   version: 1.26.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    libblas: '>=3.9.0,<4.0a0'
-    libcblas: '>=3.9.0,<4.0a0'
-    liblapack: '>=3.9.0,<4.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.* *_cp312
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py312h8753938_0.conda
-  hash:
-    md5: 341c2575404e3f96ea2cf78f152563dc
-    sha256: 3d61870e3ccaffee2371a4a93ddc7ee64c16df154a9dd6e5c93c8cb4b1e657ec
-  optional: false
   category: main
-  build: py312h8753938_0
+  manager: conda
+  dependencies:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py311h0b4df5a_0.conda
+  hash:
+    md5: a65e57fff208fd1d0f632e0afa8985d4
+    sha256: 3da6bcf524a4418d7d0dbc084c23c74e1f2fc4b19c34a5805f5e201e5d7fcd8f
+  build: py311h0b4df5a_0
   arch: x86_64
   subdir: win-64
   build_number: 0
@@ -9306,20 +11687,19 @@ package:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6454001
-  timestamp: 1695291651104
-- name: ocl-icd
+  size: 7085715
+  timestamp: 1694920741486
+- platform: linux-64
+  name: ocl-icd
   version: 2.3.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.4.0'
+  - libgcc-ng >=9.4.0
   url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.1-h7f98852_0.tar.bz2
   hash:
     md5: a9b00e3aa7ecf158ed8e34ef91915f16
     sha256: b4db0e12f0c5d988be154bb469235a216dc3d63836d784308507eb101463344e
-  optional: false
-  category: main
   build: h7f98852_0
   arch: x86_64
   subdir: linux-64
@@ -9328,18 +11708,17 @@ package:
   license_family: BSD
   size: 121465
   timestamp: 1629253199482
-- name: ocl-icd-system
+- platform: linux-64
+  name: ocl-icd-system
   version: 1.0.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    ocl-icd: '*'
+  - ocl-icd *
   url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-system-1.0.0-1.tar.bz2
   hash:
     md5: 577a4bd049737b11a24524e39a16a1f3
     sha256: cb0ce5ce5ede1be2fd9edf88abd3ce3e6c2b7397c0283d623e4d8ccf96a1ed09
-  optional: false
-  category: main
   build: '1'
   arch: x86_64
   subdir: linux-64
@@ -9348,107 +11727,102 @@ package:
   license_family: BSD
   size: 4253
   timestamp: 1575483836797
-- name: opencv
+- platform: linux-64
+  name: opencv
   version: 4.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libopencv: ==4.8.1 py312hd874328_3
-    py-opencv: ==4.8.1 py312h8da182e_3
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/opencv-4.8.1-py312h7900ff3_3.conda
-  hash:
-    md5: cc3a9d637dc1c1f33dea7335197ce9a1
-    sha256: ac1483a06fddeb7d49657d11e859266dbff546f3a78a501b9385940af0d3db08
-  optional: false
   category: main
-  build: py312h7900ff3_3
+  manager: conda
+  dependencies:
+  - libopencv 4.8.1 py311h60c0964_3
+  - py-opencv 4.8.1 py311h781c19f_3
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/opencv-4.8.1-py311h38be061_3.conda
+  hash:
+    md5: d190d5d4a323ccb215e911bbd295ae81
+    sha256: db22fcd402635d97800574f13478b954896ed3cce878584f63698f6cde8d475b
+  build: py311h38be061_3
   arch: x86_64
   subdir: linux-64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 25600
-  timestamp: 1698365999071
-- name: opencv
+  size: 25468
+  timestamp: 1698366073417
+- platform: osx-64
+  name: opencv
   version: 4.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libopencv: ==4.8.1 py312h086e99c_3
-    py-opencv: ==4.8.1 py312hdce95a9_3
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/osx-64/opencv-4.8.1-py312hb401068_3.conda
-  hash:
-    md5: 925dd83ef663111ed791fd23725f95e8
-    sha256: 9c119df5a320e24a369fe88a1485677740a515e4409f4a4d61fcd194e3615bb4
-  optional: false
   category: main
-  build: py312hb401068_3
+  manager: conda
+  dependencies:
+  - libopencv 4.8.1 py311h0ef0a85_3
+  - py-opencv 4.8.1 py311h9bdd199_3
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-64/opencv-4.8.1-py311h6eed73b_3.conda
+  hash:
+    md5: 664b27530ffaad957700de815c87f368
+    sha256: d0e6f84ca8a2304840a027700fb6e290b5026584be31082553a8c615c299edf5
+  build: py311h6eed73b_3
   arch: x86_64
   subdir: osx-64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 25709
-  timestamp: 1698366652694
-- name: opencv
+  size: 25588
+  timestamp: 1698366547724
+- platform: osx-arm64
+  name: opencv
   version: 4.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libopencv: ==4.8.1 py312h494ba3b_3
-    py-opencv: ==4.8.1 py312h37858a2_3
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/opencv-4.8.1-py312h1f38498_3.conda
-  hash:
-    md5: 3fa5a0603bb0dd1cdbbc9c5a71a15f68
-    sha256: 8b6fe84201abde1847d9c6243fd8b55a18d5c1489380eda0634cbb4af338ba85
-  optional: false
   category: main
-  build: py312h1f38498_3
+  manager: conda
+  dependencies:
+  - libopencv 4.8.1 py311h927bda1_3
+  - py-opencv 4.8.1 py311hf3b2ce4_3
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/opencv-4.8.1-py311ha1ab1f8_3.conda
+  hash:
+    md5: 24913f164911887fdf03a0d3d1c7a995
+    sha256: 1d4b6b8959d47191a0f32aa04377570a900ac8cd04f0fb50b891841908f6d5c4
+  build: py311ha1ab1f8_3
   arch: aarch64
   subdir: osx-arm64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 25795
-  timestamp: 1698366723288
-- name: opencv
+  size: 25817
+  timestamp: 1698366945504
+- platform: win-64
+  name: opencv
   version: 4.8.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    libopencv: ==4.8.1 py312h55e7661_3
-    py-opencv: ==4.8.1 py312hd42ba9a_3
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/win-64/opencv-4.8.1-py312h2e8e312_3.conda
-  hash:
-    md5: 79d4c8739326b1a9201ae3cb66469f57
-    sha256: d3c7b0828c254ed75c9a3b155a4ac106c83befbf066d8aacb5784ab2c1a4d1f6
-  optional: false
   category: main
-  build: py312h2e8e312_3
+  manager: conda
+  dependencies:
+  - libopencv 4.8.1 py311h6be31c5_3
+  - py-opencv 4.8.1 py311h3810d55_3
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/win-64/opencv-4.8.1-py311h1ea47a8_3.conda
+  hash:
+    md5: c0f8f557b5c1ee3456c2cfb389493eb0
+    sha256: 47c889fdd84d2edd27df3e8d4206cdb0d51fc95ae7810925e5b0c34f68a948d3
+  build: py311h1ea47a8_3
   arch: x86_64
   subdir: win-64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 25743
-  timestamp: 1698367177710
-- name: openh264
+  size: 25841
+  timestamp: 1698367711814
+- platform: linux-64
+  name: openh264
   version: 2.3.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.3.1-hcb278e6_2.conda
   hash:
     md5: 37d01894f256b2a6921c5a218f42f8a2
     sha256: 3be6de15d40f02c9bb34d5095c65b6b3f07e04fc21a0fb63d1885f1a31de5ae2
-  optional: false
-  category: main
   build: hcb278e6_2
   arch: x86_64
   subdir: linux-64
@@ -9457,18 +11831,17 @@ package:
   license_family: BSD
   size: 718775
   timestamp: 1675880590512
-- name: openh264
+- platform: osx-64
+  name: openh264
   version: 2.3.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.3.1-hf0c8a7f_2.conda
   hash:
     md5: 989ba22b08353c5ca0e6fba80bcd4321
     sha256: 5f39b97f048d72b149627993072e15d37428338a9fe83600db5d09ae7ca9f7b4
-  optional: false
-  category: main
   build: hf0c8a7f_2
   arch: x86_64
   subdir: osx-64
@@ -9477,18 +11850,17 @@ package:
   license_family: BSD
   size: 671537
   timestamp: 1675880810146
-- name: openh264
+- platform: osx-arm64
+  name: openh264
   version: 2.3.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.3.1-hb7217d7_2.conda
   hash:
     md5: 6ce0517e73640933cf5916deb21d4f23
     sha256: 36c6dc71bb10245ed93f3cb13280948cc8c6ca525f1639aac9d541726e4c80af
-  optional: false
-  category: main
   build: hb7217d7_2
   arch: aarch64
   subdir: osx-arm64
@@ -9497,20 +11869,19 @@ package:
   license_family: BSD
   size: 587729
   timestamp: 1675880932590
-- name: openh264
+- platform: win-64
+  name: openh264
   version: 2.3.1
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/openh264-2.3.1-h63175ca_2.conda
   hash:
     md5: 76e822d93cdc32b00b61810d3fa030e0
     sha256: 251566b5326a292215a3db5a184c255a092242a371431b617c7baf300fa9d170
-  optional: false
-  category: main
   build: h63175ca_2
   arch: x86_64
   subdir: win-64
@@ -9519,19 +11890,109 @@ package:
   license_family: BSD
   size: 410812
   timestamp: 1675882258839
-- name: openssl
-  version: 3.1.4
+- platform: linux-64
+  name: openjpeg
+  version: 2.5.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    ca-certificates: '*'
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
+  - libpng >=1.6.39,<1.7.0a0
+  - libstdcxx-ng >=12
+  - libtiff >=4.6.0,<4.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h488ebb8_3.conda
+  hash:
+    md5: 128c25b7fe6a25286a48f3a6a9b5b6f3
+    sha256: 9fe91b67289267de68fda485975bb48f0605ac503414dc663b50d8b5f29bc82a
+  build: h488ebb8_3
+  arch: x86_64
+  subdir: linux-64
+  build_number: 3
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 356698
+  timestamp: 1694708325417
+- platform: osx-64
+  name: openjpeg
+  version: 2.5.0
+  category: main
+  manager: conda
+  dependencies:
+  - libcxx >=15.0.7
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+  hash:
+    md5: 40a36f8e9a6fdf6a78c6428ee6c44188
+    sha256: fdccd9668b85bf6e798b628bceed5ff764e1114cfc4e6a4dee551cafbe549e74
+  build: ha4da562_3
+  arch: x86_64
+  subdir: osx-64
+  build_number: 3
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 335643
+  timestamp: 1694708811338
+- platform: osx-arm64
+  name: openjpeg
+  version: 2.5.0
+  category: main
+  manager: conda
+  dependencies:
+  - libcxx >=15.0.7
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-h4c1507b_3.conda
+  hash:
+    md5: 4127dd217a010d9c6cbefdaae07d9f19
+    sha256: a6998c0da4643a84dc7c0b3a9e5137db258619ea922317bb7d9ae64f54b4a9ed
+  build: h4c1507b_3
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 3
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 323335
+  timestamp: 1694708748389
+- platform: win-64
+  name: openjpeg
+  version: 2.5.0
+  category: main
+  manager: conda
+  dependencies:
+  - libpng >=1.6.39,<1.7.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
+  hash:
+    md5: 45a9628a04efb6fc326fff0a8f47b799
+    sha256: c0f64d9642f0287f17cd9b6f1633d97a91efd66a0cb9b0414c540b247684985d
+  build: h3d672ee_3
+  arch: x86_64
+  subdir: win-64
+  build_number: 3
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 236847
+  timestamp: 1694708878963
+- platform: linux-64
+  name: openssl
+  version: 3.1.4
+  category: main
+  manager: conda
+  dependencies:
+  - ca-certificates *
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.1.4-hd590300_0.conda
   hash:
     md5: 412ba6938c3e2abaca8b1129ea82e238
     sha256: d15b3e83ce66c6f6fbb4707f2f5c53337124c01fb03bfda1cf25c5b41123efc7
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -9542,18 +12003,17 @@ package:
   license_family: Apache
   size: 2648006
   timestamp: 1698164814626
-- name: openssl
+- platform: osx-64
+  name: openssl
   version: 3.1.4
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ca-certificates: '*'
+  - ca-certificates *
   url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.1.4-hd75f5a5_0.conda
   hash:
     md5: bc9201da6eb1e0df4107901df5371347
     sha256: 1c436103a8de0dc82c9c56974badaa1b8b8f8cd9f37c2766bd50cd9899720f6b
-  optional: false
-  category: main
   build: hd75f5a5_0
   arch: x86_64
   subdir: osx-64
@@ -9564,18 +12024,17 @@ package:
   license_family: Apache
   size: 2320542
   timestamp: 1698165459976
-- name: openssl
+- platform: osx-arm64
+  name: openssl
   version: 3.1.4
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ca-certificates: '*'
+  - ca-certificates *
   url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.1.4-h0d3ecfb_0.conda
   hash:
     md5: 5a89552fececf4cd99628318ccbb67a3
     sha256: 3c715b1d4940c7ad6065935db18924b85a54048dde066f963cfc250340639457
-  optional: false
-  category: main
   build: h0d3ecfb_0
   arch: aarch64
   subdir: osx-arm64
@@ -9586,21 +12045,20 @@ package:
   license_family: Apache
   size: 2147225
   timestamp: 1698164947105
-- name: openssl
+- platform: win-64
+  name: openssl
   version: 3.1.4
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ca-certificates: '*'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ca-certificates *
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.4-hcfcfb64_0.conda
   hash:
     md5: 2eebbc64373a1c6db62ad23304e9678e
     sha256: e30b7f55c27d06e3322876c9433a3522e751d06a40b3bb6c4f8b4bcd781a3794
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -9611,20 +12069,121 @@ package:
   license_family: Apache
   size: 7427765
   timestamp: 1698166937344
-- name: p11-kit
-  version: 0.24.1
+- platform: linux-64
+  name: orc
+  version: 1.9.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libffi: '>=3.4.2,<3.5.0a0'
-    libgcc-ng: '>=12'
-    libtasn1: '>=4.18.0,<5.0a0'
+  - libgcc-ng >=12
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.0-h208142c_3.conda
+  hash:
+    md5: f983ae19192439116ca5b5589560f167
+    sha256: 591fbeb2cf01406f649bbc78c73da682bfb5e34375c63259748aabb6e6a8b38d
+  build: h208142c_3
+  arch: x86_64
+  subdir: linux-64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 1017338
+  timestamp: 1696768703004
+- platform: osx-64
+  name: orc
+  version: 1.9.0
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.13
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.0-hb037d9a_3.conda
+  hash:
+    md5: 6f7bea3c994dc0308d467ca3871ead7f
+    sha256: b41971a64f3d12b5dd8024dc93382d30431c9fb9d42c47e96db65b528537e686
+  build: hb037d9a_3
+  arch: x86_64
+  subdir: osx-64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 423379
+  timestamp: 1696768921701
+- platform: osx-arm64
+  name: orc
+  version: 1.9.0
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.0-hcd02cb2_3.conda
+  hash:
+    md5: f641dc4341fc504ef31923bf5ded9782
+    sha256: 745ae7b01053f2602e136d30e303ab3946f2706b502cff795b5cc18e7d17ae2f
+  build: hcd02cb2_3
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 405788
+  timestamp: 1696768918785
+- platform: win-64
+  name: orc
+  version: 1.9.0
+  category: main
+  manager: conda
+  dependencies:
+  - libprotobuf >=4.24.3,<4.24.4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  url: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.0-hd95f75e_3.conda
+  hash:
+    md5: 7886f9102401c5e697187c05821cea23
+    sha256: faf72cde79571b475a77fc036a62f73cf270b03dbfc1fbe6f6a785464b656245
+  build: hd95f75e_3
+  arch: x86_64
+  subdir: win-64
+  build_number: 3
+  license: Apache-2.0
+  license_family: Apache
+  size: 881734
+  timestamp: 1696768993450
+- platform: linux-64
+  name: p11-kit
+  version: 0.24.1
+  category: main
+  manager: conda
+  dependencies:
+  - libffi >=3.4.2,<3.5.0a0
+  - libgcc-ng >=12
+  - libtasn1 >=4.18.0,<5.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
   hash:
     md5: 56ee94e34b71742bbdfa832c974e47a8
     sha256: aa8d3887b36557ad0c839e4876c0496e0d670afe843bf5bba4a87764b868196d
-  optional: false
-  category: main
   build: hc5aa10d_0
   arch: x86_64
   subdir: linux-64
@@ -9633,19 +12192,18 @@ package:
   license_family: MIT
   size: 4702497
   timestamp: 1654868759643
-- name: p11-kit
+- platform: osx-64
+  name: p11-kit
   version: 0.24.1
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libffi: '>=3.4.2,<3.5.0a0'
-    libtasn1: '>=4.18.0,<5.0a0'
+  - libffi >=3.4.2,<3.5.0a0
+  - libtasn1 >=4.18.0,<5.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/p11-kit-0.24.1-h65f8906_0.tar.bz2
   hash:
     md5: e936a0ee28be948846108582f00e2d61
     sha256: e16fbaadb2714c0965cb76de32fe7d13a21874cec02c97efef8ac51f4fda86fc
-  optional: false
-  category: main
   build: h65f8906_0
   arch: x86_64
   subdir: osx-64
@@ -9654,19 +12212,18 @@ package:
   license_family: MIT
   size: 834487
   timestamp: 1654869241699
-- name: p11-kit
+- platform: osx-arm64
+  name: p11-kit
   version: 0.24.1
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libffi: '>=3.4.2,<3.5.0a0'
-    libtasn1: '>=4.18.0,<5.0a0'
+  - libffi >=3.4.2,<3.5.0a0
+  - libtasn1 >=4.18.0,<5.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
   hash:
     md5: 8f111d56c8c7c1895bde91a942c43d93
     sha256: 3e124859307956f9f390f39c74b9700be4843eaaf56891c4b09da75b1bd5b57f
-  optional: false
-  category: main
   build: h29577a5_0
   arch: aarch64
   subdir: osx-arm64
@@ -9675,20 +12232,19 @@ package:
   license_family: MIT
   size: 890711
   timestamp: 1654869118646
-- name: pcre2
+- platform: linux-64
+  name: pcre2
   version: '10.40'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.12,<1.3.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libgcc-ng >=12
+  - libzlib >=1.2.12,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
   hash:
     md5: 69e2c796349cd9b273890bee0febfe1b
     sha256: 7a29ec847556eed4faa1646010baae371ced69059a4ade43851367a076d6108a
-  optional: false
-  category: main
   build: hc3806b6_0
   arch: x86_64
   subdir: linux-64
@@ -9697,19 +12253,18 @@ package:
   license_family: BSD
   size: 2412495
   timestamp: 1665562915343
-- name: pcre2
+- platform: osx-64
+  name: pcre2
   version: '10.40'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.2.12,<1.3.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.40-h1c4e4bc_0.tar.bz2
   hash:
     md5: e0f80c8f3a0352a54eddfe59cd2b25b1
     sha256: 60265b48c96decbea89a19a7bc34be88d9b95d4725fd4dbdae158529c601875a
-  optional: false
-  category: main
   build: h1c4e4bc_0
   arch: x86_64
   subdir: osx-64
@@ -9718,19 +12273,18 @@ package:
   license_family: BSD
   size: 2552113
   timestamp: 1665563254214
-- name: pcre2
+- platform: osx-arm64
+  name: pcre2
   version: '10.40'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.2.12,<1.3.0a0'
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2
   hash:
     md5: 721b7288270bafc83586b0f01c2a67f2
     sha256: 93503b5e05470ccc87f696c0fdf0d47938e0305b5047eacb85c15d78dcf641fe
-  optional: false
-  category: main
   build: hb34f9b4_0
   arch: aarch64
   subdir: osx-arm64
@@ -9739,22 +12293,21 @@ package:
   license_family: BSD
   size: 1161688
   timestamp: 1665563317371
-- name: pcre2
+- platform: win-64
+  name: pcre2
   version: '10.40'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libzlib: '>=1.2.12,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.12,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.40-h17e33f8_0.tar.bz2
   hash:
     md5: 2519de0d9620dc2bc7e19caf6867136d
     sha256: 5833c63548e4fae91da6d77739eab7dc9bf6542e43f105826b23c01bfdd9cb57
-  optional: false
-  category: main
   build: h17e33f8_0
   arch: x86_64
   subdir: win-64
@@ -9763,19 +12316,135 @@ package:
   license_family: BSD
   size: 2001630
   timestamp: 1665563527916
-- name: pixman
-  version: 0.42.2
+- platform: linux-64
+  name: pillow
+  version: 10.1.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libgcc-ng >=12
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.1.0-py311ha6c5da5_0.conda
+  hash:
+    md5: 83a988daf5c49e57f7d2086fb6781fe8
+    sha256: 5b037243f76644fe2e565aa6a3764039dba47cddf8bbef8ef01643775a459b60
+  build: py311ha6c5da5_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: HPND
+  size: 46400469
+  timestamp: 1697423839735
+- platform: osx-64
+  name: pillow
+  version: 10.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py311hea5c87a_0.conda
+  hash:
+    md5: ffff517d90b21a5d44ef907a5a01f695
+    sha256: 44bb951ae60cc96ab9273592ede9ee94a422857e857e52c55c261ad5f1525686
+  build: py311hea5c87a_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: HPND
+  size: 46474850
+  timestamp: 1697423945362
+- platform: osx-arm64
+  name: pillow
+  version: 10.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.1.0-py311hb9c5795_0.conda
+  hash:
+    md5: 90fd1f60da9f3d5eccdece0945043037
+    sha256: 9699ba6886e94e32eb949009195ed78c2c949f74450235af491cd4cbe390d7b4
+  build: py311hb9c5795_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: HPND
+  size: 45850858
+  timestamp: 1697424033737
+- platform: win-64
+  name: pillow
+  version: 10.1.0
+  category: main
+  manager: conda
+  dependencies:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.15,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.7.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py311h4dd8a23_0.conda
+  hash:
+    md5: c03c410ca23313c36381a128737ac25f
+    sha256: 494426ecfcbf5f177b5350dfdb5ca93a529a1873247c38beda25a70ad369fe36
+  build: py311h4dd8a23_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: HPND
+  size: 46022436
+  timestamp: 1697424195333
+- platform: linux-64
+  name: pixman
+  version: 0.42.2
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.42.2-h59595ed_0.conda
   hash:
     md5: 700edd63ccd5fc66b70b1c028cea9a68
     sha256: ae917851474eb3b08812b02c9e945d040808523ec53f828aa74a90b0cdf15f57
-  optional: false
-  category: main
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -9784,18 +12453,17 @@ package:
   license_family: MIT
   size: 385309
   timestamp: 1695736061006
-- name: pixman
+- platform: osx-64
+  name: pixman
   version: 0.42.2
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.42.2-he965462_0.conda
   hash:
     md5: e4180dcfd3e3621560fe1ad522997520
     sha256: d9181736d4b3260a03443e8fd1c47c491e189b2344913eaf5dead27947a274e4
-  optional: false
-  category: main
   build: he965462_0
   arch: x86_64
   subdir: osx-64
@@ -9804,18 +12472,17 @@ package:
   license_family: MIT
   size: 336190
   timestamp: 1695736270076
-- name: pixman
+- platform: osx-arm64
+  name: pixman
   version: 0.42.2
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.42.2-h13dd4ca_0.conda
   hash:
     md5: f96347021db6f33ccabe314ddeab62d4
     sha256: 90e60dc5604e356d47ef97b23b13759ef3d8b70fa2c637f4809d29851435d7d7
-  optional: false
-  category: main
   build: h13dd4ca_0
   arch: aarch64
   subdir: osx-arm64
@@ -9824,20 +12491,19 @@ package:
   license_family: MIT
   size: 213843
   timestamp: 1695736518800
-- name: pixman
+- platform: win-64
+  name: pixman
   version: 0.42.2
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.42.2-h63175ca_0.conda
   hash:
     md5: fb6fe034c742dc8562d3197c2d91423d
     sha256: bc663647468255781e3fba488372b0e699b717a63fa2450b9c282e68b6eb9543
-  optional: false
-  category: main
   build: h63175ca_0
   arch: x86_64
   subdir: win-64
@@ -9846,18 +12512,17 @@ package:
   license_family: MIT
   size: 455866
   timestamp: 1695736519750
-- name: pthread-stubs
+- platform: linux-64
+  name: pthread-stubs
   version: '0.4'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=7.5.0'
+  - libgcc-ng >=7.5.0
   url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
   hash:
     md5: 22dad4df6e8630e8dff2428f6f6a7036
     sha256: 67c84822f87b641d89df09758da498b2d4558d47b920fd1d3fe6d3a871e000ff
-  optional: false
-  category: main
   build: h36c2ea0_1001
   arch: x86_64
   subdir: linux-64
@@ -9866,18 +12531,72 @@ package:
   license_family: MIT
   size: 5625
   timestamp: 1606147468727
-- name: pthreads-win32
-  version: 2.9.1
+- platform: osx-64
+  name: pthread-stubs
+  version: '0.4'
+  category: main
   manager: conda
-  platform: win-64
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+  hash:
+    md5: addd19059de62181cd11ae8f4ef26084
+    sha256: 6e3900bb241bcdec513d4e7180fe9a19186c1a38f0b4080ed619d26014222c53
+  build: hc929b4f_1001
+  arch: x86_64
+  subdir: osx-64
+  build_number: 1001
+  license: MIT
+  license_family: MIT
+  size: 5653
+  timestamp: 1606147699844
+- platform: osx-arm64
+  name: pthread-stubs
+  version: '0.4'
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+  hash:
+    md5: d3f26c6494d4105d4ecb85203d687102
+    sha256: 9da9e6f5d51dff6ad2e4ee0874791437ba952e0a6249942273f0fedfd07ea826
+  build: h27ca646_1001
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 1001
+  license: MIT
+  license_family: MIT
+  size: 5696
+  timestamp: 1606147608402
+- platform: win-64
+  name: pthread-stubs
+  version: '0.4'
+  category: main
+  manager: conda
   dependencies:
-    vc: 14.*
+  - m2w64-gcc-libs
+  url: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+  hash:
+    md5: a1f820480193ea83582b13249a7e7bd9
+    sha256: bb5a6ddf1a609a63addd6d7b488b0f58d05092ea84e9203283409bff539e202a
+  build: hcd874cb_1001
+  arch: x86_64
+  subdir: win-64
+  build_number: 1001
+  license: MIT
+  license_family: MIT
+  size: 6417
+  timestamp: 1606147814351
+- platform: win-64
+  name: pthreads-win32
+  version: 2.9.1
+  category: main
+  manager: conda
+  dependencies:
+  - vc 14.*
   url: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
   hash:
     md5: e2da8758d7d51ff6aa78a14dfb9dbed4
     sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
-  optional: false
-  category: main
   build: hfa6e2cd_3
   arch: x86_64
   subdir: win-64
@@ -9885,19 +12604,18 @@ package:
   license: LGPL 2
   size: 144301
   timestamp: 1537755684331
-- name: pugixml
+- platform: linux-64
+  name: pugixml
   version: '1.14'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
   hash:
     md5: 2c97dd90633508b422c11bd3018206ab
     sha256: ea5f2d593177318f6b19af05018c953f41124cbb3bf21f9fdedfdb6ac42913ae
-  optional: false
-  category: main
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -9906,18 +12624,17 @@ package:
   license_family: MIT
   size: 114871
   timestamp: 1696182708943
-- name: pugixml
+- platform: osx-64
+  name: pugixml
   version: '1.14'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
   hash:
     md5: 92f9416f48c010bf04c34c9841c84b09
     sha256: 8ba30eb9ead058a19a472bb8e795ab408c629b0b84fc5bb7b6899e7429d5e625
-  optional: false
-  category: main
   build: he965462_0
   arch: x86_64
   subdir: osx-64
@@ -9926,18 +12643,17 @@ package:
   license_family: MIT
   size: 94175
   timestamp: 1696182807580
-- name: pugixml
+- platform: osx-arm64
+  name: pugixml
   version: '1.14'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
   hash:
     md5: 4de774bb04e03af9704ec1a2618c636c
     sha256: 0bfeac4f1a374da9ff0a322344cdab577d397d6a0a0e5591f08cb7b491926825
-  optional: false
-  category: main
   build: h13dd4ca_0
   arch: aarch64
   subdir: osx-arm64
@@ -9946,20 +12662,19 @@ package:
   license_family: MIT
   size: 92472
   timestamp: 1696182843052
-- name: pugixml
+- platform: win-64
+  name: pugixml
   version: '1.14'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
   hash:
     md5: 6794ab7a1f26ebfe0452297eba029d4f
     sha256: 68a5cb9a7560b2ce0d72ccebc7f6623e13ca66a67f80feb1094a75199bd1a50c
-  optional: false
-  category: main
   build: h63175ca_0
   arch: x86_64
   subdir: win-64
@@ -9968,22 +12683,21 @@ package:
   license_family: MIT
   size: 111324
   timestamp: 1696182979614
-- name: pulseaudio-client
+- platform: linux-64
+  name: pulseaudio-client
   version: '16.1'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    dbus: '>=1.13.6,<2.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.76.4,<3.0a0'
-    libsndfile: '>=1.2.2,<1.3.0a0'
-    libsystemd0: '>=254'
+  - dbus >=1.13.6,<2.0a0
+  - libgcc-ng >=12
+  - libglib >=2.76.4,<3.0a0
+  - libsndfile >=1.2.2,<1.3.0a0
+  - libsystemd0 >=254
   url: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
   hash:
     md5: ac902ff3c1c6d750dd0dfc93a974ab74
     sha256: 9981c70893d95c8cac02e7edd1a9af87f2c8745b772d529f08b7f9dafbe98606
-  optional: false
-  category: main
   build: hb77b528_5
   arch: x86_64
   subdir: linux-64
@@ -9994,365 +12708,455 @@ package:
   license_family: LGPL
   size: 754844
   timestamp: 1693928953742
-- name: py-opencv
+- platform: linux-64
+  name: py-opencv
   version: 4.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libopencv: ==4.8.1 py312hd874328_3
-    numpy: '>=1.26.0,<2.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.8.1-py312h8da182e_3.conda
-  hash:
-    md5: 86e3920bf856acbd3db9254c767e990b
-    sha256: bd5e65993be1c1fabdf077276ec13bc5c65ad2e74eda3fadd39b5bc54e53b22f
-  optional: false
   category: main
-  build: py312h8da182e_3
+  manager: conda
+  dependencies:
+  - libopencv 4.8.1 py311h60c0964_3
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.8.1-py311h781c19f_3.conda
+  hash:
+    md5: ce08981066ef28e5b6bcdb2cc48cd318
+    sha256: 793aedde2705e1a2fc3c34b104d2978b00e617f848b0ade524739834a665486c
+  build: py311h781c19f_3
   arch: x86_64
   subdir: linux-64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 1152864
-  timestamp: 1698365984347
-- name: py-opencv
+  size: 1152487
+  timestamp: 1698366059461
+- platform: osx-64
+  name: py-opencv
   version: 4.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libopencv: ==4.8.1 py312h086e99c_3
-    numpy: '>=1.26.0,<2.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/osx-64/py-opencv-4.8.1-py312hdce95a9_3.conda
-  hash:
-    md5: b6c9a993fedc52a742149122b0153180
-    sha256: eefae35b8d55c910c421a7c370fe4effe5e591dbeb5b1c0f85395b3daaf93942
-  optional: false
   category: main
-  build: py312hdce95a9_3
+  manager: conda
+  dependencies:
+  - libopencv 4.8.1 py311h0ef0a85_3
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-64/py-opencv-4.8.1-py311h9bdd199_3.conda
+  hash:
+    md5: f1322dfb54cf8503c3e41f0ffee997f0
+    sha256: 697cb6612de3b83965d2fd83335cf93cd57585e5842a7f96d4e074453bae2c9f
+  build: py311h9bdd199_3
   arch: x86_64
   subdir: osx-64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 1152896
-  timestamp: 1698366629556
-- name: py-opencv
+  size: 1152378
+  timestamp: 1698366526643
+- platform: osx-arm64
+  name: py-opencv
   version: 4.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libopencv: ==4.8.1 py312h494ba3b_3
-    numpy: '>=1.26.0,<2.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.8.1-py312h37858a2_3.conda
-  hash:
-    md5: e25c21e64dec9d6b98ad57bb25c5a08b
-    sha256: 85c3c30d00fb85085744c5c5bb7222515eb3c3cc41b8b1be05e9a688bc306773
-  optional: false
   category: main
-  build: py312h37858a2_3
+  manager: conda
+  dependencies:
+  - libopencv 4.8.1 py311h927bda1_3
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.8.1-py311hf3b2ce4_3.conda
+  hash:
+    md5: 5300c4019cf40d9df0006d5c8fc294b5
+    sha256: 11753cd3764e6f1b9f09d94b55bc78557d0d5ab01b6c57d66ffd9825649bd7e0
+  build: py311hf3b2ce4_3
   arch: aarch64
   subdir: osx-arm64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 1152874
-  timestamp: 1698366694238
-- name: py-opencv
+  size: 1152820
+  timestamp: 1698366913155
+- platform: win-64
+  name: py-opencv
   version: 4.8.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    libopencv: ==4.8.1 py312h55e7661_3
-    numpy: '>=1.26.0,<2.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.* *_cp312
-  url: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.8.1-py312hd42ba9a_3.conda
-  hash:
-    md5: 70ff98e5eca9b771b14eaf9d23111304
-    sha256: 6897d8b24d4987615babf1fa7cf825c8293e6a7e6054d367c203e98dfd3fe33d
-  optional: false
   category: main
-  build: py312hd42ba9a_3
+  manager: conda
+  dependencies:
+  - libopencv 4.8.1 py311h6be31c5_3
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.8.1-py311h3810d55_3.conda
+  hash:
+    md5: 718d0e8a7bc388167383cf39272a892e
+    sha256: 45612f9ce588a09ea1bf90a81a98bb3a7dd1d714316197c01449d588e41137d5
+  build: py311h3810d55_3
   arch: x86_64
   subdir: win-64
   build_number: 3
   license: Apache-2.0
   license_family: Apache
-  size: 1152746
-  timestamp: 1698367149524
-- name: python
-  version: 3.12.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.5.0,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libgcc-ng: '>=12'
-    libnsl: '>=2.0.0,<2.1.0a0'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libuuid: '>=2.38.1,<3.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: '*'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.0-hab00c5b_0_cpython.conda
-  hash:
-    md5: 7f97faab5bebcc2580f4f299285323da
-    sha256: 5398ebae6a1ccbfd3f76361eac75f3ac071527a8072627c4bf9008c689034f48
-  optional: false
+  size: 1152515
+  timestamp: 1698367682190
+- platform: linux-64
+  name: pyarrow
+  version: 10.0.1
   category: main
+  manager: conda
+  dependencies:
+  - gflags >=2.2.2,<2.3.0a0
+  - libarrow 10.0.1 hecbb4c5_50_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-10.0.1-py311hdf9aeb4_50_cpu.conda
+  hash:
+    md5: bf109870d078c79d3b6faa0a3f10e600
+    sha256: c3a63b1142d08d1c2f4bc3a52ab477d55b8605eef9d51a195f19dea3b12dd8be
+  build: py311hdf9aeb4_50_cpu
+  arch: x86_64
+  subdir: linux-64
+  build_number: 50
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  size: 3429125
+  timestamp: 1698344901620
+- platform: osx-64
+  name: pyarrow
+  version: 10.0.1
+  category: main
+  manager: conda
+  dependencies:
+  - gflags >=2.2.2,<2.3.0a0
+  - libarrow 10.0.1 h99c5134_50_cpu
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-10.0.1-py311h0d82e2d_50_cpu.conda
+  hash:
+    md5: ea933b6497a5ab73906dadacc6e355d3
+    sha256: 2c7abdd6045e7daa63a3f5be921a953e7b67bb86b43b89f2dc812b35fc19ca98
+  build: py311h0d82e2d_50_cpu
+  arch: x86_64
+  subdir: osx-64
+  build_number: 50
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  size: 3080651
+  timestamp: 1698345966492
+- platform: osx-arm64
+  name: pyarrow
+  version: 10.0.1
+  category: main
+  manager: conda
+  dependencies:
+  - gflags >=2.2.2,<2.3.0a0
+  - libarrow 10.0.1 h8276777_50_cpu
+  - libcxx >=14.0.6
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-10.0.1-py311h1e679ab_50_cpu.conda
+  hash:
+    md5: 4d4f81c5a82b192d16833de85489b0cd
+    sha256: 2c92bcd29ba43e0309d6948284280d7e15f01024bd14f9a17e56c79cb659f694
+  build: py311h1e679ab_50_cpu
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 50
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  size: 3000928
+  timestamp: 1698344948625
+- platform: win-64
+  name: pyarrow
+  version: 10.0.1
+  category: main
+  manager: conda
+  dependencies:
+  - libarrow 10.0.1 hd2d01ff_50_cpu
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-10.0.1-py311h6a6099b_50_cpu.conda
+  hash:
+    md5: 260ba0f58ad9fd995ad0643aa6d72a78
+    sha256: cb0db5dbfc6b472c6ed49ed49b1a0f0309ead75715ea1f380e46489b8203fc2c
+  build: py311h6a6099b_50_cpu
+  arch: x86_64
+  subdir: win-64
+  build_number: 50
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  size: 2878472
+  timestamp: 1698344639815
+- platform: linux-64
+  name: python
+  version: 3.11.6
+  category: main
+  manager: conda
+  dependencies:
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libnsl >=2.0.0,<2.1.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.6-hab00c5b_0_cpython.conda
+  hash:
+    md5: b0dfbe2fcbfdb097d321bfd50ecddab1
+    sha256: 84f13bd70cff5dcdaee19263b2d4291d5793856a718efc1b63a9cfa9eb6e2ca1
   build: hab00c5b_0_cpython
   arch: x86_64
   subdir: linux-64
   build_number: 0
   constrains:
-  - python_abi 3.12.* *_cp312
+  - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 32123473
-  timestamp: 1696324522323
-- name: python
-  version: 3.12.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: '*'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.0-h30d4d87_0_cpython.conda
-  hash:
-    md5: d11dc8f4551011fb6baa2865f1ead48f
-    sha256: 0a1ed3983acbd0528bef5216179e46170f024f4409032875b27865568fef46a1
-  optional: false
+  size: 30720625
+  timestamp: 1696331287478
+- platform: osx-64
+  name: python
+  version: 3.11.6
   category: main
+  manager: conda
+  dependencies:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.6-h30d4d87_0_cpython.conda
+  hash:
+    md5: 4d66c5fc01e9be526afe5d828d4de24d
+    sha256: e3ed331204fbeb03a9a2c2fa834e74997ad4f732ba2124b36f327d38b0cded93
   build: h30d4d87_0_cpython
   arch: x86_64
   subdir: osx-64
   build_number: 0
   constrains:
-  - python_abi 3.12.* *_cp312
+  - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 14529683
-  timestamp: 1696323482650
-- name: python
-  version: 3.12.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    readline: '>=8.2,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: '*'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.0-h47c9636_0_cpython.conda
-  hash:
-    md5: ed8ae98b1b510de68392971b9367d18c
-    sha256: eb66f8f249caa9d5a956c3a407f079e4779d652ebfc2a4b4f50dcea078e84fa8
-  optional: false
+  size: 15393521
+  timestamp: 1696330855485
+- platform: osx-arm64
+  name: python
+  version: 3.11.6
   category: main
+  manager: conda
+  dependencies:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4,<7.0a0
+  - openssl >=3.1.3,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.6-h47c9636_0_cpython.conda
+  hash:
+    md5: 2271df1db9534f5cac7c2d0820c3359d
+    sha256: 77054fa9a8fc30f71a18f599ee2897905a3c515202b614fa0f793add7a04a155
   build: h47c9636_0_cpython
   arch: aarch64
   subdir: osx-arm64
   build_number: 0
   constrains:
-  - python_abi 3.12.* *_cp312
+  - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 13306758
-  timestamp: 1696322682581
-- name: python
-  version: 3.12.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.43.0,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: '*'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.0-h2628c8c_0_cpython.conda
-  hash:
-    md5: defd5d375853a2caff36a19d2d81a28e
-    sha256: 90553586879bf328f2f9efb8d8faa958ecba822faf379f0a20c3461467b9b955
-  optional: false
+  size: 14626958
+  timestamp: 1696329727433
+- platform: win-64
+  name: python
+  version: 3.11.6
   category: main
+  manager: conda
+  dependencies:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.43.0,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.6-h2628c8c_0_cpython.conda
+  hash:
+    md5: 80b761856b20383615a3fe8b1b13eef8
+    sha256: 7fb38fda8296b2651ef727bb57603f0952c07fc533b172044395744a2641a00a
   build: h2628c8c_0_cpython
   arch: x86_64
   subdir: win-64
   build_number: 0
   constrains:
-  - python_abi 3.12.* *_cp312
+  - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 16140836
-  timestamp: 1696321871976
-- name: python_abi
-  version: '3.12'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
-  hash:
-    md5: dccc2d142812964fcc6abdc97b672dff
-    sha256: 182a329de10a4165f6e8a3804caf751f918f6ea6176dd4e5abcdae1ed3095bf6
-  optional: false
+  size: 18121128
+  timestamp: 1696329396864
+- platform: linux-64
+  name: python_abi
+  version: '3.11'
   category: main
-  build: 4_cp312
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-4_cp311.conda
+  hash:
+    md5: d786502c97404c94d7d58d258a445a65
+    sha256: 0be3ac1bf852d64f553220c7e6457e9c047dfb7412da9d22fbaa67e60858b3cf
+  build: 4_cp311
   arch: x86_64
   subdir: linux-64
   build_number: 4
   constrains:
-  - python 3.12.* *_cpython
+  - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
   size: 6385
-  timestamp: 1695147396604
-- name: python_abi
-  version: '3.12'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
-  hash:
-    md5: 87201ac4314b911b74197e588cca3639
-    sha256: 82c154d95c1637604671a02a89e72f1382e89a4269265a03506496bd928f6f14
-  optional: false
+  timestamp: 1695147338551
+- platform: osx-64
+  name: python_abi
+  version: '3.11'
   category: main
-  build: 4_cp312
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-4_cp311.conda
+  hash:
+    md5: fef7a52f0eca6bae9e8e2e255bc86394
+    sha256: f56dfe2a57b3b27bad3f9527f943548e8b2526e949d9d6fc0a383020d9359afe
+  build: 4_cp311
   arch: x86_64
   subdir: osx-64
   build_number: 4
   constrains:
-  - python 3.12.* *_cpython
+  - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6496
-  timestamp: 1695147498447
-- name: python_abi
-  version: '3.12'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
-  hash:
-    md5: bbb3a02c78b2d8219d7213f76d644a2a
-    sha256: db25428e4f24f8693ffa39f3ff6dfbb8fd53bc298764b775b57edab1c697560f
-  optional: false
+  size: 6478
+  timestamp: 1695147518012
+- platform: osx-arm64
+  name: python_abi
+  version: '3.11'
   category: main
-  build: 4_cp312
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-4_cp311.conda
+  hash:
+    md5: 8d3751bc73d3bbb66f216fa2331d5649
+    sha256: 4837089c477b9b84fa38a17f453e6634e68237267211b27a8a2f5ccd847f4e55
+  build: 4_cp311
   arch: aarch64
   subdir: osx-arm64
   build_number: 4
   constrains:
-  - python 3.12.* *_cpython
+  - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6508
-  timestamp: 1695147497048
-- name: python_abi
-  version: '3.12'
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
-  hash:
-    md5: 17f4ccf6be9ded08bd0a376f489ac1a6
-    sha256: 488f8519d04b48f59bd6fde21ebe2d7a527718ff28aac86a8b53aa63658bdef6
-  optional: false
+  size: 6492
+  timestamp: 1695147509940
+- platform: win-64
+  name: python_abi
+  version: '3.11'
   category: main
-  build: 4_cp312
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-4_cp311.conda
+  hash:
+    md5: 70513332c71b56eace4ee6441e66c012
+    sha256: 67c2aade3e2160642eec0742384e766b20c766055e3d99335681e3e05d88ed7b
+  build: 4_cp311
   arch: x86_64
   subdir: win-64
   build_number: 4
   constrains:
-  - python 3.12.* *_cpython
+  - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6785
-  timestamp: 1695147430513
-- name: qt-main
+  size: 6755
+  timestamp: 1695147711935
+- platform: linux-64
+  name: qt-main
   version: 5.15.8
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    alsa-lib: '>=1.2.10,<1.2.11.0a0'
-    dbus: '>=1.13.6,<2.0a0'
-    fontconfig: '>=2.14.2,<3.0a0'
-    fonts-conda-ecosystem: '*'
-    freetype: '>=2.12.1,<3.0a0'
-    gst-plugins-base: '>=1.22.6,<1.23.0a0'
-    gstreamer: '>=1.22.6,<1.23.0a0'
-    harfbuzz: '>=8.2.1,<9.0a0'
-    icu: '>=73.2,<74.0a0'
-    krb5: '>=1.21.2,<1.22.0a0'
-    libclang: '>=15.0.7,<16.0a0'
-    libclang13: '>=15.0.7'
-    libcups: '>=2.3.3,<2.4.0a0'
-    libevent: '>=2.1.12,<2.1.13.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
-    libgcc-ng: '>=12'
-    libglib: '>=2.78.0,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libpq: '>=16.0,<17.0a0'
-    libsqlite: '>=3.43.2,<4.0a0'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    libxkbcommon: '>=1.6.0,<2.0a0'
-    libxml2: '>=2.11.5,<2.12.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    mysql-libs: '>=8.0.33,<8.1.0a0'
-    nspr: '>=4.35,<5.0a0'
-    nss: '>=3.94,<4.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    pulseaudio-client: '>=16.1,<16.2.0a0'
-    xcb-util: '>=0.4.0,<0.5.0a0'
-    xcb-util-image: '>=0.4.0,<0.5.0a0'
-    xcb-util-keysyms: '>=0.4.0,<0.5.0a0'
-    xcb-util-renderutil: '>=0.3.9,<0.4.0a0'
-    xcb-util-wm: '>=0.4.1,<0.5.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
-    xorg-libsm: '>=1.2.4,<2.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-xf86vidmodeproto: '*'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - __glibc >=2.17,<3.0.a0
+  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - dbus >=1.13.6,<2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem *
+  - freetype >=2.12.1,<3.0a0
+  - gst-plugins-base >=1.22.6,<1.23.0a0
+  - gstreamer >=1.22.6,<1.23.0a0
+  - harfbuzz >=8.2.1,<9.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libcups >=2.3.3,<2.4.0a0
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libexpat >=2.5.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.78.0,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libpq >=16.0,<17.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxkbcommon >=1.6.0,<2.0a0
+  - libxml2 >=2.11.5,<2.12.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - mysql-libs >=8.0.33,<8.1.0a0
+  - nspr >=4.35,<5.0a0
+  - nss >=3.94,<4.0a0
+  - openssl >=3.1.3,<4.0a0
+  - pulseaudio-client >=16.1,<16.2.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
+  - xcb-util-image >=0.4.0,<0.5.0a0
+  - xcb-util-keysyms >=0.4.0,<0.5.0a0
+  - xcb-util-renderutil >=0.3.9,<0.4.0a0
+  - xcb-util-wm >=0.4.1,<0.5.0a0
+  - xorg-libice >=1.1.1,<2.0a0
+  - xorg-libsm >=1.2.4,<2.0a0
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-xf86vidmodeproto *
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h82b777d_17.conda
   hash:
     md5: 4f01e33dbb406085a16a2813ab067e95
     sha256: 4c3d2b37b00a0a84b9674e88b636e10817ae2c23f5af27bbe77cf4f46f3a4225
-  optional: false
-  category: main
   build: h82b777d_17
   arch: x86_64
   subdir: linux-64
@@ -10363,33 +13167,32 @@ package:
   license_family: LGPL
   size: 61143429
   timestamp: 1696995668228
-- name: qt-main
+- platform: win-64
+  name: qt-main
   version: 5.15.8
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    gst-plugins-base: '>=1.22.6,<1.23.0a0'
-    gstreamer: '>=1.22.6,<1.23.0a0'
-    icu: '>=73.2,<74.0a0'
-    krb5: '>=1.21.2,<1.22.0a0'
-    libclang: '>=15.0.7,<16.0a0'
-    libclang13: '>=15.0.7'
-    libglib: '>=2.78.0,<3.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.39,<1.7.0a0'
-    libsqlite: '>=3.43.2,<4.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.1.3,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    zstd: '>=1.5.5,<1.6.0a0'
+  - gst-plugins-base >=1.22.6,<1.23.0a0
+  - gstreamer >=1.22.6,<1.23.0a0
+  - icu >=73.2,<74.0a0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libclang >=15.0.7,<16.0a0
+  - libclang13 >=15.0.7
+  - libglib >=2.78.0,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.39,<1.7.0a0
+  - libsqlite >=3.43.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.1.3,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
   url: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_17.conda
   hash:
     md5: 568b134e26f3e2a44ff24028c27b8c0e
     sha256: ca624ec9c0d07d2c61b7007661b10111c2f3bb38bcc6175a459f4a5180a5748d
-  optional: false
-  category: main
   build: h9e85ed6_17
   arch: x86_64
   subdir: win-64
@@ -10400,19 +13203,115 @@ package:
   license_family: LGPL
   size: 60395805
   timestamp: 1697003065087
-- name: readline
-  version: '8.2'
+- platform: linux-64
+  name: rdma-core
+  version: '28.9'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    ncurses: '>=6.3,<7.0a0'
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
+  hash:
+    md5: aeffb7c06b5f65e55e6c637408dc4100
+    sha256: 832f9393ab3144ce6468c6f150db9d398fad4451e96a8879afb3059f0c9902f6
+  build: h59595ed_1
+  arch: x86_64
+  subdir: linux-64
+  build_number: 1
+  license: Linux-OpenIB
+  license_family: BSD
+  size: 3735644
+  timestamp: 1684785130341
+- platform: linux-64
+  name: re2
+  version: 2023.06.02
+  category: main
+  manager: conda
+  dependencies:
+  - libre2-11 2023.06.02 h7a70373_0
+  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.06.02-h2873b5e_0.conda
+  hash:
+    md5: bb2d5e593ef13fe4aff0bc9440f945ae
+    sha256: 3e0bfb04b6d43312d711c5b49dbc3c7660b2e6e681ed504b1b322794462a1bcd
+  build: h2873b5e_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 26953
+  timestamp: 1697065840782
+- platform: osx-64
+  name: re2
+  version: 2023.06.02
+  category: main
+  manager: conda
+  dependencies:
+  - libre2-11 2023.06.02 h4694dbf_0
+  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.06.02-hd34609a_0.conda
+  hash:
+    md5: e498042c254db56d398b6ee858888b9d
+    sha256: dd749346b868ac9a8765cd18e102f808103330b3fc1fac5d267fbf4257ea31c9
+  build: hd34609a_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27005
+  timestamp: 1697065900029
+- platform: osx-arm64
+  name: re2
+  version: 2023.06.02
+  category: main
+  manager: conda
+  dependencies:
+  - libre2-11 2023.06.02 h1753957_0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
+  hash:
+    md5: 8f23674174b155300696a2be8b5c1407
+    sha256: 963847258a82d9647311c5eb8829a49ac2161df12a304d5d6e61f788f0563442
+  build: h6135d0a_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 27073
+  timestamp: 1697065856329
+- platform: win-64
+  name: re2
+  version: 2023.06.02
+  category: main
+  manager: conda
+  dependencies:
+  - libre2-11 2023.06.02 h8c5ae5e_0
+  url: https://conda.anaconda.org/conda-forge/win-64/re2-2023.06.02-hcbb65ff_0.conda
+  hash:
+    md5: aabaf2fe639029a25b39b6b14a1aa760
+    sha256: 97cfa7fe2e4111bd0915b8e14f1f1a00ee3fab14758ac89620c5e119c668e5b8
+  build: hcbb65ff_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 203957
+  timestamp: 1697066138562
+- platform: linux-64
+  name: readline
+  version: '8.2'
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - ncurses >=6.3,<7.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
   hash:
     md5: 47d31b792659ce70f470b5c82fdfb7a4
     sha256: 5435cf39d039387fbdc977b0a762357ea909a7694d9528ab40f005e9208744d7
-  optional: false
-  category: main
   build: h8228510_1
   arch: x86_64
   subdir: linux-64
@@ -10421,18 +13320,17 @@ package:
   license_family: GPL
   size: 281456
   timestamp: 1679532220005
-- name: readline
+- platform: osx-64
+  name: readline
   version: '8.2'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    ncurses: '>=6.3,<7.0a0'
+  - ncurses >=6.3,<7.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
   hash:
     md5: f17f77f2acf4d344734bda76829ce14e
     sha256: 41e7d30a097d9b060037f0c6a2b1d4c4ae7e942c06c943d23f9d481548478568
-  optional: false
-  category: main
   build: h9e318b2_1
   arch: x86_64
   subdir: osx-64
@@ -10441,18 +13339,17 @@ package:
   license_family: GPL
   size: 255870
   timestamp: 1679532707590
-- name: readline
+- platform: osx-arm64
+  name: readline
   version: '8.2'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    ncurses: '>=6.3,<7.0a0'
+  - ncurses >=6.3,<7.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
   hash:
     md5: 8cbb776a2f641b943d413b3e19df71f4
     sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
-  optional: false
-  category: main
   build: h92ec313_1
   arch: aarch64
   subdir: osx-arm64
@@ -10461,18 +13358,125 @@ package:
   license_family: GPL
   size: 250351
   timestamp: 1679532511311
-- name: rhash
-  version: 1.4.4
+- platform: linux-64
+  name: rerun-sdk
+  version: 0.10.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - attrs >=23.1.0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.23
+  - pillow
+  - pyarrow 10.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions >=4.5
+  url: https://conda.anaconda.org/conda-forge/linux-64/rerun-sdk-0.10.0-py311hb755f60_0.conda
+  hash:
+    md5: 8b12222c94c216fe71a08e8f71d97f3a
+    sha256: 666da5a2c247f7d9cd5f545c4d94f496b99b8f1e4f3be8ca01c2eeeb24e1917f
+  build: py311hb755f60_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: MIT OR Apache-2.0
+  size: 15365158
+  timestamp: 1698695374652
+- platform: osx-64
+  name: rerun-sdk
+  version: 0.10.0
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.12
+  - __osx >=10.9
+  - attrs >=23.1.0
+  - libcxx >=16.0.6
+  - numpy >=1.23
+  - pillow
+  - pyarrow 10.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions >=4.5
+  url: https://conda.anaconda.org/conda-forge/osx-64/rerun-sdk-0.10.0-py311h7834347_0.conda
+  hash:
+    md5: 69ca38bd7851d059d0f3be62409acfe9
+    sha256: cecf6ff86d7edfefc25aa009ec891f653c8e245c8e99dd479ef69387535dc154
+  build: py311h7834347_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT OR Apache-2.0
+  size: 12177894
+  timestamp: 1698696777129
+- platform: osx-arm64
+  name: rerun-sdk
+  version: 0.10.0
+  category: main
+  manager: conda
+  dependencies:
+  - __osx >=10.12
+  - __osx >=10.9
+  - attrs >=23.1.0
+  - libcxx >=16.0.6
+  - numpy >=1.23
+  - pillow
+  - pyarrow 10.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - typing_extensions >=4.5
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rerun-sdk-0.10.0-py311h1f7c971_0.conda
+  hash:
+    md5: 5cdad07b5829c8e777169d11126890f7
+    sha256: d5f7b4ef0fed0fd80a37a758b7f84ecf12caeab52499e0be100cb840f90897a8
+  build: py311h1f7c971_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT OR Apache-2.0
+  size: 11726480
+  timestamp: 1698695877790
+- platform: win-64
+  name: rerun-sdk
+  version: 0.10.0
+  category: main
+  manager: conda
+  dependencies:
+  - attrs >=23.1.0
+  - numpy >=1.23
+  - pillow
+  - pyarrow 10.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - typing_extensions >=4.5
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  url: https://conda.anaconda.org/conda-forge/win-64/rerun-sdk-0.10.0-py311h12c1d0e_0.conda
+  hash:
+    md5: 9a3284a1e4e8deb6268b5bd9365e3f5f
+    sha256: 15c0124455c352bd9e72ca7a2378ff2bdcc224b3a524dd7de0316a666db8e56d
+  build: py311h12c1d0e_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT OR Apache-2.0
+  size: 11294791
+  timestamp: 1698697622803
+- platform: linux-64
+  name: rhash
+  version: 1.4.4
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
   hash:
     md5: ec972a9a2925ac8d7a19eb9606561fff
     sha256: 12711d2d4a808a503c2e49b25d26ecb351435521e814c154e682dd2be71c2611
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -10481,17 +13485,16 @@ package:
   license_family: MIT
   size: 185144
   timestamp: 1693455923632
-- name: rhash
+- platform: osx-64
+  name: rhash
   version: 1.4.4
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
   hash:
     md5: 55a2ada70c8a208c01f77978f2783121
     sha256: f1ae47e8c4e46f856faf5d8ee1e5291f55627aa93401b61a877f18ade5780c87
-  optional: false
-  category: main
   build: h0dc2134_0
   arch: x86_64
   subdir: osx-64
@@ -10500,17 +13503,16 @@ package:
   license_family: MIT
   size: 177229
   timestamp: 1693456080514
-- name: rhash
+- platform: osx-arm64
+  name: rhash
   version: 1.4.4
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
   hash:
     md5: 710c4b1abf65b697c1d9716eba16dbb0
     sha256: 3ab595e2280ed2118b6b1e8ce7e5949da2047846c81b6af1bbf5ac859d062edd
-  optional: false
-  category: main
   build: hb547adb_0
   arch: aarch64
   subdir: osx-arm64
@@ -10519,18 +13521,37 @@ package:
   license_family: MIT
   size: 177491
   timestamp: 1693456037505
-- name: sigtool
-  version: 0.1.3
+- platform: linux-64
+  name: s2n
+  version: 1.3.55
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    openssl: '>=3.0.0,<4.0a0'
+  - libgcc-ng >=12
+  - openssl >=3.1.3,<4.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.55-h06160fa_0.conda
+  hash:
+    md5: 8cdfb7d58bdfd543717eeacc0801f3c0
+    sha256: d9b8c7f6dcab6c34c9eec7dae8aa05ec0ad79365ff5512456f19fa35c5084ecf
+  build: h06160fa_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: Apache-2.0
+  license_family: Apache
+  size: 387282
+  timestamp: 1697620087705
+- platform: osx-64
+  name: sigtool
+  version: 0.1.3
+  category: main
+  manager: conda
+  dependencies:
+  - openssl >=3.0.0,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
   hash:
     md5: fbfb84b9de9a6939cb165c02c69b1865
     sha256: 46fdeadf8f8d725819c4306838cdfd1099cd8fe3e17bd78862a5dfdcd6de61cf
-  optional: false
-  category: main
   build: h88f4db0_0
   arch: x86_64
   subdir: osx-64
@@ -10539,18 +13560,17 @@ package:
   license_family: MIT
   size: 213817
   timestamp: 1643442169866
-- name: sigtool
+- platform: osx-arm64
+  name: sigtool
   version: 0.1.3
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    openssl: '>=3.0.0,<4.0a0'
+  - openssl >=3.0.0,<4.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
   hash:
     md5: 4a2cac04f86a4540b8c9b8d8f597848f
     sha256: 70791ae00a3756830cb50451db55f63e2a42a2fa2a8f1bab1ebd36bbb7d55bff
-  optional: false
-  category: main
   build: h44b9a77_0
   arch: aarch64
   subdir: osx-arm64
@@ -10559,19 +13579,18 @@ package:
   license_family: MIT
   size: 210264
   timestamp: 1643442231687
-- name: snappy
+- platform: linux-64
+  name: snappy
   version: 1.1.10
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
   hash:
     md5: e6d228cd0bb74a51dd18f5bfce0b4115
     sha256: 02219f2382b4fe39250627dade087a4412d811936a5a445636b7260477164eac
-  optional: false
-  category: main
   build: h9fff704_0
   arch: x86_64
   subdir: linux-64
@@ -10580,18 +13599,17 @@ package:
   license_family: BSD
   size: 38865
   timestamp: 1678534590321
-- name: snappy
+- platform: osx-64
+  name: snappy
   version: 1.1.10
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
   hash:
     md5: 4320a8781f14cd959689b86e349f3b73
     sha256: 575915dc13152e446a84e2f88de70a14f8b6af1a870e708f9370bd4be105583b
-  optional: false
-  category: main
   build: h225ccf5_0
   arch: x86_64
   subdir: osx-64
@@ -10600,18 +13618,17 @@ package:
   license_family: BSD
   size: 34657
   timestamp: 1678534768395
-- name: snappy
+- platform: osx-arm64
+  name: snappy
   version: 1.1.10
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=14.0.6'
+  - libcxx >=14.0.6
   url: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
   hash:
     md5: ac82a611d1a67a598096ebaa857198e3
     sha256: dfae03cd2339587871e53b42833657faa4c9e42e3e2c56ee9e32bc60797c7f62
-  optional: false
-  category: main
   build: h17c5cce_0
   arch: aarch64
   subdir: osx-arm64
@@ -10620,20 +13637,19 @@ package:
   license_family: BSD
   size: 33879
   timestamp: 1678534968831
-- name: snappy
+- platform: win-64
+  name: snappy
   version: 1.1.10
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vs2015_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
   hash:
     md5: cff1df79c9cff719460eb2dd172568de
     sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
-  optional: false
-  category: main
   build: hfb803bf_0
   arch: x86_64
   subdir: win-64
@@ -10642,19 +13658,18 @@ package:
   license_family: BSD
   size: 57065
   timestamp: 1678534804734
-- name: svt-av1
+- platform: linux-64
+  name: svt-av1
   version: 1.7.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.7.0-h59595ed_0.conda
   hash:
     md5: b6e0b4f1edc2740d1cf87669195c39d4
     sha256: e79878bba3b013db1b59766895a182dd12d2e1a45e24c01b61b4e922ed8500b6
-  optional: false
-  category: main
   build: h59595ed_0
   arch: x86_64
   subdir: linux-64
@@ -10663,18 +13678,17 @@ package:
   license_family: BSD
   size: 2641420
   timestamp: 1692966629866
-- name: svt-av1
+- platform: osx-64
+  name: svt-av1
   version: 1.7.0
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.7.0-he965462_0.conda
   hash:
     md5: 0f15584eeb93b270ac297cc3990d5e95
     sha256: dd56ba8b8a885df0b0c261929781b22ce41b765439dd334b680812443ae53ace
-  optional: false
-  category: main
   build: he965462_0
   arch: x86_64
   subdir: osx-64
@@ -10683,18 +13697,17 @@ package:
   license_family: BSD
   size: 2429529
   timestamp: 1692967052961
-- name: svt-av1
+- platform: osx-arm64
+  name: svt-av1
   version: 1.7.0
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
+  - libcxx >=15.0.7
   url: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.7.0-hb765f3a_0.conda
   hash:
     md5: e90a180c1ad53fe8e170db74e544cbf6
     sha256: 70feb55a556e2561132fc8c7a69148d79e3afb58bb251980c6608bf789b00cf9
-  optional: false
-  category: main
   build: hb765f3a_0
   arch: aarch64
   subdir: osx-arm64
@@ -10703,20 +13716,19 @@ package:
   license_family: BSD
   size: 1229909
   timestamp: 1692967009529
-- name: svt-av1
+- platform: win-64
+  name: svt-av1
   version: 1.7.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.7.0-h63175ca_0.conda
   hash:
     md5: fe5d2314e6fc3be8f8e3e2e73c14ab02
     sha256: 3d52d959e9b4e4654c36d03765fb4e8dbebfc1d17f271a46033bf301737a25cc
-  optional: false
-  category: main
   build: h63175ca_0
   arch: x86_64
   subdir: win-64
@@ -10725,18 +13737,17 @@ package:
   license_family: BSD
   size: 2353906
   timestamp: 1692967156046
-- name: sysroot_linux-64
+- platform: linux-64
+  name: sysroot_linux-64
   version: '2.12'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    kernel-headers_linux-64: ==2.6.32 he073ed8_16
+  - kernel-headers_linux-64 ==2.6.32 he073ed8_16
   url: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
   hash:
     md5: 071ea8dceff4d30ac511f4a2f8437cd1
     sha256: 4c024b2eee24c6da7d3e08723111ec02665c578844c5b3e9e6b38f89000bec41
-  optional: false
-  category: main
   build: he073ed8_16
   arch: x86_64
   subdir: linux-64
@@ -10746,18 +13757,17 @@ package:
   noarch: generic
   size: 15277813
   timestamp: 1689214980563
-- name: tapi
+- platform: osx-64
+  name: tapi
   version: 1100.0.11
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=10.0.0.a0'
+  - libcxx >=10.0.0.a0
   url: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
   hash:
     md5: f9ff42ccf809a21ba6f8607f8de36108
     sha256: 34b18ce8d1518b67e333ca1d3af733c3976ecbdf3a36b727f9b4dedddcc588fa
-  optional: false
-  category: main
   build: h9ce4665_0
   arch: x86_64
   subdir: osx-64
@@ -10766,18 +13776,17 @@ package:
   license_family: MIT
   size: 201044
   timestamp: 1602664232074
-- name: tapi
+- platform: osx-arm64
+  name: tapi
   version: 1100.0.11
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=11.0.0.a0'
+  - libcxx >=11.0.0.a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
   hash:
     md5: d83362e7d0513f35f454bc50b0ca591d
     sha256: 1709265fbee693a9e8b4126b0a3e68a6c4718b05821c659279c1af051f2d40f3
-  optional: false
-  category: main
   build: he4954df_0
   arch: aarch64
   subdir: osx-arm64
@@ -10786,20 +13795,19 @@ package:
   license_family: MIT
   size: 191416
   timestamp: 1602687595316
-- name: tbb
+- platform: linux-64
+  name: tbb
   version: 2021.10.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libhwloc: '>=2.9.3,<2.9.4.0a0'
-    libstdcxx-ng: '>=12'
+  - libgcc-ng >=12
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - libstdcxx-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.10.0-h00ab1b0_2.conda
   hash:
     md5: eb0d5c122f42714f86a7058d1ce7b2e6
     sha256: 79a6c48fa1df661af7ab3e4f5fa444dd305d87921be017413a8b97fd6d642328
-  optional: false
-  category: main
   build: h00ab1b0_2
   arch: x86_64
   subdir: linux-64
@@ -10808,17 +13816,16 @@ package:
   license_family: APACHE
   size: 186022
   timestamp: 1697713416932
-- name: tbb
+- platform: osx-64
+  name: tbb
   version: 2021.10.0
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.10.0-h1c7c39f_2.conda
   hash:
     md5: 73434bcf87082942e938352afae9b0fa
     sha256: 81e3fae041696a9a74d493e49ab08ceda0022b4bd3716c1d88c0dae5435af94a
-  optional: false
-  category: main
   build: h1c7c39f_2
   arch: x86_64
   subdir: osx-64
@@ -10827,17 +13834,16 @@ package:
   license_family: APACHE
   size: 159786
   timestamp: 1697713666733
-- name: tbb
+- platform: osx-arm64
+  name: tbb
   version: 2021.10.0
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.10.0-h1995070_2.conda
   hash:
     md5: 245760f53d4fa23bfb58ffbf89a4edc8
     sha256: 5acedf2ba0d18217a6387f4788086e51cac56cef12ac120335fc3b31d40c0417
-  optional: false
-  category: main
   build: h1995070_2
   arch: aarch64
   subdir: osx-arm64
@@ -10846,21 +13852,20 @@ package:
   license_family: APACHE
   size: 125356
   timestamp: 1697713774680
-- name: tbb
+- platform: win-64
+  name: tbb
   version: 2021.10.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libhwloc: '>=2.9.3,<2.9.4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
   hash:
     md5: 5b8c97cf8f0e81d6c22c0bda9978790d
     sha256: e55a2f1324f0fc8916ab8d590a3944ba1af62de727bb66e3019cf2744d26e679
-  optional: false
-  category: main
   build: h91493d7_2
   arch: x86_64
   subdir: win-64
@@ -10869,19 +13874,18 @@ package:
   license_family: APACHE
   size: 156566
   timestamp: 1697713986066
-- name: tk
+- platform: linux-64
+  name: tk
   version: 8.6.13
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
   hash:
     md5: 513336054f884f95d9fd925748f41ef3
     sha256: 679e944eb93fde45d0963a22598fafacbb429bb9e7ee26009ba81c4e0c435055
-  optional: false
-  category: main
   build: h2797004_0
   arch: x86_64
   subdir: linux-64
@@ -10890,18 +13894,17 @@ package:
   license_family: BSD
   size: 3290187
   timestamp: 1695506262576
-- name: tk
+- platform: osx-64
+  name: tk
   version: 8.6.13
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
   hash:
     md5: 0c25eedcc888b6d765948ab62a18c03e
     sha256: 573e5d7dde0a63b06ceef2c574295cbc2ec8668ec08e35d2f2c6220f4aa7fb98
-  optional: false
-  category: main
   build: hef22860_0
   arch: x86_64
   subdir: osx-64
@@ -10910,18 +13913,17 @@ package:
   license_family: BSD
   size: 3273909
   timestamp: 1695506576288
-- name: tk
+- platform: osx-arm64
+  name: tk
   version: 8.6.13
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
   hash:
     md5: aa913a828b65f30ee3aba9c59bb0b514
     sha256: 6df6ff49dba487eb891ddc0099642a36af2fe3929ed8023f76b745f0485c54a6
-  optional: false
-  category: main
   build: hb31c410_0
   arch: aarch64
   subdir: osx-arm64
@@ -10930,20 +13932,19 @@ package:
   license_family: BSD
   size: 3223549
   timestamp: 1695506653047
-- name: tk
+- platform: win-64
+  name: tk
   version: 8.6.13
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
   hash:
     md5: 74405f2ccbb40af409fee1a71ce70dc6
     sha256: 7e42db6b5f1c5ef8d4660e6ce41b52802b6c2fdc270d5e1eccc0048d0a3f03a8
-  optional: false
-  category: main
   build: hcfcfb64_0
   arch: x86_64
   subdir: win-64
@@ -10952,17 +13953,96 @@ package:
   license_family: BSD
   size: 3478482
   timestamp: 1695506766462
-- name: tzdata
-  version: 2023c
+- platform: linux-64
+  name: typing_extensions
+  version: 4.8.0
+  category: main
   manager: conda
-  platform: linux-64
-  dependencies: {}
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  hash:
+    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  build: pyha770c72_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  license: PSF-2.0
+  license_family: PSF
+  noarch: python
+  size: 35108
+  timestamp: 1695040948828
+- platform: osx-64
+  name: typing_extensions
+  version: 4.8.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  hash:
+    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  build: pyha770c72_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: PSF-2.0
+  license_family: PSF
+  noarch: python
+  size: 35108
+  timestamp: 1695040948828
+- platform: osx-arm64
+  name: typing_extensions
+  version: 4.8.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  hash:
+    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  build: pyha770c72_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: PSF-2.0
+  license_family: PSF
+  noarch: python
+  size: 35108
+  timestamp: 1695040948828
+- platform: win-64
+  name: typing_extensions
+  version: 4.8.0
+  category: main
+  manager: conda
+  dependencies:
+  - python >=3.8
+  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.8.0-pyha770c72_0.conda
+  hash:
+    md5: 5b1be40a26d10a06f6d4f1f9e19fa0c7
+    sha256: 38d16b5c53ec1af845d37d22e7bb0e6c934c7f19499123507c5a470f6f8b7dde
+  build: pyha770c72_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: PSF-2.0
+  license_family: PSF
+  noarch: python
+  size: 35108
+  timestamp: 1695040948828
+- platform: linux-64
+  name: tzdata
+  version: 2023c
+  category: main
+  manager: conda
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: x86_64
   subdir: linux-64
@@ -10971,17 +14051,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: tzdata
+- platform: osx-64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: x86_64
   subdir: osx-64
@@ -10990,17 +14069,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: tzdata
+- platform: osx-arm64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: aarch64
   subdir: osx-arm64
@@ -11009,17 +14087,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: tzdata
+- platform: win-64
+  name: tzdata
   version: 2023c
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
   hash:
     md5: 939e3e74d8be4dac89ce83b20de2492a
     sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  optional: false
-  category: main
   build: h71feb2d_0
   arch: x86_64
   subdir: win-64
@@ -11028,17 +14105,16 @@ package:
   noarch: generic
   size: 117580
   timestamp: 1680041306008
-- name: ucrt
+- platform: win-64
+  name: ucrt
   version: 10.0.22621.0
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
   hash:
     md5: 72608f6cd3e5898229c3ea16deb1ac43
     sha256: f29cdaf8712008f6b419b8b1a403923b00ab2504bfe0fb2ba8eb60e72d4f14c6
-  optional: false
-  category: main
   build: h57928b3_0
   arch: x86_64
   subdir: win-64
@@ -11049,40 +14125,61 @@ package:
   license_family: PROPRIETARY
   size: 1283972
   timestamp: 1666630199266
-- name: vc
-  version: '14.3'
+- platform: linux-64
+  name: ucx
+  version: 1.15.0
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc14_runtime: '>=14.36.32532'
+  - libgcc-ng >=12
+  - libnuma >=2.0.16,<3.0a0
+  - libstdcxx-ng >=12
+  - rdma-core >=28.9,<29.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h64cca9d_0.conda
+  hash:
+    md5: b35b1f1a9fdbf93266c91f297dc9060e
+    sha256: 8a4dce10304fee0df715addec3d078421aa7aa0824422a6630d621d15bd98e5f
+  build: h64cca9d_0
+  arch: x86_64
+  subdir: linux-64
+  build_number: 0
+  constrains:
+  - cuda-version >=11.2,<12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15425900
+  timestamp: 1696028080367
+- platform: win-64
+  name: vc
+  version: '14.3'
+  category: main
+  manager: conda
+  dependencies:
+  - vc14_runtime >=14.36.32532
   url: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
   hash:
     md5: 67ff6791f235bb606659bf2a5c169191
     sha256: 86ae94bf680980776aa761c2b0909a0ddbe1f817e7eeb8b16a1730f10f8891b6
-  optional: false
-  category: main
   build: h64f974e_17
   arch: x86_64
   subdir: win-64
   build_number: 17
-  track_features:
-  - vc14
+  track_features: vc14
   license: BSD-3-Clause
   license_family: BSD
   size: 17176
   timestamp: 1688020629925
-- name: vc14_runtime
+- platform: win-64
+  name: vc14_runtime
   version: 14.36.32532
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    ucrt: '>=10.0.20348.0'
+  - ucrt >=10.0.20348.0
   url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
   hash:
     md5: d0de20f2f3fc806a81b44fcdd941aaf7
     sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
-  optional: false
-  category: main
   build: hdcecf7f_17
   arch: x86_64
   subdir: win-64
@@ -11093,18 +14190,17 @@ package:
   license_family: Proprietary
   size: 739437
   timestamp: 1694292382336
-- name: vs2015_runtime
+- platform: win-64
+  name: vs2015_runtime
   version: 14.36.32532
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc14_runtime: '>=14.36.32532'
+  - vc14_runtime >=14.36.32532
   url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
   hash:
     md5: 4618046c39f7c81861e53ded842e738a
     sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
-  optional: false
-  category: main
   build: h05e6639_17
   arch: x86_64
   subdir: win-64
@@ -11113,39 +14209,36 @@ package:
   license_family: BSD
   size: 17207
   timestamp: 1688020635322
-- name: vs2022_win-64
+- platform: win-64
+  name: vs2022_win-64
   version: 19.37.32822
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vswhere: '*'
+  - vswhere *
   url: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
   hash:
     md5: 8b02594cf497f7516a3ed20a164de75e
     sha256: 259b5d4ac07b131bf15bf1a2d101eb9eb039e32cfef57de79061cb4c8f1889fe
-  optional: false
-  category: main
   build: h0123c8e_17
   arch: x86_64
   subdir: win-64
   build_number: 17
-  track_features:
-  - vc14
+  track_features: vc14
   license: BSD-3-Clause
   license_family: BSD
   size: 19405
   timestamp: 1694292390059
-- name: vswhere
+- platform: win-64
+  name: vswhere
   version: 3.1.4
+  category: main
   manager: conda
-  platform: win-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
   hash:
     md5: b1d1d6a1f874d8c93a57b5efece52f03
     sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
-  optional: false
-  category: main
   build: h57928b3_0
   arch: x86_64
   subdir: win-64
@@ -11154,18 +14247,17 @@ package:
   license_family: MIT
   size: 218421
   timestamp: 1682376911339
-- name: x264
+- platform: linux-64
+  name: x264
   version: 1!164.3095
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
   hash:
     md5: 6c99772d483f566d59e25037fea2c4b1
     sha256: 175315eb3d6ea1f64a6ce470be00fa2ee59980108f246d3072ab8b977cb048a5
-  optional: false
-  category: main
   build: h166bdaf_2
   arch: x86_64
   subdir: linux-64
@@ -11174,17 +14266,16 @@ package:
   license_family: GPL
   size: 897548
   timestamp: 1660323080555
-- name: x264
+- platform: osx-64
+  name: x264
   version: 1!164.3095
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
   hash:
     md5: 23e9c3180e2c0f9449bb042914ec2200
     sha256: de611da29f4ed0733a330402e163f9260218e6ba6eae593a5f945827d0ee1069
-  optional: false
-  category: main
   build: h775f41a_2
   arch: x86_64
   subdir: osx-64
@@ -11193,17 +14284,16 @@ package:
   license_family: GPL
   size: 937077
   timestamp: 1660323305349
-- name: x264
+- platform: osx-arm64
+  name: x264
   version: 1!164.3095
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
   hash:
     md5: b1f6dccde5d3a1f911960b6e567113ff
     sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
-  optional: false
-  category: main
   build: h57fd34a_2
   arch: aarch64
   subdir: osx-arm64
@@ -11212,19 +14302,18 @@ package:
   license_family: GPL
   size: 717038
   timestamp: 1660323292329
-- name: x264
+- platform: win-64
+  name: x264
   version: 1!164.3095
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
   url: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
   hash:
     md5: 19e39905184459760ccb8cf5c75f148b
     sha256: 97166b318f8c68ffe4d50b2f4bd36e415219eeaef233e7d41c54244dc6108249
-  optional: false
-  category: main
   build: h8ffe710_2
   arch: x86_64
   subdir: win-64
@@ -11233,19 +14322,18 @@ package:
   license_family: GPL
   size: 1041889
   timestamp: 1660323726084
-- name: x265
+- platform: linux-64
+  name: x265
   version: '3.5'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=10.3.0'
-    libstdcxx-ng: '>=10.3.0'
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
   hash:
     md5: e7f6ed84d4623d52ee581325c1587a6b
     sha256: 76c7405bcf2af639971150f342550484efac18219c0203c5ee2e38b8956fe2a0
-  optional: false
-  category: main
   build: h924138e_3
   arch: x86_64
   subdir: linux-64
@@ -11254,18 +14342,17 @@ package:
   license_family: GPL
   size: 3357188
   timestamp: 1646609687141
-- name: x265
+- platform: osx-64
+  name: x265
   version: '3.5'
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libcxx: '>=12.0.1'
+  - libcxx >=12.0.1
   url: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
   hash:
     md5: a3bf3e95b7795871a6734a784400fcea
     sha256: 6b6a57710192764d0538f72ea1ccecf2c6174a092e0bc76d790f8ca36bbe90e4
-  optional: false
-  category: main
   build: hbb4e6a2_3
   arch: x86_64
   subdir: osx-64
@@ -11274,18 +14361,17 @@ package:
   license_family: GPL
   size: 3433205
   timestamp: 1646610148268
-- name: x265
+- platform: osx-arm64
+  name: x265
   version: '3.5'
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libcxx: '>=12.0.1'
+  - libcxx >=12.0.1
   url: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
   hash:
     md5: b1f7f2780feffe310b068c021e8ff9b2
     sha256: 2fed6987dba7dee07bd9adc1a6f8e6c699efb851431bcb6ebad7de196e87841d
-  optional: false
-  category: main
   build: hbc6ce65_3
   arch: aarch64
   subdir: osx-arm64
@@ -11294,19 +14380,18 @@ package:
   license_family: GPL
   size: 1832744
   timestamp: 1646609481185
-- name: x265
+- platform: win-64
+  name: x265
   version: '3.5'
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
   url: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
   hash:
     md5: ca7129a334198f08347fb19ac98a2de9
     sha256: 02b9874049112f2b7335c9a3e880ac05d99a08d9a98160c5a98898b2b3ac42b2
-  optional: false
-  category: main
   build: h2d74725_3
   arch: x86_64
   subdir: win-64
@@ -11315,19 +14400,18 @@ package:
   license_family: GPL
   size: 5517425
   timestamp: 1646611941216
-- name: xcb-util
+- platform: linux-64
+  name: xcb-util
   version: 0.4.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
   hash:
     md5: 9bfac7ccd94d54fd21a0501296d60424
     sha256: 0c91d87f0efdaadd4e56a5f024f8aab20ec30f90aa2ce9e4ebea05fbc20f71ad
-  optional: false
-  category: main
   build: hd590300_1
   arch: x86_64
   subdir: linux-64
@@ -11336,20 +14420,19 @@ package:
   license_family: MIT
   size: 19728
   timestamp: 1684639166048
-- name: xcb-util-image
+- platform: linux-64
+  name: xcb-util-image
   version: 0.4.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xcb-util: '>=0.4.0,<0.5.0a0'
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xcb-util >=0.4.0,<0.5.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
   hash:
     md5: 9d7bcddf49cbf727730af10e71022c73
     sha256: 92ffd68d2801dbc27afe223e04ae7e78ef605fc8575f107113c93c7bafbd15b0
-  optional: false
-  category: main
   build: h8ee46fc_1
   arch: x86_64
   subdir: linux-64
@@ -11358,19 +14441,18 @@ package:
   license_family: MIT
   size: 24474
   timestamp: 1684679894554
-- name: xcb-util-keysyms
+- platform: linux-64
+  name: xcb-util-keysyms
   version: 0.4.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
   hash:
     md5: 632413adcd8bc16b515cab87a2932913
     sha256: 8451d92f25d6054a941b962179180728c48c62aab5bf20ac10fef713d5da6a9a
-  optional: false
-  category: main
   build: h8ee46fc_1
   arch: x86_64
   subdir: linux-64
@@ -11379,19 +14461,18 @@ package:
   license_family: MIT
   size: 14186
   timestamp: 1684680497805
-- name: xcb-util-renderutil
+- platform: linux-64
+  name: xcb-util-renderutil
   version: 0.3.9
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
   hash:
     md5: e995b155d938b6779da6ace6c6b13816
     sha256: 6987588e6fff5892056021c2ea52f7a0deefb2c7348e70d24750e2d60dabf009
-  optional: false
-  category: main
   build: hd590300_1
   arch: x86_64
   subdir: linux-64
@@ -11400,19 +14481,18 @@ package:
   license_family: MIT
   size: 16955
   timestamp: 1684639112393
-- name: xcb-util-wm
+- platform: linux-64
+  name: xcb-util-wm
   version: 0.4.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
   hash:
     md5: 90108a432fb5c6150ccfee3f03388656
     sha256: 08ba7147c7579249b6efd33397dc1a8c2404278053165aaecd39280fee705724
-  optional: false
-  category: main
   build: h8ee46fc_1
   arch: x86_64
   subdir: linux-64
@@ -11421,19 +14501,18 @@ package:
   license_family: MIT
   size: 52114
   timestamp: 1684679248466
-- name: xkeyboard-config
+- platform: linux-64
+  name: xkeyboard-config
   version: '2.40'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.8.6,<2.0a0'
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.6,<2.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.40-hd590300_0.conda
   hash:
     md5: 07c15d846a2e4d673da22cbd85fdb6d2
     sha256: a01fcb9c3346ee08aa24b3900a08896f2e8f80c891378a57d71764e16bbd6141
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -11442,19 +14521,18 @@ package:
   license_family: MIT
   size: 895713
   timestamp: 1696647097478
-- name: xorg-fixesproto
+- platform: linux-64
+  name: xorg-fixesproto
   version: '5.0'
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-xextproto: '*'
+  - libgcc-ng >=9.3.0
+  - xorg-xextproto *
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
   hash:
     md5: 65ad6e1eb4aed2b0611855aff05e04f6
     sha256: 5d2af1b40f82128221bace9466565eca87c97726bb80bbfcd03871813f3e1876
-  optional: false
-  category: main
   build: h7f98852_1002
   arch: x86_64
   subdir: linux-64
@@ -11463,18 +14541,17 @@ package:
   license_family: MIT
   size: 9122
   timestamp: 1617479697350
-- name: xorg-inputproto
+- platform: linux-64
+  name: xorg-inputproto
   version: 2.3.2
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
   hash:
     md5: bcd1b3396ec6960cbc1d2855a9e60b2b
     sha256: 6c8c2803de0f643f8bad16ece3f9a7259e4a49247543239c182d66d5e3a129a7
-  optional: false
-  category: main
   build: h7f98852_1002
   arch: x86_64
   subdir: linux-64
@@ -11483,18 +14560,17 @@ package:
   license_family: MIT
   size: 19602
   timestamp: 1610027678228
-- name: xorg-kbproto
+- platform: linux-64
+  name: xorg-kbproto
   version: 1.0.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
   hash:
     md5: 4b230e8381279d76131116660f5a241a
     sha256: e90b0a6a5d41776f11add74aa030f789faf4efd3875c31964d6f9cfa63a10dd1
-  optional: false
-  category: main
   build: h7f98852_1002
   arch: x86_64
   subdir: linux-64
@@ -11503,18 +14579,17 @@ package:
   license_family: MIT
   size: 27338
   timestamp: 1610027759842
-- name: xorg-libice
+- platform: linux-64
+  name: xorg-libice
   version: 1.1.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
   hash:
     md5: b462a33c0be1421532f28bfe8f4a7514
     sha256: 5aa9b3682285bb2bf1a8adc064cb63aff76ef9178769740d855abb42b0d24236
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -11523,20 +14598,19 @@ package:
   license_family: MIT
   size: 58469
   timestamp: 1685307573114
-- name: xorg-libsm
+- platform: linux-64
+  name: xorg-libsm
   version: 1.2.4
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libuuid: '>=2.38.1,<3.0a0'
-    xorg-libice: '>=1.1.1,<2.0a0'
+  - libgcc-ng >=12
+  - libuuid >=2.38.1,<3.0a0
+  - xorg-libice >=1.1.1,<2.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
   hash:
     md5: 93ee23f12bc2e684548181256edd2cf6
     sha256: 089ad5f0453c604e18985480218a84b27009e9e6de9a0fa5f4a20b8778ede1f1
-  optional: false
-  category: main
   build: h7391055_0
   arch: x86_64
   subdir: linux-64
@@ -11545,22 +14619,21 @@ package:
   license_family: MIT
   size: 27433
   timestamp: 1685453649160
-- name: xorg-libx11
+- platform: linux-64
+  name: xorg-libx11
   version: 1.8.7
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xorg-kbproto: '*'
-    xorg-xextproto: '>=7.3.0,<8.0a0'
-    xorg-xproto: '*'
+  - libgcc-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - xorg-kbproto *
+  - xorg-xextproto >=7.3.0,<8.0a0
+  - xorg-xproto *
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
   hash:
     md5: 49e482d882669206653b095f5206c05b
     sha256: 7a02a7beac472ae2759498550b5fc5261bf5be7a9a2b4648a3f67818a7bfefcf
-  optional: false
-  category: main
   build: h8ee46fc_0
   arch: x86_64
   subdir: linux-64
@@ -11569,18 +14642,17 @@ package:
   license_family: MIT
   size: 828692
   timestamp: 1697056910935
-- name: xorg-libxau
+- platform: linux-64
+  name: xorg-libxau
   version: 1.0.11
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
   hash:
     md5: 2c80dc38fface310c9bd81b17037fee5
     sha256: 309751371d525ce50af7c87811b435c176915239fc9e132b99a25d5e1703f2d4
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -11589,18 +14661,73 @@ package:
   license_family: MIT
   size: 14468
   timestamp: 1684637984591
-- name: xorg-libxdmcp
-  version: 1.1.3
+- platform: osx-64
+  name: xorg-libxau
+  version: 1.0.11
+  category: main
   manager: conda
-  platform: linux-64
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+  hash:
+    md5: 9566b4c29274125b0266d0177b5eb97b
+    sha256: 8a2e398c4f06f10c64e69f56bcf3ddfa30b432201446a0893505e735b346619a
+  build: h0dc2134_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 13071
+  timestamp: 1684638167647
+- platform: osx-arm64
+  name: xorg-libxau
+  version: 1.0.11
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+  hash:
+    md5: ca73dc4f01ea91e44e3ed76602c5ea61
+    sha256: 02c313a1cada46912e5b9bdb355cfb4534bfe22143b4ea4ecc419690e793023b
+  build: hb547adb_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 13667
+  timestamp: 1684638272445
+- platform: win-64
+  name: xorg-libxau
+  version: 1.0.11
+  category: main
+  manager: conda
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+  hash:
+    md5: c46ba8712093cb0114404ae8a7582e1a
+    sha256: 8c5b976e3b36001bdefdb41fb70415f9c07eff631f1f0155f3225a7649320e77
+  build: hcd874cb_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 51297
+  timestamp: 1684638355740
+- platform: linux-64
+  name: xorg-libxdmcp
+  version: 1.1.3
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
   hash:
     md5: be93aabceefa2fac576e971aef407908
     sha256: 4df7c5ee11b8686d3453e7f3f4aa20ceef441262b49860733066c52cfd0e4a77
-  optional: false
-  category: main
   build: h7f98852_0
   arch: x86_64
   subdir: linux-64
@@ -11609,20 +14736,74 @@ package:
   license_family: MIT
   size: 19126
   timestamp: 1610071769228
-- name: xorg-libxext
-  version: 1.3.4
+- platform: osx-64
+  name: xorg-libxdmcp
+  version: 1.1.3
+  category: main
   manager: conda
-  platform: linux-64
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+  hash:
+    md5: 86ac76d6bf1cbb9621943eb3bd9ae36e
+    sha256: 485421c16f03a01b8ed09984e0b2ababdbb3527e1abf354ff7646f8329be905f
+  build: h35c211d_0
+  arch: x86_64
+  subdir: osx-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 17225
+  timestamp: 1610071995461
+- platform: osx-arm64
+  name: xorg-libxdmcp
+  version: 1.1.3
+  category: main
+  manager: conda
+  dependencies: []
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+  hash:
+    md5: 6738b13f7fadc18725965abdd4129c36
+    sha256: d9a2fb4762779994718832f05a7d62ab2dcf6103a312235267628b5187ce88f7
+  build: h27ca646_0
+  arch: aarch64
+  subdir: osx-arm64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 18164
+  timestamp: 1610071737668
+- platform: win-64
+  name: xorg-libxdmcp
+  version: 1.1.3
+  category: main
+  manager: conda
   dependencies:
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.7.2,<2.0a0'
-    xorg-xextproto: '*'
+  - m2w64-gcc-libs
+  url: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+  hash:
+    md5: 46878ebb6b9cbd8afcf8088d7ef00ece
+    sha256: f51205d33c07d744ec177243e5d9b874002910c731954f2c8da82459be462b93
+  build: hcd874cb_0
+  arch: x86_64
+  subdir: win-64
+  build_number: 0
+  license: MIT
+  license_family: MIT
+  size: 67908
+  timestamp: 1610072296570
+- platform: linux-64
+  name: xorg-libxext
+  version: 1.3.4
+  category: main
+  manager: conda
+  dependencies:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.7.2,<2.0a0
+  - xorg-xextproto *
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
   hash:
     md5: 82b6df12252e6f32402b96dacc656fec
     sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
-  optional: false
-  category: main
   build: h0b41bf4_2
   arch: x86_64
   subdir: linux-64
@@ -11631,20 +14812,19 @@ package:
   license_family: MIT
   size: 50143
   timestamp: 1677036907815
-- name: xorg-libxfixes
+- platform: linux-64
+  name: xorg-libxfixes
   version: 5.0.3
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-fixesproto: '*'
-    xorg-libx11: '>=1.7.0,<2.0a0'
+  - libgcc-ng >=9.3.0
+  - xorg-fixesproto *
+  - xorg-libx11 >=1.7.0,<2.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
   hash:
     md5: e9a21aa4d5e3e5f1aed71e8cefd46b6a
     sha256: 1e426a1abb774ef1dcf741945ed5c42ad12ea2dc7aeed7682d293879c3e1e4c3
-  optional: false
-  category: main
   build: h7f98852_1004
   arch: x86_64
   subdir: linux-64
@@ -11653,22 +14833,21 @@ package:
   license_family: MIT
   size: 18145
   timestamp: 1617717802636
-- name: xorg-libxi
+- platform: linux-64
+  name: xorg-libxi
   version: 1.7.10
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-inputproto: '*'
-    xorg-libx11: '>=1.7.0,<2.0a0'
-    xorg-libxext: 1.3.*
-    xorg-libxfixes: 5.0.*
+  - libgcc-ng >=9.3.0
+  - xorg-inputproto *
+  - xorg-libx11 >=1.7.0,<2.0a0
+  - xorg-libxext 1.3.*
+  - xorg-libxfixes 5.0.*
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-h7f98852_0.tar.bz2
   hash:
     md5: e77615e5141cad5a2acaa043d1cf0ca5
     sha256: 745c1284a96b4282fe6fe122b2643e1e8c26a7ff40b733a8f4b61357238c4e68
-  optional: false
-  category: main
   build: h7f98852_0
   arch: x86_64
   subdir: linux-64
@@ -11677,20 +14856,19 @@ package:
   license_family: MIT
   size: 47287
   timestamp: 1620070911951
-- name: xorg-libxrender
+- platform: linux-64
+  name: xorg-libxrender
   version: 0.9.11
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-renderproto: '*'
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-renderproto *
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
   hash:
     md5: ed67c36f215b310412b2af935bf3e530
     sha256: 26da4d1911473c965c32ce2b4ff7572349719eaacb88a066db8d968a4132c3f7
-  optional: false
-  category: main
   build: hd590300_0
   arch: x86_64
   subdir: linux-64
@@ -11699,18 +14877,17 @@ package:
   license_family: MIT
   size: 37770
   timestamp: 1688300707994
-- name: xorg-renderproto
+- platform: linux-64
+  name: xorg-renderproto
   version: 0.11.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
   hash:
     md5: 06feff3d2634e3097ce2fe681474b534
     sha256: 38942930f233d1898594dd9edf4b0c0786f3dbc12065a0c308634c37fd936034
-  optional: false
-  category: main
   build: h7f98852_1002
   arch: x86_64
   subdir: linux-64
@@ -11719,18 +14896,17 @@ package:
   license_family: MIT
   size: 9621
   timestamp: 1614866326326
-- name: xorg-xextproto
+- platform: linux-64
+  name: xorg-xextproto
   version: 7.3.0
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
   hash:
     md5: bce9f945da8ad2ae9b1d7165a64d0f87
     sha256: b8dda3b560e8a7830fe23be1c58cc41f407b2e20ae2f3b6901eb5842ba62b743
-  optional: false
-  category: main
   build: h0b41bf4_1003
   arch: x86_64
   subdir: linux-64
@@ -11739,18 +14915,17 @@ package:
   license_family: MIT
   size: 30270
   timestamp: 1677036833037
-- name: xorg-xf86vidmodeproto
+- platform: linux-64
+  name: xorg-xf86vidmodeproto
   version: 2.3.1
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
   hash:
     md5: 3ceea9668625c18f19530de98b15d5b0
     sha256: 43398aeacad5b8753b7a1c12cb6bca36124e0c842330372635879c350c430791
-  optional: false
-  category: main
   build: h7f98852_1002
   arch: x86_64
   subdir: linux-64
@@ -11759,18 +14934,17 @@ package:
   license_family: MIT
   size: 23875
   timestamp: 1620067286978
-- name: xorg-xproto
+- platform: linux-64
+  name: xorg-xproto
   version: 7.0.31
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=9.3.0'
+  - libgcc-ng >=9.3.0
   url: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
   hash:
     md5: b4a4381d54784606820704f7b5f05a15
     sha256: f197bb742a17c78234c24605ad1fe2d88b1d25f332b75d73e5ba8cf8fbc2a10d
-  optional: false
-  category: main
   build: h7f98852_1007
   arch: x86_64
   subdir: linux-64
@@ -11779,18 +14953,17 @@ package:
   license_family: MIT
   size: 74922
   timestamp: 1607291557628
-- name: xz
+- platform: linux-64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
+  - libgcc-ng >=12
   url: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
   hash:
     md5: 2161070d867d1b1204ea749c8eec4ef0
     sha256: 03a6d28ded42af8a347345f82f3eebdd6807a08526d47899a42d62d319609162
-  optional: false
-  category: main
   build: h166bdaf_0
   arch: x86_64
   subdir: linux-64
@@ -11798,17 +14971,16 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
-- name: xz
+- platform: osx-64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: osx-64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
   hash:
     md5: a72f9d4ea13d55d745ff1ed594747f10
     sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
-  optional: false
-  category: main
   build: h775f41a_0
   arch: x86_64
   subdir: osx-64
@@ -11816,17 +14988,16 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 238119
   timestamp: 1660346964847
-- name: xz
+- platform: osx-arm64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: osx-arm64
-  dependencies: {}
+  dependencies: []
   url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
   hash:
     md5: 39c6b54e94014701dd157f4f576ed211
     sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
-  optional: false
-  category: main
   build: h57fd34a_0
   arch: aarch64
   subdir: osx-arm64
@@ -11834,19 +15005,18 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 235693
   timestamp: 1660346961024
-- name: xz
+- platform: win-64
+  name: xz
   version: 5.2.6
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    vc: '>=14.1,<15'
-    vs2015_runtime: '>=14.16.27033'
+  - vc >=14.1,<15
+  - vs2015_runtime >=14.16.27033
   url: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
   hash:
     md5: 515d77642eaa3639413c6b1bc3f94219
     sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
-  optional: false
-  category: main
   build: h8d14728_0
   arch: x86_64
   subdir: win-64
@@ -11854,19 +15024,18 @@ package:
   license: LGPL-2.1 and GPL-2.0
   size: 217804
   timestamp: 1660346976440
-- name: zlib
+- platform: linux-64
+  name: zlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libzlib: ==1.2.13 hd590300_5
+  - libgcc-ng >=12
+  - libzlib ==1.2.13 hd590300_5
   url: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
   hash:
     md5: 68c34ec6149623be41a1933ab996a209
     sha256: 9887a04d7e7cb14bd2b52fa01858f05a6d7f002c890f618d9fcd864adbfecb1b
-  optional: false
-  category: main
   build: hd590300_5
   arch: x86_64
   subdir: linux-64
@@ -11875,18 +15044,17 @@ package:
   license_family: Other
   size: 92825
   timestamp: 1686575231103
-- name: zlib
+- platform: osx-64
+  name: zlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: ==1.2.13 h8a1eda9_5
+  - libzlib ==1.2.13 h8a1eda9_5
   url: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
   hash:
     md5: 75a8a98b1c4671c5d2897975731da42d
     sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
-  optional: false
-  category: main
   build: h8a1eda9_5
   arch: x86_64
   subdir: osx-64
@@ -11895,18 +15063,17 @@ package:
   license_family: Other
   size: 90764
   timestamp: 1686575574678
-- name: zlib
+- platform: osx-arm64
+  name: zlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: ==1.2.13 h53f4e23_5
+  - libzlib ==1.2.13 h53f4e23_5
   url: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
   hash:
     md5: a08383f223b10b71492d27566fafbf6c
     sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
-  optional: false
-  category: main
   build: h53f4e23_5
   arch: aarch64
   subdir: osx-arm64
@@ -11915,21 +15082,20 @@ package:
   license_family: Other
   size: 79577
   timestamp: 1686575471024
-- name: zlib
+- platform: win-64
+  name: zlib
   version: 1.2.13
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libzlib: ==1.2.13 hcfcfb64_5
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libzlib ==1.2.13 hcfcfb64_5
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
   hash:
     md5: a318e8622e11663f645cc7fa3260f462
     sha256: 0f91b719c7558046bcd37fdc7ae4b9eb2b7a8e335beb8b59ae7ccb285a46aa46
-  optional: false
-  category: main
   build: hcfcfb64_5
   arch: x86_64
   subdir: win-64
@@ -11938,20 +15104,19 @@ package:
   license_family: Other
   size: 107711
   timestamp: 1686575474476
-- name: zstd
+- platform: linux-64
+  name: zstd
   version: 1.5.5
+  category: main
   manager: conda
-  platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
   hash:
     md5: 04b88013080254850d6c01ed54810589
     sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  optional: false
-  category: main
   build: hfc55251_0
   arch: x86_64
   subdir: linux-64
@@ -11960,18 +15125,17 @@ package:
   license_family: BSD
   size: 545199
   timestamp: 1693151163452
-- name: zstd
+- platform: osx-64
+  name: zstd
   version: 1.5.5
+  category: main
   manager: conda
-  platform: osx-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
   hash:
     md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
     sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
-  optional: false
-  category: main
   build: h829000d_0
   arch: x86_64
   subdir: osx-64
@@ -11980,18 +15144,17 @@ package:
   license_family: BSD
   size: 499383
   timestamp: 1693151312586
-- name: zstd
+- platform: osx-arm64
+  name: zstd
   version: 1.5.5
+  category: main
   manager: conda
-  platform: osx-arm64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
+  - libzlib >=1.2.13,<1.3.0a0
   url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
   hash:
     md5: 5b212cfb7f9d71d603ad891879dc7933
     sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
-  optional: false
-  category: main
   build: h4f39d0f_0
   arch: aarch64
   subdir: osx-arm64
@@ -12000,21 +15163,20 @@ package:
   license_family: BSD
   size: 400508
   timestamp: 1693151393180
-- name: zstd
+- platform: win-64
+  name: zstd
   version: 1.5.5
+  category: main
   manager: conda
-  platform: win-64
   dependencies:
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
+  - libzlib >=1.2.13,<1.3.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
   hash:
     md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
     sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
-  optional: false
-  category: main
   build: h12be248_0
   arch: x86_64
   subdir: win-64

--- a/pixi.toml
+++ b/pixi.toml
@@ -64,6 +64,7 @@ cmake = "3.27.6"
 # Required by this example:
 eigen = "3.4.0.*"
 opencv = "4.8.1.*"
+rerun-sdk = "0.10.0"
 
 [target.linux-64.dependencies]
 # Build tools:


### PR DESCRIPTION
This now lets us skip the `installing the rerun viewer` step and do everything with a single command:
```
pixi run example
```