### PR TITLE
Update to Rerun 0.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
 endif()
 
 include(FetchContent)
-FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.12.0/rerun_cpp_sdk.zip)
+FetchContent_Declare(rerun_sdk URL https://github.com/rerun-io/rerun/releases/download/0.13.0/rerun_cpp_sdk.zip)
 FetchContent_MakeAvailable(rerun_sdk)
 
 find_package(Eigen3 REQUIRED)

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ If you choose not to use pixi, you will need to install a few things yourself be
 The Rerun C++ SDK works by connecting to an awaiting Rerun Viewer over TCP.
 
 If you need to install the viewer, follow the [installation guide](https://www.rerun.io/docs/getting-started/installing-viewer). Two of the more common ways to install the Rerun are:
-* Via cargo: `cargo install rerun-cli@0.12.0`
-* Via pip: `pip install rerun-sdk==0.12.0`
+* Via cargo: `cargo install rerun-cli@0.13.0`
+* Via pip: `pip install rerun-sdk==0.13.0`
 
 After you have installed it, you should be able to type `rerun` in your terminal to start the viewer.
 


### PR DESCRIPTION
The new heuristics doesn't show the logged images:

![image](https://github.com/rerun-io/cpp-example-opencv-eigen/assets/1148717/bde1d5ed-113a-404c-9133-0441c700205a)
