### PR TITLE
Add example of downloading rerun c++ lib via pixi

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.6.0
         with:
-          pixi-version: v0.20.0
+          pixi-version: v0.22.0
           cache: true
 
       - name: run build task on all environments

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -11,10 +11,10 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@v0.6.0
         with:
-          pixi-version: v0.22.0
+          pixi-version: v0.20.0
           cache: true
 
       - name: run build task on all environments
         run: |
-          - pixi run -e default build
-          - pixi run -e rerunfindpackage build
+          pixi run -e default build
+          pixi run -e rerunfindpackage build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -14,4 +14,7 @@ jobs:
           pixi-version: v0.20.0
           cache: true
 
-      - run: pixi run build
+      - name: run build task on all environments
+        run: |
+          - pixi run -e default build
+          - pixi run -e rerunfindpackage build

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -9,9 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: prefix-dev/setup-pixi@v0.3.0
+      - uses: prefix-dev/setup-pixi@v0.6.0
         with:
-          pixi-version: v0.19.1
+          pixi-version: v0.20.0
           cache: true
 
       - run: pixi run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-# Build directory
+# Build directories
 build
+buildrerunfindpackage
 
 # Pixi environment
 .pixi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ if(NOT DEFINED CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
 
-set(RERUN_CPP_URL "https://github.com/rerun-io/rerun/releases/download/0.15.1/rerun_cpp_sdk.zip" CACHE STRING "URL to the rerun_cpp zip.")
+set(RERUN_CPP_URL "https://github.com/rerun-io/rerun/releases/download/0.16.0/rerun_cpp_sdk.zip" CACHE STRING "URL to the rerun_cpp zip.")
 option(RERUN_FIND_PACKAGE "Whether to use find_package to find a preinstalled rerun package (instead of using FetchContent)." OFF)
 
 if(RERUN_FIND_PACKAGE)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ This is a minimal CMake project that shows how to use [Rerun](https://github.com
 The easiest way to get started is to install [pixi](https://prefix.dev/docs/pixi/overview).
 
 The pixi environment described in `pixi.toml` contains all of the dependencies, including the rerun viewer,
-allowing you to run the example with a single command:
-* `pixi run example`
+allowing you to run the example with a single command, while the rerun C++ SDK is downloaded via `FetchContent`
+* `pixi run -e default example`
+
+If you want to also download rerun C++ SDK via pixi, you can run:
+* `pixi run -e rerundfindpackage example`
 
 ## Without `pixi`
 If you choose not to use pixi, you will need to install a few things yourself before you get started.

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,4 +1,4 @@
-version: 4
+version: 5
 environments:
   default:
     channels:
@@ -8,7 +8,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.10-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.6.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.7.1-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.11-h0b4cabd_1.conda
@@ -30,7 +30,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.6.0-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15-15.0.7-default_h7634d5b_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15.0.7-default_h7634d5b_3.conda
@@ -40,8 +40,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.0.0-gpl_h334edf3_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.0-gpl_ha330e6d_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -55,23 +55,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-h59595ed_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.0-hfc55251_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.0-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.2-hf974151_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.2-hb6ce0ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.2.1-h58526e2_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.8-hf3e180e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.6-h8e1006c_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.6-h98fc4e7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-h8e1006c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.2.1-h3d44ed6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.2-nompi_h4f84152_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.5.0-hfac3d4d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.0.0-he6dfbbe_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
@@ -80,14 +81,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-15.0.0-h84dd17c_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-15.0.0-h59595ed_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-15.0.0-h59595ed_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-15.0.0-h120cb0d_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-15.0.0-h61ff412_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-15.0.0-hacb8726_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-15.0.0-h61ff412_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-h84dd17c_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-h120cb0d_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h61ff412_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hacb8726_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h61ff412_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-h661eb56_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-h661eb56_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
@@ -102,27 +105,29 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.114-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.120-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.3.0-h8bca6fd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-h59595ed_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.0-hebfc3b9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.2-hf974151_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h5206363_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.47-h71f35ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.49-h4f305b6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.3-hd6c4280_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.4-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-19_linux64_openblas.conda
@@ -131,7 +136,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.9.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_h413a1c8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.8.1-py312hed1d938_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2023.1.0-h59595ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2023.1.0-h59595ed_1.conda
@@ -146,10 +151,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2023.1.0-h59595ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2023.1.0-h59595ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-15.0.0-h352af49_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.17-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.0-hfc447b1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h7a70373_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_2.conda
@@ -158,65 +163,65 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-254-h3516f8a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.46.0-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.20.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.48.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-h5d7e998_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.6-h232c23b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.3-h59595ed_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.8.1-hc379101_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.6-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.94-h1d7d5a4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.100-hca3bf56_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.1-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-system-1.0.0-1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/opencv-4.8.1-py312h74ac831_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.3.1-hcb278e6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.0-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h4b38347_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py312hdcec9eb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.42.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.8.1-py312h0af958d_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-15.0.0-py312h176e3d2_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.2-hab00c5b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py312h176e3d2_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.3-hab00c5b_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h82b777d_17.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-51.0-hd3aeb46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rerun-sdk-0.15.1-py312h9118e91_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rerun-sdk-0.16.0-py312h5715c7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.1-h06160fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.7.0-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.10.0-h00ab1b0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-ha691c75_8.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
@@ -225,13 +230,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.40-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
@@ -244,7 +249,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
@@ -269,7 +274,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-h870a726_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h95d2017_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h31becfc_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.27.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.28.1-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.6.0-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.2.2-hcefe29a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
@@ -296,23 +301,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-he80d746_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-hcde2664_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h9622932_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.21.1-ha18d298_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h2f0025b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.2.2-h54f1f3f_1004.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.80.0-h9d8fbc1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.80.0-hfbcf09e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.80.2-h34bac0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.80.2-he16435f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.6.0-h8ab10f1_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.7.9-hb309da9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h7fd3ca4_1001.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h6d82d15_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h0a86eba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-he80d746_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-12.3.0-hcde2664_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h3d1e521_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.5.0-h9812418_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_ha486f32_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.2-h381c573_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.2-hc419048_0.conda
@@ -321,14 +327,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h2d8c526_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20230802.1-cxx17_h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.2-h2f0025b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-15.0.0-he4a0828_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-acero-15.0.0-h2f0025b_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-dataset-15.0.0-h2f0025b_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-15.0.0-h43033d3_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-sql-15.0.0-hb5131e1_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-gandiva-15.0.0-h1bc7839_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-substrait-15.0.0-h318fca9_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-14.0.2-he4a0828_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-acero-14.0.2-h2f0025b_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-dataset-14.0.2-h2f0025b_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-14.0.2-h43033d3_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-sql-14.0.2-hb5131e1_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-gandiva-14.0.2-h1bc7839_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-substrait-14.0.2-h318fca9_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h7b6a552_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h7b6a552_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-21_linuxaarch64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-h31becfc_1.conda
@@ -341,7 +349,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf5d3afd_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcrc32c-1.1.2-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.5.0-h4e8248e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.7.1-h4e8248e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.19-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
@@ -352,15 +360,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-13.2.0-hf8544c7_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.10.3-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h2f0025b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-13.2.0-he9431aa_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-13.2.0-h582850c_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.0-h9d8fbc1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.2-h34bac0b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-13.2.0-hf8544c7_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-2.12.0-h40f64ef_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.48-h5ce24db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.49-hb13efb6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgrpc-1.59.3-h877c88e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.9.3-default_hda148da_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.10.0-default_h3030c0e_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.7-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
@@ -385,14 +395,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2023.1.0-h2f0025b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2023.1.0-h2f0025b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-15.0.0-hb18b541_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-14.0.2-hb18b541_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.3-hcf0348d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.24.4-h87e877f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2023.09.01-hf48c5ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h8ebda82_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.2-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.3-h194ca79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-13.2.0-h9a76618_5.conda
@@ -406,26 +416,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.48.0-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.3.2-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.6.0-h217f472_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.5-h3091e33_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h2555907_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h49dc7a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h31becfc_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.4-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.6-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-8.0.33-hb6794ad_6.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-8.0.33-hf629957_6.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4-h0425590_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.11.1-hdd96247_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.35-h4de3ea5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.98-hc5a5cc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.100-h8c4e863_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/opencv-4.8.1-py312ha6f0c23_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.0-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.2-h0d9d63b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.0-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orc-1.9.2-h7b7b289_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.43-hd0f9c67_0.conda
@@ -435,20 +445,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-16.1-h729494f_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.8.1-py312hcbf8c54_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-15.0.0-py312h2f65cca_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.2-h43d1f9e_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-14.0.2-py312h2f65cca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.3-h43d1f9e_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-4_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h5992497_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-51.0-h0425590_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/re2-2023.09.01-h9caee61_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rerun-sdk-0.15.1-py312hb434743_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rerun-sdk-0.16.0-py312h18b2cab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.4-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.4.1-h5a25046_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-he8610fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-1.8.0-h2f0025b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.11.0-h2a328a1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.12.0-h70be974_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
@@ -466,7 +476,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h3557bc0_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h7935292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-h5a01bc2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.7-h055a233_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-h055a233_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.4-h2a766a3_2.conda
@@ -479,9 +489,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h3557bc0_1007.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.2.13-h31becfc_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.5-h4c53e97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
       osx-64:
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.6.1-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.7.1-h93d8f39_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.11-h94c8779_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-he75d6b7_3.conda
@@ -499,7 +509,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.28.1-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.6.0-h63c33a9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-hd9ad811_15.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-habff3f6_15.conda
@@ -519,8 +529,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h1c7c39f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.0.0-gpl_h789aacd_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.0-gpl_h0a522cb_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -530,16 +540,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-h5ff76d1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.2.1-h2e338ed_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.8-h207c4f0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h73e2aa4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.9-h1951705_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h2e338ed_1001.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.2.1-h7666e2a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.2-nompi_hedada53_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.5.0-h053f038_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_hb512a33_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.0.0-h6513c55_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.4-hb10263b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
@@ -547,14 +558,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-h0fd476b_15.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-15.0.0-h1aaacd4_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-15.0.0-h000cb23_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-15.0.0-h000cb23_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-15.0.0-ha1803ca_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-15.0.0-h8ec153b_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-15.0.0-h01dce7f_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-15.0.0-h8ec153b_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-h1aaacd4_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-ha1803ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h8ec153b_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h01dce7f_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h8ec153b_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-h5ff76d1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.1-h80904bb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
@@ -566,26 +579,31 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h953c2e9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-17.0.6-h88467a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-h5ff76d1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.0-hc62aa5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.2-h0f68cf7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-hc0857f6_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.59.3-ha7f534c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h24e0189_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.4-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.7-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-h5ff76d1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-19_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-he4b1e75_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_hfef2a42_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.8.1-py312h989985c_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2023.1.0-h93d8f39_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2023.1.0-h93d8f39_1.conda
@@ -599,7 +617,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2023.1.0-h93d8f39_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2023.1.0-h93d8f39_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-15.0.0-h381d950_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.4-hc4f2305_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h4694dbf_1.conda
@@ -610,55 +628,55 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libunistring-0.9.10-h0d85af4_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.46.0-h0c2f820_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.48.0-h67532ce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.13.1-he965462_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.6-hc0ae0f7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.3-hb6ac08f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.5-h39e0ece_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-15.0.7-he4b1e75_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.8.1-h96f3785_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.9.1-h8e11ae5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/opencv-4.8.1-py312hbdb8196_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.3.1-hf0c8a7f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.4.0-h93d8f39_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.0-hd75f5a5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-h9ab30d4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/p11-kit-0.24.1-h65f8906_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.40-h1c4e4bc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.3.0-py312h0c923fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.42.2-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/py-opencv-4.8.1-py312h128fb24_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-15.0.0-py312h40fbfea_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.2-h9f0c242_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py312h40fbfea_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.3-h1411813_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.09.01-hb168e87_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rerun-sdk-0.15.1-py312hbe1a6d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rerun-sdk-0.16.0-py312h0329a8d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.7.0-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.10.0-h1c7c39f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
       osx-arm64:
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.6.1-hb765f3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.7.1-h463b476_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.11-ha4ce7b8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-h4fd42c2_3.conda
@@ -676,7 +694,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.28.1-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.6.0-hd291e01_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-hd1ac623_15.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h2a25c60_15.conda
@@ -696,8 +714,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h1995070_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.0.0-gpl_h1ceb99f_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.0-gpl_h032c140_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -707,16 +725,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8fbad5d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.2.1-h9f76cd9_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.8-h9f1a10d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hebf3989_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.2.1-hf1a6348_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.2-nompi_h3aba7b3_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.5.0-h1836168_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_h751145d_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.0.0-h6a52c50_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
@@ -724,14 +743,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-hc4dc95b_15.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-15.0.0-h4ce3932_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-15.0.0-h13dd4ca_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-15.0.0-h13dd4ca_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-15.0.0-ha94d253_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-15.0.0-h39a9b85_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-15.0.0-hf757142_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-15.0.0-h7fd9903_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h4ce3932_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-ha94d253_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h39a9b85_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hf757142_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h7fd9903_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8fbad5d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
@@ -743,26 +764,31 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-15.0.7-default_hc7183e1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.7.1-h2d989ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-17.0.6-h5f092b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8fbad5d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.0-h24e9cb9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.2-h535f939_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-hfb399a7_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.59.3-h9560976_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.9.3-default_h4394839_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.4-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.7-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8fbad5d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-19_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h504e6bf_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.27-openmp_h6c19121_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.8.1-py312hc03029b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2023.1.0-h965bd2d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2023.1.0-h965bd2d_1.conda
@@ -776,7 +802,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2023.1.0-h965bd2d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2023.1.0-h965bd2d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-15.0.0-hf6ce1d5_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.4-h810fc01_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.09.01-h741fcf5_1.conda
@@ -787,55 +813,55 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.46.0-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.48.0-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.6-h0d0cfa8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.3-hcd81f8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.5-hde57baf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-15.0.7-h504e6bf_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.8.1-h63371fa_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencv-4.8.1-py312h2a52fbe_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.3.1-hb7217d7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.0-h965bd2d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.0-h0d3ecfb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.2-h7c018df_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.3.0-py312h8a801b1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.42.2-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.8.1-py312hf81aaa1_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-15.0.0-py312h14a4a34_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.2-hdf0ec26_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py312h14a4a34_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.3-h4a7b5fc_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.09.01-h4cba328_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rerun-sdk-0.15.1-py312h6a27564_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rerun-sdk-0.16.0-py312h5c2e7bc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.7.0-hb765f3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.10.0-h1995070_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.11.0-h2ffa867_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
       win-64:
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.6.1-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.0-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.11-hcf9e330_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.9-hd33547d_3.conda
@@ -852,15 +878,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.210-h20b5662_10.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.28.1-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/clang-format-15.0.7-default_h66ee7f4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/clang-tools-15.0.7-default_h66ee7f4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.0.0-gpl_h1627b0f_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_h69c1fb8_111.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
@@ -871,29 +897,29 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-h63175ca_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.0-h12be248_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.0-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.2-h0df6a38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.2-h2f9d560_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-1000.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.6-h001b923_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.6-hb4038d2_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.2.1-h7ab893a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.2-nompi_h73e8ff5_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.5.0-h81778c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_101.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.0.0-h28f2b1a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2023.04.17-h64bf75a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-15.0.0-he5f67d5_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-15.0.0-h63175ca_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-15.0.0-h63175ca_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-15.0.0-h53b1db0_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-15.0.0-h78eab7c_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-15.0.0-hb2eaab1_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-15.0.0-hd4c9904_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-he5f67d5_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-h53b1db0_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h78eab7c_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hb2eaab1_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-hd4c9904_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
@@ -905,13 +931,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.7.1-hd5e4a3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.0-he8f3873_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.2-h0df6a38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-h39f2fc6_4.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.59.3-h5bbd4a7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.10.0-default_h8125262_1001.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-19_win64_mkl.conda
@@ -930,7 +958,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2023.1.0-h63175ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2023.1.0-h63175ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-15.0.0-h7ec3a38_0_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.24.4-hb8276f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-h8c5ae5e_1.conda
@@ -939,11 +967,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.44.2-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h283a6d9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
@@ -955,33 +983,33 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/opencv-4.8.1-py312h63a316d_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.3.1-h63175ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.0-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.2-hf0b6bd4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.40-h17e33f8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.3.0-py312h6f6a607_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.42.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.8.1-py312hc50e9f6_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-15.0.0-py312h85e32bb_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.2-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py312h85e32bb_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_17.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.09.01-hd3b24a8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rerun-sdk-0.15.1-py312h60fbdae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rerun-sdk-0.16.0-py312h7a6832a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.7.0-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.0.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
@@ -990,7 +1018,1031 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  rerunfindpackage:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.10-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.7.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/attr-2.5.1-h166bdaf_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.11-h0b4cabd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h14ec70c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.12-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h572eabf_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.1-h97bb272_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.0-h9129f04_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.0-hf8f278a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.1-h2b97f5f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.9-hca09fc5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.13-h572eabf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h572eabf_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.0-h04327c0_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.210-hba3e011_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils-2.40-hdd6e379_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_impl_linux-64-2.40-hf600244_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/binutils_linux-64-2.40-hbdbef99_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-compiler-1.6.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15-15.0.7-default_h7634d5b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-format-15.0.7-default_h7634d5b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/clang-tools-15.0.7-default_h7634d5b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cmake-3.27.6-hcfe8598_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.6.0-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.13.6-h5008d03_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h00ab1b0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.0-gpl_ha330e6d_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.14.2-h14ed4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-hac7e632_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fribidi-1.0.10-h36c2ea0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc-12.3.0-h8d2909c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-12.3.0-he2b93b0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_linux-64-12.3.0-h76fc315_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-he1b5a44_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.2-hf974151_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.2-hb6ce0ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-h8e1006c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx-12.3.0-h8d2909c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_impl_linux-64-12.3.0-he2b93b0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gxx_linux-64-12.3.0-h8a814eb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.5.0-hfac3d4d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-64-2.6.32-he073ed8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.2-h659d440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lame-3.100-h166bdaf_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.16-hb7c19ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-h41732ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-h84dd17c_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-h120cb0d_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h61ff412_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hacb8726_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h61ff412_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-h661eb56_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-h661eb56_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libass-0.17.1-h8fe9dca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcap-2.69-h0f662aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-15.0.7-default_h7634d5b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang-cpp15-15.0.7-default_h7634d5b_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libclang13-15.0.7-default_h9986a30_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.120-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libflac-1.4.3-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-12.3.0-h8bca6fd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.2-hf974151_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-13.2.0-h807b86a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h5206363_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.49-h4f305b6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.59.3-hd6c4280_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libhwloc-2.9.3-default_h554bfaf_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.0.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapacke-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-h5cf9203_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnl-3.9.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libogg-1.3.4-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_h413a1c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopencv-4.8.1-py312hed1d938_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-batch-plugin-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-auto-plugin-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-hetero-plugin-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-cpu-plugin-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-intel-gpu-plugin-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-ir-frontend-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-onnx-frontend-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-paddle-frontend-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-pytorch-frontend-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-frontend-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenvino-tensorflow-lite-frontend-2023.1.0-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libopus-1.3.1-h7f98852_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.24.4-hf27288f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h7a70373_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/librerun-sdk-0.16.0-h181fc98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-12.3.0-h0f45ef3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsndfile-1.2.2-hc60ed4a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.3-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-devel_linux-64-12.3.0-h8bca6fd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtasn1-4.19.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libunistring-0.9.10-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.48.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvorbis-1.3.7-h9c3ff4c_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libvpx-1.13.1-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-h5d7e998_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.6-h232c23b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.6-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ninja-1.11.1-h924138e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nspr-4.35-h27087fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/nss-3.100-hca3bf56_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-system-1.0.0-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/opencv-4.8.1-py312h74ac831_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h4b38347_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/p11-kit-0.24.1-hc5aa10d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py312hdcec9eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pugixml-1.14-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pulseaudio-client-16.1-hb77b528_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/py-opencv-4.8.1-py312h0af958d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py312h176e3d2_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.3-hab00c5b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qt-main-5.15.8-h82b777d_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-51.0-hd3aeb46_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rerun-sdk-0.16.0-py312h5715c7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rhash-1.4.4-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.1-h06160fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.1.10-h9fff704_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/svt-av1-1.7.0-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-64-2.12-he073ed8_16.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-h2797004_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-ha691c75_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x264-1!164.3095-h166bdaf_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/x265-3.5-h924138e_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-0.4.0-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-image-0.4.0-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-keysyms-0.4.0-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-renderutil-0.3.9-hd590300_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xcb-util-wm-0.4.1-h8ee46fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-kbproto-1.0.7-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.4-h7391055_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.3-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.4-h0b41bf4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-h7f98852_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.11-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-renderproto-0.11.1-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xextproto-7.3.0-h0b41bf4_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xf86vidmodeproto-2.3.1-h7f98852_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-xproto-7.0.31-h7f98852_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.2.13-hd590300_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+      linux-aarch64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/_sysroot_linux-aarch64_curr_repodata_hack-4-h57d6b7b_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/alsa-lib-1.2.11-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aom-3.7.1-h0425590_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/attr-2.5.1-h4e544f5_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-auth-0.7.11-haf82e57_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-cal-0.6.9-h854096e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-common-0.9.12-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-compression-0.2.17-hf7cfaa6_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-event-stream-0.4.1-h1459288_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-http-0.8.0-hfb0987e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-io-0.14.0-hc95754b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-mqtt-0.10.1-h8a8a0aa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-s3-0.4.9-h1eed58e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-c-sdkutils-0.1.13-hf7cfaa6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-checksums-0.1.17-hf7cfaa6_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-crt-cpp-0.26.0-hbdb2a1c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/aws-sdk-cpp-1.11.210-hf4e9681_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils-2.40-h64c2a2e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_impl_linux-aarch64-2.40-h870a726_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/binutils_linux-aarch64-2.40-h95d2017_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h31becfc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.28.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-compiler-1.6.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ca-certificates-2024.2.2-hcefe29a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cairo-1.18.0-ha13f110_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-format-15-15.0.7-default_h65c9d4d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-format-15.0.7-default_h65c9d4d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/clang-tools-15.0.7-default_h65c9d4d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cmake-3.27.6-hef020d8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cxx-compiler-1.6.0-h2a328a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dav1d-1.2.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/dbus-1.13.6-h12b9eeb_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/eigen-3.4.0-h2a328a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/expat-2.6.2-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ffmpeg-6.1.1-gpl_h9c27ee1_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fontconfig-2.14.2-ha9a116f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freeglut-3.2.2-hf4b6fbe_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freetype-2.12.1-hf0a5ef3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/fribidi-1.0.10-hb9de7d4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc-12.3.0-he80d746_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_impl_linux-aarch64-12.3.0-hcde2664_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gcc_linux-aarch64-12.3.0-h9622932_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.2.2-h54f1f3f_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.80.2-h34bac0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.80.2-he16435f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.6.0-h8ab10f1_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gmp-6.3.0-h2f0025b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gnutls-3.7.9-hb309da9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/graphite2-1.3.13-h7fd3ca4_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h0a86eba_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx-12.3.0-he80d746_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_impl_linux-aarch64-12.3.0-hcde2664_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gxx_linux-aarch64-12.3.0-h3d1e521_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.5.0-h9812418_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.3-nompi_ha486f32_100.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-73.2-h787c7f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/kernel-headers_linux-aarch64-4.18.0-h5b4a56d_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/keyutils-1.6.1-h4e544f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/krb5-1.21.2-hc419048_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lame-3.100-h4e544f5_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lcms2-2.16-h922389a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ld_impl_linux-aarch64-2.40-h2d8c526_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lerc-4.0.0-h4de3ea5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libabseil-20230802.1-cxx17_h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-14.0.2-he4a0828_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-acero-14.0.2-h2f0025b_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-dataset-14.0.2-h2f0025b_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-14.0.2-h43033d3_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-sql-14.0.2-hb5131e1_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-gandiva-14.0.2-h1bc7839_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-substrait-14.0.2-h318fca9_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h7b6a552_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h7b6a552_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libass-0.17.1-h36b5d3b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libblas-3.9.0-21_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlicommon-1.1.0-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlidec-1.1.0-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libbrotlienc-1.1.0-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcap-2.69-h883460d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcblas-3.9.0-21_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-15.0.7-default_h65c9d4d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang-cpp15-15.0.7-default_h65c9d4d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libclang13-15.0.7-default_hf5d3afd_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcrc32c-1.1.2-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcups-2.3.3-h405e4a8_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.7.1-h4e8248e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libdeflate-1.19-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libev-4.33-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libevent-2.1.12-h4ba1bb4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libexpat-2.6.2-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.4.2-h3557bc0_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libflac-1.4.3-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libgcc-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-13.2.0-hf8544c7_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcrypt-1.10.3-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-ng-13.2.0-he9431aa_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-13.2.0-h582850c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.2-h34bac0b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libglu-9.0.0-hf4b6fbe_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-13.2.0-hf8544c7_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgoogle-cloud-2.12.0-h40f64ef_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.49-hb13efb6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgrpc-1.59.3-h877c88e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.10.0-default_h3030c0e_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libiconv-1.17-h31becfc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libidn2-2.3.7-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libjpeg-turbo-3.0.0-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapack-3.9.0-21_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/liblapacke-3.9.0-21_linuxaarch64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libllvm15-15.0.7-hb4f23b0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnghttp2-1.58.0-hb0e430d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnl-3.9.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libnsl-2.0.1-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libogg-1.3.4-h3557bc0_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenblas-0.3.26-pthreads_h5a5ec62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopencv-4.8.1-py312hdc4b82e_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-arm-cpu-plugin-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-batch-plugin-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-auto-plugin-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-hetero-plugin-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-ir-frontend-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-onnx-frontend-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-paddle-frontend-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-pytorch-frontend-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-frontend-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopenvino-tensorflow-lite-frontend-2023.1.0-h2f0025b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopus-1.3.1-hf897c2e_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-14.0.2-hb18b541_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.43-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.3-hcf0348d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-4.24.4-h87e877f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2023.09.01-hf48c5ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librerun-sdk-0.16.0-h2ac1e90_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsanitizer-12.3.0-h8ebda82_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsndfile-1.2.2-h79657aa_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.3-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libssh2-1.11.0-h492db2e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/libstdcxx-devel_linux-aarch64-12.3.0-h8b5ab12_105.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libstdcxx-ng-13.2.0-h9a76618_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libsystemd0-255-h91e93f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtasn1-4.19.0-h4e544f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libthrift-0.19.0-h043aeee_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libtiff-4.6.0-h1708d11_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libunistring-0.9.10-hf897c2e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libutf8proc-2.8.0-h4e544f5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuuid-2.38.1-hb4cce97_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libuv-1.48.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvorbis-1.3.7-h01db608_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libvpx-1.13.1-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcb-1.15-h2a766a3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxcrypt-4.4.36-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h2555907_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h49dc7a2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libzlib-1.2.13-h31becfc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/lz4-c-1.9.4-hd600fc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.6-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-common-8.0.33-hb6794ad_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/mysql-libs-8.0.33-hf629957_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nettle-3.9.1-h9d1147b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ninja-1.11.1-hdd96247_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nspr-4.35-h4de3ea5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.100-h8c4e863_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-1.26.4-py312h470d778_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/opencv-4.8.1-py312ha6f0c23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openh264-2.4.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.2-h0d9d63b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.0-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/orc-1.9.2-h7b7b289_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/p11-kit-0.24.1-h9f2702f_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.43-hd0f9c67_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pillow-10.3.0-py312h317ddc0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pixman-0.43.4-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pthread-stubs-0.4-hb9de7d4_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pugixml-1.14-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pulseaudio-client-16.1-h729494f_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/py-opencv-4.8.1-py312hcbf8c54_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-14.0.2-py312h2f65cca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.3-h43d1f9e_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/qt-main-5.15.8-h5992497_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rdma-core-51.0-h0425590_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/re2-2023.09.01-h9caee61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.2-h8fc344f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rerun-sdk-0.16.0-py312h18b2cab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/rhash-1.4.4-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.4.1-h5a25046_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.1.10-he8610fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/svt-av1-1.8.0-h2f0025b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/sysroot_linux-aarch64-2.17-h5b4a56d_14.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.12.0-h70be974_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/tk-8.6.13-h194ca79_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ucx-1.15.0-hb4872d8_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x264-1!164.3095-h4e544f5_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/x265-3.5-hdd96247_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-0.4.0-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-image-0.4.0-hcb25cf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-keysyms-0.4.0-hcb25cf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-renderutil-0.3.9-h31becfc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xcb-util-wm-0.4.1-hcb25cf1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xkeyboard-config-2.41-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-fixesproto-5.0-h3557bc0_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-inputproto-2.3.2-h3557bc0_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-kbproto-1.0.7-h3557bc0_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libice-1.1.1-h7935292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libsm-1.2.4-h5a01bc2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-h055a233_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxau-1.0.11-h31becfc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxdmcp-1.1.3-h3557bc0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxext-1.3.4-h2a766a3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxfixes-5.0.3-h3557bc0_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxi-1.7.10-h3557bc0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libxrender-0.9.11-h7935292_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-renderproto-0.11.1-h3557bc0_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xextproto-7.3.0-h2a766a3_1003.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xf86vidmodeproto-2.3.1-hf897c2e_1002.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-xproto-7.0.31-h3557bc0_1007.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/xz-5.2.6-h9cdd2b7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.2.13-h31becfc_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
+      osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.7.1-h93d8f39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.11-h94c8779_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-he75d6b7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.12-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-h45babc2_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.1-h3600a39_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.0-h19e0e28_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.0-h49ca7b5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.1-h947eb33_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.4.9-hee0ca28_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.13-h45babc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-h45babc2_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.0-he4637c3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.210-hf51409f_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.28.1-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-compiler-1.6.0-h63c33a9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cairo-1.18.0-h99e66fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools-973.0.1-hd9ad811_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cctools_osx-64-973.0.1-habff3f6_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-15-15.0.7-default_hdb78580_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-15.0.7-h694c41f_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-15-15.0.7-default_hdb78580_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-format-15.0.7-default_hdb78580_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang-tools-15.0.7-default_hdb78580_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_impl_osx-64-15.0.7-h03d6864_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clang_osx-64-15.0.7-hb91bd55_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx-15.0.7-default_hdb78580_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_impl_osx-64-15.0.7-h3d2d1bf_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/clangxx_osx-64-15.0.7-h655633e_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cmake-3.27.6-hf40c264_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/compiler-rt-15.0.7-he1888fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-64-15.0.7-he1888fc_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cxx-compiler-1.6.0-h1c7c39f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/eigen-3.4.0-h1c7c39f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.0-gpl_h0a522cb_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fontconfig-2.14.2-h5bb23bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h73e2aa4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.9-h1951705_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/graphite2-1.3.13-h2e338ed_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.5.0-h053f038_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_hb512a33_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.4-hb10263b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64-609-ha91a046_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ld64_osx-64-609-h0fd476b_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-h1aaacd4_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-ha1803ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h8ec153b_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h01dce7f_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h8ec153b_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libass-0.17.1-h80904bb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-15.0.7-default_hdb78580_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang-cpp15-15.0.7-default_hdb78580_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libclang13-15.0.7-default_h953c2e9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-17.0.6-h88467a6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.2-h0f68cf7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-hc0857f6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.59.3-ha7f534c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h24e0189_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.17-hac89ed1_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.7-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-h5ff76d1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapacke-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-he4b1e75_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_hfef2a42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopencv-4.8.1-py312h989985c_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-batch-plugin-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-auto-plugin-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-hetero-plugin-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-intel-cpu-plugin-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-ir-frontend-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-onnx-frontend-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-paddle-frontend-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-pytorch-frontend-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-frontend-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenvino-tensorflow-lite-frontend-2023.1.0-h93d8f39_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.24.4-hc4f2305_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h4694dbf_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/librerun-sdk-0.16.0-ha45f3c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.3-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtasn1-4.19.0-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libunistring-0.9.10-h0d85af4_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.48.0-h67532ce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libvpx-1.13.1-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.6-hc0ae0f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.5-h39e0ece_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-tools-15.0.7-he4b1e75_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.9.1-h8e11ae5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ninja-1.11.1-hb8565cd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py312he3a82b2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/opencv-4.8.1-py312hbdb8196_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.4.0-h93d8f39_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.0-hd75f5a5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-h9ab30d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/p11-kit-0.24.1-h65f8906_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.3.0-py312h0c923fa_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pugixml-1.14-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/py-opencv-4.8.1-py312h128fb24_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py312h40fbfea_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.3-h1411813_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.09.01-hb168e87_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rerun-sdk-0.16.0-py312h0329a8d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/sigtool-0.1.3-h88f4db0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.1.10-h225ccf5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.7.0-he965462_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tapi-1100.0.11-h9ce4665_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/x265-3.5-hbb4e6a2_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+      osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.7.1-h463b476_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.11-ha4ce7b8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-h4fd42c2_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.12-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-h4fd42c2_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.1-he66824e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.0-hd3d28cd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.0-h8daa835_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.1-h59ff425_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.4.9-h7f99a2c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.13-h4fd42c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-h4fd42c2_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.0-hfff802b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.210-he93ac2d_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.28.1-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-compiler-1.6.0-hd291e01_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.18.0-hd1e100b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools-973.0.1-hd1ac623_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cctools_osx-arm64-973.0.1-h2a25c60_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-15-15.0.7-default_h5dc8d65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-15.0.7-hce30654_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-15-15.0.7-default_h5dc8d65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-format-15.0.7-default_h5dc8d65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang-tools-15.0.7-default_h5dc8d65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_impl_osx-arm64-15.0.7-h77e971b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clang_osx-arm64-15.0.7-h54d7cd3_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx-15.0.7-default_h610c423_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_impl_osx-arm64-15.0.7-h768a7fd_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/clangxx_osx-arm64-15.0.7-h77e971b_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cmake-3.27.6-h1c59155_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/compiler-rt-15.0.7-hf8d1dfb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/compiler-rt_osx-arm64-15.0.7-hf8d1dfb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cxx-compiler-1.6.0-h1995070_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/eigen-3.4.0-h1995070_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.0-gpl_h032c140_102.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fontconfig-2.14.2-h82840c6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.12.1-hadb7bae_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hc88da5d_1004.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hebf3989_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.5.0-h1836168_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_h751145d_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.2-h92f50d5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.16-ha0e7c42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64-609-h89fa09d_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ld64_osx-arm64-609-hc4dc95b_15.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h4ce3932_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-ha94d253_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h39a9b85_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hf757142_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h7fd9903_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libass-0.17.1-hf7da4fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.1.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-15.0.7-default_h5dc8d65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang-cpp15-15.0.7-default_h5dc8d65_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libclang13-15.0.7-default_hc7183e1_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.7.1-h2d989ff_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-17.0.6-h5f092b4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.2-h535f939_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-hfb399a7_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.59.3-h9560976_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.9.3-default_h4394839_1009.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.7-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8fbad5d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libjpeg-turbo-3.0.0-hb547adb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapacke-3.9.0-19_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h504e6bf_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.58.0-ha4dd798_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.27-openmp_h6c19121_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopencv-4.8.1-py312hc03029b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-arm-cpu-plugin-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-batch-plugin-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-auto-plugin-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-hetero-plugin-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-ir-frontend-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-onnx-frontend-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-paddle-frontend-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-pytorch-frontend-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-frontend-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopenvino-tensorflow-lite-frontend-2023.1.0-h965bd2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.24.4-h810fc01_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.09.01-h741fcf5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librerun-sdk-0.16.0-hda85e2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.3-h091b4b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.19.0-h026a170_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.48.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libvpx-1.13.1-hb765f3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.15-hf346824_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.6-h0d0cfa8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.5-hde57baf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-tools-15.0.7-h504e6bf_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ninja-1.11.1-hffc8910_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/opencv-4.8.1-py312h2a52fbe_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.0-h965bd2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.0-h0d3ecfb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.2-h7c018df_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/p11-kit-0.24.1-h29577a5_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.3.0-py312h8a801b1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pugixml-1.14-h13dd4ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/py-opencv-4.8.1-py312hf81aaa1_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py312h14a4a34_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.3-h4a7b5fc_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.09.01-h4cba328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rerun-sdk-0.16.0-py312h5c2e7bc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/sigtool-0.1.3-h44b9a77_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/snappy-1.1.10-h17c5cce_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/svt-av1-1.7.0-hb765f3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tapi-1100.0.11-he4954df_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.11.0-h2ffa867_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hb31c410_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/x265-3.5-hbc6ce65_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+      win-64:
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.0-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.11-hcf9e330_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.9-hd33547d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.12-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-hd33547d_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.1-h875930a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.0-ha1a3518_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.0-hf372335_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.1-hda1dad8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.4.9-hef93162_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.13-hd33547d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-hd33547d_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.0-hed7b20b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.210-h20b5662_10.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.28.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cairo-1.18.0-h1fef639_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/clang-format-15.0.7-default_h66ee7f4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/clang-tools-15.0.7-default_h66ee7f4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cmake-3.27.6-hf0feee3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/eigen-3.4.0-h91493d7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_h69c1fb8_111.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-hab24e00_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/fontconfig-2.14.2-hbde0cde_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-h63175ca_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.2-h0df6a38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.2-h2f9d560_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/graphite2-1.3.13-1000.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.5.0-h81778c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/icu-73.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/khronos-opencl-icd-loader-2023.04.17-h64bf75a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-he5f67d5_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-h53b1db0_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h78eab7c_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hb2eaab1_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-hd4c9904_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang-15.0.7-default_h77d9078_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libclang13-15.0.7-default_h77d9078_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.7.1-hd5e4a3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.2-h0df6a38_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-h39f2fc6_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.59.3-h5bbd4a7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.10.0-default_h8125262_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/liblapacke-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libogg-1.3.4-h8ffe710_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopencv-4.8.1-py312h601028a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-batch-plugin-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-auto-plugin-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-hetero-plugin-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-cpu-plugin-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-intel-gpu-plugin-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-ir-frontend-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-onnx-frontend-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-paddle-frontend-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-pytorch-frontend-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-frontend-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopenvino-tensorflow-lite-frontend-2023.1.0-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libopus-1.3.1-h8ffe710_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.24.4-hb8276f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-h8c5ae5e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/librerun-sdk-0.16.0-h68b577a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.3-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libvorbis-1.3.7-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h283a6d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libs-core-5.3.0-7.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py312h8753938_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/opencv-4.8.1-py312h63a316d_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.2-hf0b6bd4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.3.0-py312h6f6a607_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pugixml-1.14-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/py-opencv-4.8.1-py312hc50e9f6_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py312h85e32bb_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.12-4_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/qt-main-5.15.8-h9e85ed6_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.09.01-hd3b24a8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rerun-sdk-0.16.0-py312h7a6832a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.0.0-h63175ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.11.0-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h0c530f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.22621.0-h57928b3_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2022_win-64-19.37.32822-h0123c8e_17.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x264-1!164.3095-h8ffe710_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/x265-3.5-h2d74725_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
 packages:
 - kind: conda
   name: _libgcc_mutex
@@ -1000,8 +2052,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
   md5: d7c89558ba9fa0495403155b64376d81
-  arch: x86_64
-  platform: linux
   license: None
   size: 2562
   timestamp: 1578324546067
@@ -1015,12 +2065,10 @@ packages:
   sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
   md5: 73aaf86a425cc6e73fcf236a5a46396d
   depends:
-  - _libgcc_mutex ==0.1 conda_forge
+  - _libgcc_mutex 0.1 conda_forge
   - libgomp >=7.5.0
   constrains:
   - openmp_impl 9999
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 23621
@@ -1066,8 +2114,6 @@ packages:
   md5: 75dae9a4201732aa78a530b826ee5fe0
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   license_family: GPL
   size: 554938
@@ -1089,73 +2135,6 @@ packages:
   timestamp: 1709396718705
 - kind: conda
   name: aom
-  version: 3.6.1
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.6.1-h59595ed_0.conda
-  sha256: 006d10fe845374e71fb15a6c1f58ae4b3efef69be02b0992265abfb5c4c2e026
-  md5: 8457db6d1175ee86c8e077f6ac60ff55
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2678249
-  timestamp: 1694225960207
-- kind: conda
-  name: aom
-  version: 3.6.1
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.6.1-h63175ca_0.conda
-  sha256: 3d5ae5f4f032daf24b9ac412cd57047590866e09e807f5a16d8112c6fe84700c
-  md5: 40e557b0d849edcb884d02d9ea6511bf
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 7918540
-  timestamp: 1694228877684
-- kind: conda
-  name: aom
-  version: 3.6.1
-  build: hb765f3a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.6.1-hb765f3a_0.conda
-  sha256: 71e86411093a5241fa9349b61e0c42a841d39364b8298bd80919ede75fc496bd
-  md5: efe2c75abcf259999d1779bbbc9cd3ce
-  depends:
-  - libcxx >=15.0.7
-  arch: aarch64
-  platform: osx
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2067686
-  timestamp: 1694226240409
-- kind: conda
-  name: aom
-  version: 3.6.1
-  build: he965462_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.6.1-he965462_0.conda
-  sha256: 254f15bbfda2e474c63f9a30bfc7f2d4d30ff49d6543481bf6a5bf414ec9bcd7
-  md5: 3685ccc84e1b901601331f1aecead92c
-  depends:
-  - libcxx >=15.0.7
-  arch: x86_64
-  platform: osx
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2855123
-  timestamp: 1694226514540
-- kind: conda
-  name: aom
   version: 3.7.1
   build: h0425590_0
   subdir: linux-aarch64
@@ -1170,6 +2149,67 @@ packages:
   size: 2938408
   timestamp: 1700530384923
 - kind: conda
+  name: aom
+  version: 3.7.1
+  build: h463b476_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.7.1-h463b476_0.conda
+  sha256: a12485082ca6f3774bd866df308fcb9856e675da66f83b220a43aa12309d4d68
+  md5: 21f849867fa093cafe263e1b54967e46
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2098343
+  timestamp: 1700530866396
+- kind: conda
+  name: aom
+  version: 3.7.1
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aom-3.7.1-h59595ed_0.conda
+  sha256: 57ad60805ffc7097a690d6d0e07ba432a3dae187158e13001c392177358478f9
+  md5: 504e70332b8322cda93b7bceb5925fca
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2688122
+  timestamp: 1700530526866
+- kind: conda
+  name: aom
+  version: 3.7.1
+  build: h93d8f39_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aom-3.7.1-h93d8f39_0.conda
+  sha256: 3deb1bd9adea4f2ec0759e113dd31525c83536c0af63483b6e23aa724662252a
+  md5: 4829474bede4266b6561d05053bcaf31
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2921470
+  timestamp: 1700531206853
+- kind: conda
+  name: aom
+  version: 3.9.0
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.0-he0c23c2_0.conda
+  sha256: 324cc117c8357c2d376314d16b4532b0abacccb197a3f1c9077e4c2e896c164e
+  md5: 12fabceb3d880581a35c78b4d195f829
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 1972773
+  timestamp: 1713925809773
+- kind: conda
   name: attr
   version: 2.5.1
   build: h166bdaf_1
@@ -1180,8 +2220,6 @@ packages:
   md5: d9c69a24ad678ffce24c6543a0176b00
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL
   size: 71042
@@ -2583,20 +3621,6 @@ packages:
   timestamp: 1606605223049
 - kind: conda
   name: c-ares
-  version: 1.27.0
-  build: h31becfc_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.27.0-h31becfc_0.conda
-  sha256: 4152e674377179b35d59ddd9218411477a206ecff5f5939dfc963f997cf3b8b8
-  md5: f03f76a77d690f2d31ce12e7b4e12ae4
-  depends:
-  - libgcc-ng >=12
-  license: MIT
-  license_family: MIT
-  size: 170421
-  timestamp: 1708684764494
-- kind: conda
-  name: c-ares
   version: 1.28.1
   build: h10d778d_0
   subdir: osx-64
@@ -2607,6 +3631,20 @@ packages:
   license_family: MIT
   size: 152607
   timestamp: 1711819681694
+- kind: conda
+  name: c-ares
+  version: 1.28.1
+  build: h31becfc_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.28.1-h31becfc_0.conda
+  sha256: 0d7b310411f069975053ee5ce750fc6d8c368607164ce2a921a7a1a068dc137b
+  md5: a8da75795c853c5fe6d8d1947e16eea8
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 176103
+  timestamp: 1711819570996
 - kind: conda
   name: c-ares
   version: 1.28.1
@@ -2676,9 +3714,7 @@ packages:
   - cctools >=949.0.1
   - clang_osx-64 15.*
   - ld64 >=530
-  - llvm-openmp *
-  arch: x86_64
-  platform: osx
+  - llvm-openmp
   license: BSD
   size: 6250
   timestamp: 1689097835926
@@ -2694,9 +3730,7 @@ packages:
   - cctools >=949.0.1
   - clang_osx-arm64 15.*
   - ld64 >=530
-  - llvm-openmp *
-  arch: aarch64
-  platform: osx
+  - llvm-openmp
   license: BSD
   size: 6269
   timestamp: 1689097851052
@@ -2709,66 +3743,45 @@ packages:
   sha256: d741ff93d5f71a83a9be0f592682f31ca2d468c37177f18a8d1a2469bb821c05
   md5: ea6c792f792bdd7ae6e7e2dee32f0a48
   depends:
-  - binutils *
-  - gcc *
+  - binutils
+  - gcc
   - gcc_linux-64 12.*
-  arch: x86_64
-  platform: linux
   license: BSD
   size: 6184
   timestamp: 1689097480051
 - kind: conda
   name: ca-certificates
-  version: 2023.7.22
+  version: 2024.2.2
   build: h56e8100_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
-  sha256: b85a6f307f8e1c803cb570bdfb9e4d811a361417873ecd2ecf687587405a72e0
-  md5: b1c2327b36f1a25d96f2039b0d3e3739
-  arch: x86_64
-  platform: win
+  url: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2024.2.2-h56e8100_0.conda
+  sha256: 4d587088ecccd393fec3420b64f1af4ee1a0e6897a45cfd5ef38055322cea5d0
+  md5: 63da060240ab8087b60d1357051ea7d6
   license: ISC
-  size: 150013
-  timestamp: 1690026269050
+  size: 155886
+  timestamp: 1706843918052
 - kind: conda
   name: ca-certificates
-  version: 2023.7.22
+  version: 2024.2.2
   build: h8857fd0_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
-  sha256: 27de15e18a12117e83ac1eb8a8e52eb65731cc7f0b607a7922206a15e2460c7b
-  md5: bf2c54c18997bf3542af074c10191771
-  arch: x86_64
-  platform: osx
+  url: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.2.2-h8857fd0_0.conda
+  sha256: 54a794aedbb4796afeabdf54287b06b1d27f7b13b3814520925f4c2c80f58ca9
+  md5: f2eacee8c33c43692f1ccfd33d0f50b1
   license: ISC
-  size: 149911
-  timestamp: 1690026363769
+  size: 155665
+  timestamp: 1706843838227
 - kind: conda
   name: ca-certificates
-  version: 2023.7.22
+  version: 2024.2.2
   build: hbcca054_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
-  sha256: 525b7b6b5135b952ec1808de84e5eca57c7c7ff144e29ef3e96ae4040ff432c1
-  md5: a73ecd2988327ad4c8f2c331482917f2
-  arch: x86_64
-  platform: linux
+  url: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.2.2-hbcca054_0.conda
+  sha256: 91d81bfecdbb142c15066df70cc952590ae8991670198f92c66b62019b251aeb
+  md5: 2f4327a1cbe7f022401b236e915a5fef
   license: ISC
-  size: 149515
-  timestamp: 1690026108541
-- kind: conda
-  name: ca-certificates
-  version: 2023.7.22
-  build: hf0a4a13_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2023.7.22-hf0a4a13_0.conda
-  sha256: b220c001b0c1448a47cc49b42a622e06a540ec60b3f7a1e057fca1f37ce515e4
-  md5: e1b99ac4dbcee71a71682996f67f7965
-  arch: aarch64
-  platform: osx
-  license: ISC
-  size: 149918
-  timestamp: 1690026385821
+  size: 155432
+  timestamp: 1706843687645
 - kind: conda
   name: ca-certificates
   version: 2024.2.2
@@ -2781,6 +3794,17 @@ packages:
   size: 155738
   timestamp: 1706845723412
 - kind: conda
+  name: ca-certificates
+  version: 2024.2.2
+  build: hf0a4a13_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.2.2-hf0a4a13_0.conda
+  sha256: 49bc3439816ac72d0c0e0f144b8cc870fdcc4adec2e861407ec818d8116b2204
+  md5: fb416a1795f18dcc5a038bc2dc54edf9
+  license: ISC
+  size: 155725
+  timestamp: 1706844034242
+- kind: conda
   name: cairo
   version: 1.18.0
   build: h1fef639_0
@@ -2790,7 +3814,7 @@ packages:
   md5: b3fe2c6381ec74afe8128e16a11eee02
   depends:
   - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
+  - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - icu >=73.2,<74.0a0
   - libglib >=2.78.0,<3.0a0
@@ -2800,9 +3824,7 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zlib *
-  arch: x86_64
-  platform: win
+  - zlib
   license: LGPL-2.1-only or MPL-1.1
   size: 1520159
   timestamp: 1697029136038
@@ -2816,7 +3838,7 @@ packages:
   md5: f907bb958910dc404647326ca80c263e
   depends:
   - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
+  - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
@@ -2831,9 +3853,7 @@ packages:
   - xorg-libx11 >=1.8.6,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxrender >=0.9.11,<0.10.0a0
-  - zlib *
-  arch: x86_64
-  platform: linux
+  - zlib
   license: LGPL-2.1-only or MPL-1.1
   size: 982351
   timestamp: 1697028423052
@@ -2848,7 +3868,7 @@ packages:
   depends:
   - __osx >=10.9
   - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
+  - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - icu >=73.2,<74.0a0
   - libcxx >=16.0.6
@@ -2856,9 +3876,7 @@ packages:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - pixman >=0.42.2,<1.0a0
-  - zlib *
-  arch: x86_64
-  platform: osx
+  - zlib
   license: LGPL-2.1-only or MPL-1.1
   size: 885311
   timestamp: 1697028802967
@@ -2902,7 +3920,7 @@ packages:
   depends:
   - __osx >=10.9
   - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
+  - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - icu >=73.2,<74.0a0
   - libcxx >=16.0.6
@@ -2910,9 +3928,7 @@ packages:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - pixman >=0.42.2,<1.0a0
-  - zlib *
-  arch: aarch64
-  platform: osx
+  - zlib
   license: LGPL-2.1-only or MPL-1.1
   size: 897919
   timestamp: 1697028755150
@@ -2926,11 +3942,9 @@ packages:
   sha256: 19355c566c376acba7beed4c6f68a2c09fa1b5bbbbcacc6375c2fcb90faf6063
   md5: bea60d4b6c7112c9d906cd8380498c99
   depends:
-  - cctools_osx-arm64 ==973.0.1 h2a25c60_15
-  - ld64 ==609 h89fa09d_15
+  - cctools_osx-arm64 973.0.1 h2a25c60_15
+  - ld64 609 h89fa09d_15
   - libllvm15 >=15.0.7,<15.1.0a0
-  arch: aarch64
-  platform: osx
   license: APSL-2.0
   license_family: Other
   size: 21948
@@ -2945,11 +3959,9 @@ packages:
   sha256: 6fc0e86e24687cde3476e04f001ac1edf5813c0caa15b72c913b660533428987
   md5: 00374d616829d1e4d2266e571147848a
   depends:
-  - cctools_osx-64 ==973.0.1 habff3f6_15
-  - ld64 ==609 ha91a046_15
+  - cctools_osx-64 973.0.1 habff3f6_15
+  - ld64 609 ha91a046_15
   - libllvm15 >=15.0.7,<15.1.0a0
-  arch: x86_64
-  platform: osx
   license: APSL-2.0
   license_family: Other
   size: 21917
@@ -2965,16 +3977,14 @@ packages:
   md5: 015a19b3900b9fce20a48551e66f7699
   depends:
   - ld64_osx-64 >=609,<610.0a0
-  - libcxx *
+  - libcxx
   - libllvm15 >=15.0.7,<15.1.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - sigtool *
+  - sigtool
   constrains:
   - cctools 973.0.1.*
   - ld64 609.*
   - clang 15.0.*
-  arch: x86_64
-  platform: osx
   license: APSL-2.0
   license_family: Other
   size: 1116869
@@ -2990,16 +4000,14 @@ packages:
   md5: e177015a6a6500334b9cac9144fc657d
   depends:
   - ld64_osx-arm64 >=609,<610.0a0
-  - libcxx *
+  - libcxx
   - libllvm15 >=15.0.7,<15.1.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - sigtool *
+  - sigtool
   constrains:
   - clang 15.0.*
   - ld64 609.*
   - cctools 973.0.1.*
-  arch: aarch64
-  platform: osx
   license: APSL-2.0
   license_family: Other
   size: 1123180
@@ -3616,8 +4624,6 @@ packages:
   - rhash >=1.4.4,<2.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  arch: aarch64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 16007289
@@ -3642,8 +4648,6 @@ packages:
   - rhash >=1.4.4,<2.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 18494905
@@ -3690,8 +4694,6 @@ packages:
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 13777396
@@ -3715,8 +4717,6 @@ packages:
   - rhash >=1.4.4,<2.0a0
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 16525734
@@ -3810,11 +4810,9 @@ packages:
   sha256: 472b6b7f967df1db634c67d71c6b31cd186d18b5d0548196c2e426833ff17d99
   md5: 364c6ae36c4e36fcbd4d273cf4db78af
   depends:
-  - c-compiler ==1.6.0 hd590300_0
-  - gxx *
+  - c-compiler 1.6.0 hd590300_0
+  - gxx
   - gxx_linux-64 12.*
-  arch: x86_64
-  platform: linux
   license: BSD
   size: 6179
   timestamp: 1689097484095
@@ -3827,10 +4825,8 @@ packages:
   sha256: f0a94c6312d0fd9e3d3c3546894bafa9f9b8b20a411bee0767ad4dac916f3eb5
   md5: 35c1be0a08578238276ca9417fc1615c
   depends:
-  - c-compiler ==1.6.0 hd291e01_0
+  - c-compiler 1.6.0 hd291e01_0
   - clangxx_osx-arm64 15.*
-  arch: aarch64
-  platform: osx
   license: BSD
   size: 6301
   timestamp: 1689097905706
@@ -3843,10 +4839,8 @@ packages:
   sha256: dc0860c05ef3083192b8ff4ac8242403f05a550cc42c7709ec8c9f4eaa88e993
   md5: 9adaf7c9d4e1e15e70a8dd46befbbab2
   depends:
-  - c-compiler ==1.6.0 h63c33a9_0
+  - c-compiler 1.6.0 h63c33a9_0
   - clangxx_osx-64 15.*
-  arch: x86_64
-  platform: osx
   license: BSD
   size: 6258
   timestamp: 1689097854160
@@ -3873,8 +4867,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
   sha256: ec71a835866b42e946cd2039a5f7a6458851a21890d315476f5e66790ac11c96
   md5: 9d88733c715300a39f8ca2e936b7808d
-  arch: x86_64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 668439
@@ -3901,8 +4893,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
   sha256: 93e077b880a85baec8227e8c72199220c7f87849ad32d02c14fb3807368260b8
   md5: 5a74cdee497e6b65173e10d94582fae6
-  arch: aarch64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 316394
@@ -3919,8 +4909,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-2-Clause
   license_family: BSD
   size: 618643
@@ -3935,8 +4923,6 @@ packages:
   md5: 418c6ca5929a611cbd69204907a83995
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 760229
@@ -3971,8 +4957,6 @@ packages:
   - expat >=2.4.2,<3.0a0
   - libgcc-ng >=9.4.0
   - libglib >=2.70.2,<3.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL
   size: 618596
@@ -3988,8 +4972,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: MPL-2.0
   license_family: MOZILLA
   size: 1088433
@@ -4004,8 +4986,6 @@ packages:
   md5: 3691ea3ff568ba38826389bafc717909
   depends:
   - libcxx >=15.0.7
-  arch: aarch64
-  platform: osx
   license: MPL-2.0
   license_family: MOZILLA
   size: 1087751
@@ -4020,8 +5000,6 @@ packages:
   md5: 5b2cfc277e3d42d84a2a648825761156
   depends:
   - libcxx >=15.0.7
-  arch: x86_64
-  platform: osx
   license: MPL-2.0
   license_family: MOZILLA
   size: 1090184
@@ -4053,81 +5031,10 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MPL-2.0
   license_family: MOZILLA
   size: 1089706
   timestamp: 1690273089254
-- kind: conda
-  name: expat
-  version: 2.5.0
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
-  sha256: 3bcd88290cd462d5573c2923c796599d0dece2ff9d9c9d6c914d31e9c5881aaf
-  md5: 87c77fe1b445aedb5c6d207dd236fa3e
-  depends:
-  - libexpat ==2.5.0 h63175ca_1
-  arch: x86_64
-  platform: win
-  license: MIT
-  license_family: MIT
-  size: 226571
-  timestamp: 1680190888036
-- kind: conda
-  name: expat
-  version: 2.5.0
-  build: hb7217d7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
-  sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
-  md5: 624fa0dd6fdeaa650b71a62296fdfedf
-  depends:
-  - libexpat ==2.5.0 hb7217d7_1
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 117851
-  timestamp: 1680190940654
-- kind: conda
-  name: expat
-  version: 2.5.0
-  build: hcb278e6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
-  sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
-  md5: 8b9b5aca60558d02ddaa09d599e55920
-  depends:
-  - libexpat ==2.5.0 hcb278e6_1
-  - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
-  license: MIT
-  license_family: MIT
-  size: 136778
-  timestamp: 1680190541750
-- kind: conda
-  name: expat
-  version: 2.5.0
-  build: hf0c8a7f_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
-  sha256: 15c04a5a690b337b50fb7550cce057d843cf94dd0109d576ec9bc3448a8571d0
-  md5: e12630038077877cbb6c7851e139c17c
-  depends:
-  - libexpat ==2.5.0 hf0c8a7f_1
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 120323
-  timestamp: 1680191057827
 - kind: conda
   name: expat
   version: 2.6.2
@@ -4144,146 +5051,206 @@ packages:
   size: 128302
   timestamp: 1710362329008
 - kind: conda
-  name: ffmpeg
-  version: 6.0.0
-  build: gpl_h1627b0f_105
-  build_number: 105
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.0.0-gpl_h1627b0f_105.conda
-  sha256: 2afe22be1e563fdf668a263b780c6eb0553cd4b693fa3cfcb703425f898db544
-  md5: f77a3331e513563b09d49c6a659da1c6
+  name: expat
+  version: 2.6.2
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
+  sha256: 89916c536ae5b85bb8bf0cfa27d751e274ea0911f04e4a928744735c14ef5155
+  md5: 53fb86322bdb89496d7579fe3f02fd61
   depends:
-  - aom >=3.6.1,<3.7.0a0
+  - libexpat 2.6.2 h59595ed_0
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 137627
+  timestamp: 1710362144873
+- kind: conda
+  name: expat
+  version: 2.6.2
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
+  sha256: f5a13d4bc591a4dc210954f492dd59a0ecf9b9d2ab28bf2ece755ca8f69ec1b4
+  md5: 52f9dec6758ceb8ce0ea8af9fa13eb1a
+  depends:
+  - libexpat 2.6.2 h63175ca_0
+  license: MIT
+  license_family: MIT
+  size: 229627
+  timestamp: 1710362661692
+- kind: conda
+  name: expat
+  version: 2.6.2
+  build: h73e2aa4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
+  sha256: 0fd1befb18d9d937358a90d5b8f97ac2402761e9d4295779cbad9d7adfb47976
+  md5: dc0882915da2ec74696ad87aa2350f27
+  depends:
+  - libexpat 2.6.2 h73e2aa4_0
+  license: MIT
+  license_family: MIT
+  size: 126612
+  timestamp: 1710362607162
+- kind: conda
+  name: expat
+  version: 2.6.2
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
+  sha256: 9ac22553a4d595d7e4c9ca9aa09a0b38da65314529a7a7008edc73d3f9e7904a
+  md5: de0cff0ec74f273c4b6aa281479906c3
+  depends:
+  - libexpat 2.6.2 hebf3989_0
+  license: MIT
+  license_family: MIT
+  size: 124594
+  timestamp: 1710362455984
+- kind: conda
+  name: ffmpeg
+  version: 6.1.0
+  build: gpl_h032c140_102
+  build_number: 102
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.1.0-gpl_h032c140_102.conda
+  sha256: f712e563e3590c03b1f63f0f7250c16f4591f9bf5b9084d020a56c347464d41c
+  md5: 889a3240dfbdc468ff8ddb483a3c966c
+  depends:
+  - __osx >=10.9
+  - aom >=3.7.1,<3.8.0a0
   - bzip2 >=1.0.8,<2.0a0
   - dav1d >=1.2.1,<1.2.2.0a0
   - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
+  - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.8,<3.8.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libcxx >=16.0.6
+  - libiconv >=1.17,<2.0a0
   - libopus >=1.3.1,<2.0a0
-  - libxml2 >=2.11.5,<2.12.0a0
+  - libvpx >=1.13.1,<1.14.0a0
+  - libxml2 >=2.11.6,<3.0.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.3.1,<2.3.2.0a0
+  - openh264 >=2.4.0,<2.4.1.0a0
   - svt-av1 >=1.7.0,<1.7.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 8637308
+  timestamp: 1700972246163
+- kind: conda
+  name: ffmpeg
+  version: 6.1.0
+  build: gpl_h0a522cb_102
+  build_number: 102
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.1.0-gpl_h0a522cb_102.conda
+  sha256: 795a80d14ee3f301f3bf25c159de4152ea190ea16cd45274839203a27f61de21
+  md5: d846af1523876e21e3476d23cad73f5d
+  depends:
+  - __osx >=10.9
+  - aom >=3.7.1,<3.8.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.8,<3.8.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libcxx >=16.0.6
+  - libiconv >=1.17,<2.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libvpx >=1.13.1,<1.14.0a0
+  - libxml2 >=2.11.6,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.0,<2.4.1.0a0
+  - svt-av1 >=1.7.0,<1.7.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9652736
+  timestamp: 1700972208550
+- kind: conda
+  name: ffmpeg
+  version: 6.1.0
+  build: gpl_ha330e6d_102
+  build_number: 102
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.1.0-gpl_ha330e6d_102.conda
+  sha256: aeb882967f9846b9a8dd5d9969650aed9550a197d43966acd216145ca103b3c1
+  md5: 43a0392a3073a0aa82cf345bc76d00f3
+  depends:
+  - aom >=3.7.1,<3.8.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - gmp >=6.3.0,<7.0a0
+  - gnutls >=3.7.8,<3.8.0a0
+  - lame >=3.100,<3.101.0a0
+  - libass >=0.17.1,<0.17.2.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libstdcxx-ng >=12
+  - libva >=2.20.0,<3.0a0
+  - libvpx >=1.13.1,<1.14.0a0
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.11.6,<3.0.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.0,<2.4.1.0a0
+  - svt-av1 >=1.7.0,<1.7.1.0a0
+  - x264 >=1!164.3095,<1!165
+  - x265 >=3.5,<3.6.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xz >=5.2.6,<6.0a0
+  license: GPL-2.0-or-later
+  license_family: GPL
+  size: 9762764
+  timestamp: 1700971914538
+- kind: conda
+  name: ffmpeg
+  version: 6.1.1
+  build: gpl_h69c1fb8_111
+  build_number: 111
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ffmpeg-6.1.1-gpl_h69c1fb8_111.conda
+  sha256: bc8010bc2a410f47fc580b26e9108843d9af740142f2b3e4a3dc0ffa69b04161
+  md5: 8e36b4e0f3be883d6180211c63b45aff
+  depends:
+  - aom >=3.9.0,<3.10.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - fontconfig >=2.14.2,<3.0a0
+  - fonts-conda-ecosystem
+  - freetype >=2.12.1,<3.0a0
+  - harfbuzz >=8.4.0,<9.0a0
+  - libiconv >=1.17,<2.0a0
+  - libopus >=1.3.1,<2.0a0
+  - libxml2 >=2.12.6,<3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openh264 >=2.4.1,<2.4.2.0a0
+  - svt-av1 >=2.0.0,<2.0.1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - x264 >=1!164.3095,<1!165
   - x265 >=3.5,<3.6.0a0
-  arch: x86_64
-  platform: win
+  - xz >=5.2.6,<6.0a0
   license: GPL-2.0-or-later
   license_family: GPL
-  size: 11547920
-  timestamp: 1696215463384
-- kind: conda
-  name: ffmpeg
-  version: 6.0.0
-  build: gpl_h1ceb99f_105
-  build_number: 105
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ffmpeg-6.0.0-gpl_h1ceb99f_105.conda
-  sha256: 7d23734203eae2fd8cb1a22f6771664258e9d57c098f0ed45533717a836db209
-  md5: ab473674ec333a0fec0de661107bc6c1
-  depends:
-  - aom >=3.6.1,<3.7.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.2.1,<7.0a0
-  - gnutls >=3.7.8,<3.8.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libcxx >=15.0.7
-  - libiconv >=1.17,<2.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libvpx >=1.13.0,<1.14.0a0
-  - libxml2 >=2.11.5,<2.12.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.3.1,<2.3.2.0a0
-  - svt-av1 >=1.7.0,<1.7.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  arch: aarch64
-  platform: osx
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 8643472
-  timestamp: 1696215071693
-- kind: conda
-  name: ffmpeg
-  version: 6.0.0
-  build: gpl_h334edf3_105
-  build_number: 105
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ffmpeg-6.0.0-gpl_h334edf3_105.conda
-  sha256: f1f9070190bc189b9ec9034e9d9adbbb530cd25b571c763b33585195c0e13813
-  md5: d47c3e10d2ca5fc07107d4ac640603da
-  depends:
-  - aom >=3.6.1,<3.7.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.2.1,<7.0a0
-  - gnutls >=3.7.8,<3.8.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libgcc-ng >=12
-  - libopus >=1.3.1,<2.0a0
-  - libstdcxx-ng >=12
-  - libva >=2.20.0,<3.0a0
-  - libvpx >=1.13.0,<1.14.0a0
-  - libxml2 >=2.11.5,<2.12.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.3.1,<2.3.2.0a0
-  - svt-av1 >=1.7.0,<1.7.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  arch: x86_64
-  platform: linux
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 9863087
-  timestamp: 1696214559606
-- kind: conda
-  name: ffmpeg
-  version: 6.0.0
-  build: gpl_h789aacd_105
-  build_number: 105
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ffmpeg-6.0.0-gpl_h789aacd_105.conda
-  sha256: d0e8d127a3d3f9331bb82ee9a0c22870a6417c0cb568a834659473e7cf546894
-  md5: d15fb0935b56b41d1510e3e749610426
-  depends:
-  - aom >=3.6.1,<3.7.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
-  - freetype >=2.12.1,<3.0a0
-  - gmp >=6.2.1,<7.0a0
-  - gnutls >=3.7.8,<3.8.0a0
-  - lame >=3.100,<3.101.0a0
-  - libass >=0.17.1,<0.17.2.0a0
-  - libcxx >=15.0.7
-  - libiconv >=1.17,<2.0a0
-  - libopus >=1.3.1,<2.0a0
-  - libvpx >=1.13.0,<1.14.0a0
-  - libxml2 >=2.11.5,<2.12.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openh264 >=2.3.1,<2.3.2.0a0
-  - svt-av1 >=1.7.0,<1.7.1.0a0
-  - x264 >=1!164.3095,<1!165
-  - x265 >=3.5,<3.6.0a0
-  arch: x86_64
-  platform: osx
-  license: GPL-2.0-or-later
-  license_family: GPL
-  size: 10026915
-  timestamp: 1696215119867
+  size: 9643045
+  timestamp: 1715340686745
 - kind: conda
   name: ffmpeg
   version: 6.1.1
@@ -4411,8 +5378,6 @@ packages:
   - libgcc-ng >=12
   - libuuid >=2.32.1,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 272010
@@ -4429,8 +5394,6 @@ packages:
   - expat >=2.5.0,<3.0a0
   - freetype >=2.12.1,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 237068
@@ -4447,8 +5410,6 @@ packages:
   - expat >=2.5.0,<3.0a0
   - freetype >=2.12.1,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 237668
@@ -4487,8 +5448,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 190111
@@ -4543,8 +5502,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 111787
@@ -4565,10 +5522,8 @@ packages:
   - xorg-libx11 >=1.8.4,<2.0a0
   - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxfixes *
-  - xorg-libxi *
-  arch: x86_64
-  platform: linux
+  - xorg-libxfixes
+  - xorg-libxi
   license: MIT
   license_family: MIT
   size: 142933
@@ -4608,8 +5563,6 @@ packages:
   - libgcc-ng >=12
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-only OR FTL
   size: 634972
   timestamp: 1694615932610
@@ -4625,8 +5578,6 @@ packages:
   depends:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: osx
   license: GPL-2.0-only OR FTL
   size: 599300
   timestamp: 1694616137838
@@ -4642,8 +5593,6 @@ packages:
   depends:
   - libpng >=1.6.39,<1.7.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  arch: aarch64
-  platform: osx
   license: GPL-2.0-only OR FTL
   size: 596430
   timestamp: 1694616332835
@@ -4662,8 +5611,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: GPL-2.0-only OR FTL
   size: 510306
   timestamp: 1694616398888
@@ -4691,8 +5638,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/fribidi-1.0.10-h27ca646_0.tar.bz2
   sha256: 4b37ea851a2cf85edf0a63d2a63266847ec3dcbba4a31156d430cdd6aa811303
   md5: c64443234ff91d70cb9c7dc926c58834
-  arch: aarch64
-  platform: osx
   license: LGPL-2.1
   size: 60255
   timestamp: 1604417405528
@@ -4706,8 +5651,6 @@ packages:
   md5: ac7bc6a654f8f41b352b38f4051135f8
   depends:
   - libgcc-ng >=7.5.0
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1
   size: 114383
   timestamp: 1604416621168
@@ -4732,8 +5675,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/fribidi-1.0.10-hbcb3906_0.tar.bz2
   sha256: 4f6db86ecc4984cd4ac88ca52030726c3cfd11a64dfb15c8602025ee3001a2b5
   md5: f1c6b41e0f56998ecd9a3e210faa1dc0
-  arch: x86_64
-  platform: osx
   license: LGPL-2.1
   size: 65388
   timestamp: 1604417213
@@ -4852,36 +5793,6 @@ packages:
 - kind: conda
   name: gettext
   version: 0.21.1
-  build: h0186832_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
-  sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
-  md5: 63d2ff6fddfa74e5458488fd311bf635
-  depends:
-  - libiconv >=1.17,<2.0a0
-  arch: aarch64
-  platform: osx
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4021036
-  timestamp: 1665674192347
-- kind: conda
-  name: gettext
-  version: 0.21.1
-  build: h27087fc_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
-  sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
-  md5: 14947d8770185e5153fdd04d4673ed37
-  depends:
-  - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4320628
-  timestamp: 1665673494324
-- kind: conda
-  name: gettext
-  version: 0.21.1
   build: h5728263_0
   subdir: win-64
   url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
@@ -4896,32 +5807,150 @@ packages:
   timestamp: 1665676022441
 - kind: conda
   name: gettext
-  version: 0.21.1
-  build: h8a4c099_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.21.1-h8a4c099_0.tar.bz2
-  sha256: 915d3cd2d777b9b3fc2e87a25901b8e4a6aa1b2b33cf2ba54e9e9ed4f6b67d94
-  md5: 1e3aff29ce703d421c43f371ad676cc5
+  version: 0.22.5
+  build: h2f0025b_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.22.5-h2f0025b_2.conda
+  sha256: 2a55989e078485473cd6963ec094a2e51c66693a2112079a45ebc6fafe067277
+  md5: 2cb8df031115b66a564f2eb225fb4c48
   depends:
-  - libiconv >=1.17,<2.0a0
-  arch: x86_64
-  platform: osx
+  - gettext-tools 0.22.5 h2f0025b_2
+  - libasprintf 0.22.5 h7b6a552_2
+  - libasprintf-devel 0.22.5 h7b6a552_2
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 h2f0025b_2
+  - libgettextpo-devel 0.22.5 h2f0025b_2
+  - libstdcxx-ng >=12
   license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4153781
-  timestamp: 1665674106245
+  size: 475799
+  timestamp: 1712512430871
 - kind: conda
   name: gettext
-  version: 0.21.1
-  build: ha18d298_0
+  version: 0.22.5
+  build: h59595ed_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.22.5-h59595ed_2.conda
+  sha256: 386181254ddd2aed1fccdfc217da5b6545f6df4e9979ad8e08f5e91e22eaf7dc
+  md5: 219ba82e95d7614cf7140d2a4afc0926
+  depends:
+  - gettext-tools 0.22.5 h59595ed_2
+  - libasprintf 0.22.5 h661eb56_2
+  - libasprintf-devel 0.22.5 h661eb56_2
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 h59595ed_2
+  - libgettextpo-devel 0.22.5 h59595ed_2
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 475058
+  timestamp: 1712512357949
+- kind: conda
+  name: gettext
+  version: 0.22.5
+  build: h5ff76d1_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-0.22.5-h5ff76d1_2.conda
+  sha256: ba9a4680b018a4ca517ec20beb25b09c97e293ecd16b931075e689db10291712
+  md5: c09b3dcf2adc5a2a32d11ab90289b8fa
+  depends:
+  - gettext-tools 0.22.5 h5ff76d1_2
+  - libasprintf 0.22.5 h5ff76d1_2
+  - libasprintf-devel 0.22.5 h5ff76d1_2
+  - libcxx >=16
+  - libgettextpo 0.22.5 h5ff76d1_2
+  - libgettextpo-devel 0.22.5 h5ff76d1_2
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5ff76d1_2
+  - libintl-devel 0.22.5 h5ff76d1_2
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 481687
+  timestamp: 1712513003915
+- kind: conda
+  name: gettext
+  version: 0.22.5
+  build: h8fbad5d_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.22.5-h8fbad5d_2.conda
+  sha256: 7188b466071698759b125aaed9b4d78940e72e6299b0c6dbad6f35c85cf3d27b
+  md5: 404e2894e9cb2835246cef47317ff763
+  depends:
+  - gettext-tools 0.22.5 h8fbad5d_2
+  - libasprintf 0.22.5 h8fbad5d_2
+  - libasprintf-devel 0.22.5 h8fbad5d_2
+  - libcxx >=16
+  - libgettextpo 0.22.5 h8fbad5d_2
+  - libgettextpo-devel 0.22.5 h8fbad5d_2
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8fbad5d_2
+  - libintl-devel 0.22.5 h8fbad5d_2
+  license: LGPL-2.1-or-later AND GPL-3.0-or-later
+  size: 482649
+  timestamp: 1712512963023
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: h2f0025b_2
+  build_number: 2
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-0.21.1-ha18d298_0.tar.bz2
-  sha256: b1d8ee80b7577661a8cebdfd21dd1676ba73b676d106c458d4ecdbe4a6d9c2eb
-  md5: b109f1a4d22966793d61fd7f75b744c3
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gettext-tools-0.22.5-h2f0025b_2.conda
+  sha256: a2fe02e43b7e0c042e01c83873da8c6c179d2cb1af04ecaf8a8c0d47d2390168
+  md5: dba96ed6fd0a19c5e52000b12221a726
   depends:
   - libgcc-ng >=12
-  license: LGPL-2.1-or-later AND GPL-3.0-or-later
-  size: 4671428
-  timestamp: 1665673486488
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2993665
+  timestamp: 1712512399997
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: h59595ed_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-tools-0.22.5-h59595ed_2.conda
+  sha256: 67d7b1d6fe4f1c516df2000640ec7dcfebf3ff6ea0785f0276870e730c403d33
+  md5: 985f2f453fb72408d6b6f1be0f324033
+  depends:
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2728420
+  timestamp: 1712512328692
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: h5ff76d1_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gettext-tools-0.22.5-h5ff76d1_2.conda
+  sha256: 4db71a66340d068c57e16c574c356db6df54ac0147b5b26d3313093f7854ee6d
+  md5: 37e1cb0efeff4d4623a6357e37e0105d
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5ff76d1_2
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2501207
+  timestamp: 1712512940076
+- kind: conda
+  name: gettext-tools
+  version: 0.22.5
+  build: h8fbad5d_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-tools-0.22.5-h8fbad5d_2.conda
+  sha256: f60d1671e30ac60598396c11fcec4426f7ddb281bf9e37af2262016b4d812cce
+  md5: 31117a80d73f4fac856ab09fd9f3c6b5
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8fbad5d_2
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 2482262
+  timestamp: 1712512901194
 - kind: conda
   name: gflags
   version: 2.2.2
@@ -4986,114 +6015,104 @@ packages:
   timestamp: 1594303828933
 - kind: conda
   name: glib
-  version: 2.78.0
-  build: h12be248_0
+  version: 2.80.2
+  build: h0df6a38_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.78.0-h12be248_0.conda
-  sha256: a9860e833d1ac9e2e87e5a0ae6863c819d893dac90aa1f6df9c06ab312d80170
-  md5: 1ed98e4da48693079f2fe83298c5b0ac
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-2.80.2-h0df6a38_0.conda
+  sha256: 8d4ebee8bfef919212e8c692f88cfa3f5f393501338ca1f1df83bbc2f0f3b6e7
+  md5: a728ca6f04c33ecb0f39eeda5fbd0e23
   depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib-tools ==2.78.0 h12be248_0
-  - libglib ==2.78.0 he8f3873_0
-  - libzlib >=1.2.13,<1.3.0a0
+  - glib-tools 2.80.2 h2f9d560_0
+  - libffi >=3.4,<4.0a0
+  - libglib 2.80.2 h0df6a38_0
+  - libintl >=0.22.5,<1.0a0
+  - libintl-devel
   - python *
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: LGPL-2.1-or-later
-  size: 509622
-  timestamp: 1694381620175
+  size: 571410
+  timestamp: 1715253202444
 - kind: conda
   name: glib
-  version: 2.78.0
-  build: hfc55251_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.78.0-hfc55251_0.conda
-  sha256: b7fd5ef9aee4205e14105dc9f79b3de326af091c0253e1e52d3e4ee0d960851d
-  md5: 2f55a36b549f51a7e0c2b1e3c3f0ccd4
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib-tools ==2.78.0 hfc55251_0
-  - libgcc-ng >=12
-  - libglib ==2.78.0 hebfc3b9_0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - python *
-  arch: x86_64
-  platform: linux
-  license: LGPL-2.1-or-later
-  size: 490912
-  timestamp: 1694381302237
-- kind: conda
-  name: glib
-  version: 2.80.0
-  build: h9d8fbc1_0
+  version: 2.80.2
+  build: h34bac0b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.80.0-h9d8fbc1_0.conda
-  sha256: f464f242ee0e53699dc43f620165cdcf33a283c8633ef5d12c2fe6d60287100f
-  md5: 04bdba041d642723901f2928a0498188
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-2.80.2-h34bac0b_0.conda
+  sha256: 81b2c2fb62042f2a0f0aaf57a693f2da903a072b6191117c5e3a516c1cf16de7
+  md5: 45c88954bba87523c331588d338e6ad4
   depends:
-  - glib-tools 2.80.0 hfbcf09e_0
+  - glib-tools 2.80.2 he16435f_0
+  - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
-  - libglib 2.80.0 h9d8fbc1_0
+  - libglib 2.80.2 h34bac0b_0
   - python *
   license: LGPL-2.1-or-later
-  size: 512433
-  timestamp: 1710249372411
+  size: 613397
+  timestamp: 1715252859763
+- kind: conda
+  name: glib
+  version: 2.80.2
+  build: hf974151_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-2.80.2-hf974151_0.conda
+  sha256: d10a0f194d2c125617352a81a4ff43a17cf5835e88e8f151da9f9710e2db176d
+  md5: d427988dc3dbd0a4c136f52db356cc6a
+  depends:
+  - glib-tools 2.80.2 hb6ce0ca_0
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libglib 2.80.2 hf974151_0
+  - python *
+  license: LGPL-2.1-or-later
+  size: 600389
+  timestamp: 1715252749399
 - kind: conda
   name: glib-tools
-  version: 2.78.0
-  build: h12be248_0
+  version: 2.80.2
+  build: h2f9d560_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.78.0-h12be248_0.conda
-  sha256: 0781647629fdb9c88a2b1dc22bb845645d3365693f104374c7d9139bc59bd0ce
-  md5: 466538fb59949a3c015b55671dc7e52c
+  url: https://conda.anaconda.org/conda-forge/win-64/glib-tools-2.80.2-h2f9d560_0.conda
+  sha256: 2ac7b9cf3cf57a7cec3c431133a989cc783673858fb4225232c03e5ae28bd1db
+  md5: 42fc785d9db7ab051a206fbf882ecf2e
   depends:
-  - libglib ==2.78.0 he8f3873_0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libglib 2.80.2 h0df6a38_0
+  - libintl >=0.22.5,<1.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: LGPL-2.1-or-later
-  size: 145796
-  timestamp: 1694381570560
+  size: 94852
+  timestamp: 1715253157140
 - kind: conda
   name: glib-tools
-  version: 2.78.0
-  build: hfc55251_0
+  version: 2.80.2
+  build: hb6ce0ca_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.78.0-hfc55251_0.conda
-  sha256: 991803ca90e6ba54568ff1bcb8a02f69a9beb8a09988d257fc21e1bbb3557d8c
-  md5: e10134de3558dd95abda6987b5548f4f
+  url: https://conda.anaconda.org/conda-forge/linux-64/glib-tools-2.80.2-hb6ce0ca_0.conda
+  sha256: 221cd047f998301b96b1517d9f7d3fb0e459e8ee18778a1211f302496f6e110d
+  md5: a965aeaf060289528a3fbe09326edae2
   depends:
   - libgcc-ng >=12
-  - libglib ==2.78.0 hebfc3b9_0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: linux
+  - libglib 2.80.2 hf974151_0
   license: LGPL-2.1-or-later
-  size: 112222
-  timestamp: 1694381266818
+  size: 114359
+  timestamp: 1715252713902
 - kind: conda
   name: glib-tools
-  version: 2.80.0
-  build: hfbcf09e_0
+  version: 2.80.2
+  build: he16435f_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.80.0-hfbcf09e_0.conda
-  sha256: 32a9e7a18141b1e3cfae5b50a3ae31dc1642d25f526b11b2a569d3bbf7bfab23
-  md5: 5b797903bdfc72e1ca6934792a9f03d1
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/glib-tools-2.80.2-he16435f_0.conda
+  sha256: 788d1edabf51f7a5e305d4a8c00343770674e7ee0784604b0611958d7ee009c4
+  md5: 58c5da9e8928edb925825c22c08a4043
   depends:
   - libgcc-ng >=12
-  - libglib 2.80.0 h9d8fbc1_0
+  - libglib 2.80.2 h34bac0b_0
   license: LGPL-2.1-or-later
-  size: 122389
-  timestamp: 1710249333798
+  size: 123117
+  timestamp: 1715252829712
 - kind: conda
   name: glog
   version: 0.6.0
@@ -5158,52 +6177,6 @@ packages:
   timestamp: 1649143914155
 - kind: conda
   name: gmp
-  version: 6.2.1
-  build: h2e338ed_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.2.1-h2e338ed_0.tar.bz2
-  sha256: d6386708f6b7bcf790c57e985a5ca5636ec6ccaed0493b8ddea231aaeb8bfb00
-  md5: dedc96914428dae572a39e69ee2a392f
-  depends:
-  - libcxx >=10.0.1
-  arch: x86_64
-  platform: osx
-  license: GPL-2.0-or-later AND LGPL-3.0-or-later
-  size: 792127
-  timestamp: 1605751675650
-- kind: conda
-  name: gmp
-  version: 6.2.1
-  build: h58526e2_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.2.1-h58526e2_0.tar.bz2
-  sha256: 07a5319e1ac54fe5d38f50c60f7485af7f830b036da56957d0bfb7558a886198
-  md5: b94cf2db16066b242ebd26db2facbd56
-  depends:
-  - libgcc-ng >=7.5.0
-  - libstdcxx-ng >=7.5.0
-  arch: x86_64
-  platform: linux
-  license: GPL-2.0-or-later AND LGPL-3.0-or-later
-  size: 825784
-  timestamp: 1605751468661
-- kind: conda
-  name: gmp
-  version: 6.2.1
-  build: h9f76cd9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.2.1-h9f76cd9_0.tar.bz2
-  sha256: 2fd12c3e78b6c632f7f34883b942b973bdd24302c74f2b9b78e776b654baf591
-  md5: f8140773b6ca51bf32feec9b4290a8c5
-  depends:
-  - libcxx >=11.0.0
-  arch: aarch64
-  platform: osx
-  license: GPL-2.0-or-later AND LGPL-3.0-or-later
-  size: 570567
-  timestamp: 1605751606013
-- kind: conda
-  name: gmp
   version: 6.3.0
   build: h2f0025b_1
   build_number: 1
@@ -5218,68 +6191,87 @@ packages:
   size: 517903
   timestamp: 1710169423575
 - kind: conda
-  name: gnutls
-  version: 3.7.8
-  build: h207c4f0_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.8-h207c4f0_0.tar.bz2
-  sha256: dc309e4c24689deb19596a745e0a31519adcf65c16bc349e23c140ee6ffb8f94
-  md5: 3886476538060824c0258316fd5bb828
-  depends:
-  - gettext >=0.19.8.1,<1.0a0
-  - libcxx >=14.0.4
-  - libidn2 >=2,<3.0a0
-  - libtasn1 >=4.19.0,<5.0a0
-  - nettle >=3.8.1,<3.9.0a0
-  - p11-kit >=0.24.1,<0.25.0a0
-  arch: x86_64
-  platform: osx
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 2228721
-  timestamp: 1664446079954
-- kind: conda
-  name: gnutls
-  version: 3.7.8
-  build: h9f1a10d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.8-h9f1a10d_0.tar.bz2
-  sha256: 7b9b69cb2b3134e064b37948a4cd54dee2184a851c0cda5fe52efcfd90ae032d
-  md5: 2367cca5a0451a70d01cff2dd2ce7d3e
-  depends:
-  - gettext >=0.19.8.1,<1.0a0
-  - libcxx >=14.0.4
-  - libidn2 >=2,<3.0a0
-  - libtasn1 >=4.19.0,<5.0a0
-  - nettle >=3.8.1,<3.9.0a0
-  - p11-kit >=0.24.1,<0.25.0a0
-  arch: aarch64
-  platform: osx
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  size: 2156057
-  timestamp: 1664444818581
-- kind: conda
-  name: gnutls
-  version: 3.7.8
-  build: hf3e180e_0
+  name: gmp
+  version: 6.3.0
+  build: h59595ed_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.8-hf3e180e_0.tar.bz2
-  sha256: 4a47e4558395b98fff4c1c44ad358dade62b350a03b5a784d4bc589d6eb7ac9e
-  md5: cbe8e27140d67c3f30e01cfb642a6e7c
+  url: https://conda.anaconda.org/conda-forge/linux-64/gmp-6.3.0-h59595ed_1.conda
+  sha256: cfc4202c23d6895d9c84042d08d5cda47d597772df870d4d2a10fc86dded5576
+  md5: e358c7c5f6824c272b5034b3816438a7
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 569852
+  timestamp: 1710169507479
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: h73e2aa4_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h73e2aa4_1.conda
+  sha256: 1a5b117908deb5a12288aba84dd0cb913f779c31c75f5a57d1a00e659e8fa3d3
+  md5: 92f8d748d95d97f92fc26cfac9bb5b6e
+  depends:
+  - libcxx >=16
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 519804
+  timestamp: 1710170159201
+- kind: conda
+  name: gmp
+  version: 6.3.0
+  build: hebf3989_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hebf3989_1.conda
+  sha256: 0ed5aff70675dc0ed5c2f39bb02b908b864e8eee4ceb56e1c798ba8d7509551f
+  md5: 64f45819921ba710398706e1a6404eb5
+  depends:
+  - libcxx >=16
+  license: GPL-2.0-or-later OR LGPL-3.0-or-later
+  size: 448714
+  timestamp: 1710169869298
+- kind: conda
+  name: gnutls
+  version: 3.7.9
+  build: h1951705_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gnutls-3.7.9-h1951705_0.conda
+  sha256: 6754e835f78733ddded127e0a044c476be466f67f6b5881b685730590bf8436f
+  md5: b43bd7c59ff7f7163106a58a493b51f9
+  depends:
+  - __osx >=10.9
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=16.0.6
+  - libidn2 >=2,<3.0a0
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.9.1,<3.10.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1980037
+  timestamp: 1701111603786
+- kind: conda
+  name: gnutls
+  version: 3.7.9
+  build: hb077bed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gnutls-3.7.9-hb077bed_0.conda
+  sha256: 52d824a5d2b8a5566cd469cae6ad6920469b5a15b3e0ddc609dd29151be71be2
+  md5: 33eded89024f21659b1975886a4acf70
   depends:
   - libgcc-ng >=12
   - libidn2 >=2,<3.0a0
   - libstdcxx-ng >=12
   - libtasn1 >=4.19.0,<5.0a0
-  - nettle >=3.8.1,<3.9.0a0
+  - nettle >=3.9.1,<3.10.0a0
   - p11-kit >=0.24.1,<0.25.0a0
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   license_family: LGPL
-  size: 2271927
-  timestamp: 1664445361111
+  size: 1974935
+  timestamp: 1701111180127
 - kind: conda
   name: gnutls
   version: 3.7.9
@@ -5299,6 +6291,26 @@ packages:
   license_family: LGPL
   size: 2021021
   timestamp: 1701110217449
+- kind: conda
+  name: gnutls
+  version: 3.7.9
+  build: hd26332c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gnutls-3.7.9-hd26332c_0.conda
+  sha256: 800eceea27032e6d3edbb0186a76d62ed4e4c05963a7d43b35c2ced9ce27ba68
+  md5: 64af58bb3f2a635471dfbe798a1b81f5
+  depends:
+  - __osx >=10.9
+  - gettext >=0.21.1,<1.0a0
+  - libcxx >=16.0.6
+  - libidn2 >=2,<3.0a0
+  - libtasn1 >=4.19.0,<5.0a0
+  - nettle >=3.9.1,<3.10.0a0
+  - p11-kit >=0.24.1,<0.25.0a0
+  license: LGPL-2.1-or-later
+  license_family: LGPL
+  size: 1829713
+  timestamp: 1701110534084
 - kind: conda
   name: graphite2
   version: 1.3.13
@@ -5381,75 +6393,71 @@ packages:
   timestamp: 1604365687923
 - kind: conda
   name: gst-plugins-base
-  version: 1.22.6
-  build: h001b923_2
-  build_number: 2
+  version: 1.22.9
+  build: h001b923_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.6-h001b923_2.conda
-  sha256: 34816d0335e796ea3610022756b3b0832f5699007adc2819a08e068120dd3a8f
-  md5: 20e57b894392cb792cdf5c501b35a8f6
+  url: https://conda.anaconda.org/conda-forge/win-64/gst-plugins-base-1.22.9-h001b923_1.conda
+  sha256: e2c37128de5bdc12e3656c9c50e7b1459d8890ea656b866e68293e334356b652
+  md5: ef961ec5b46ac75cebd3d68460691c27
   depends:
   - gettext >=0.21.1,<1.0a0
-  - gstreamer ==1.22.6 hb4038d2_2
-  - libglib >=2.78.0,<3.0a0
+  - gstreamer 1.22.9 hb4038d2_1
+  - libglib >=2.78.4,<3.0a0
   - libogg >=1.3.4,<1.4.0a0
   - libvorbis >=1.3.7,<1.4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2032915
-  timestamp: 1696222439891
+  size: 2035564
+  timestamp: 1711211913043
 - kind: conda
   name: gst-plugins-base
-  version: 1.22.6
-  build: h8e1006c_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.6-h8e1006c_2.conda
-  sha256: 07e71ef8ad4d1516695132ed142ef6bc6393243fee54f950aa0944561f2f277f
-  md5: 3d8e98279bad55287f2ef9047996f33c
+  version: 1.22.9
+  build: h0a86eba_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h0a86eba_1.conda
+  sha256: 8c52521d7a8f91e5f39e8f42fd4a68915066fd1812adc28640100a9d4e9f3ae2
+  md5: d67244c28840822a60bb1a3cb976acbd
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - alsa-lib >=1.2.10,<1.2.11.0a0
+  - alsa-lib >=1.2.11,<1.3.0a0
   - gettext >=0.21.1,<1.0a0
-  - gstreamer ==1.22.6 h98fc4e7_2
-  - libexpat >=2.5.0,<3.0a0
+  - gstreamer 1.22.9 hed71854_1
+  - libexpat >=2.6.2,<3.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
+  - libglib >=2.80.0,<3.0a0
   - libogg >=1.3.4,<1.4.0a0
   - libopus >=1.3.1,<2.0a0
-  - libpng >=1.6.39,<1.7.0a0
+  - libpng >=1.6.43,<1.7.0a0
   - libstdcxx-ng >=12
   - libvorbis >=1.3.7,<1.4.0a0
   - libxcb >=1.15,<1.16.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - xorg-libx11 >=1.8.6,<2.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
   - xorg-libxau >=1.0.11,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-libxrender >=0.9.11,<0.10.0a0
-  arch: x86_64
-  platform: linux
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2704605
-  timestamp: 1696222053755
+  size: 2668212
+  timestamp: 1711215891592
 - kind: conda
   name: gst-plugins-base
   version: 1.22.9
-  build: h6d82d15_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gst-plugins-base-1.22.9-h6d82d15_0.conda
-  sha256: 3590c472419063398d53efe1c14342a8cb566e4caad71e30cd01b61498a1afcd
-  md5: f931eeddcd3ae8698ab520656b4509aa
+  build: h8e1006c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gst-plugins-base-1.22.9-h8e1006c_0.conda
+  sha256: a4312c96a670fdbf9ff0c3efd935e42fa4b655ff33dcc52c309b76a2afaf03f0
+  md5: 614b81f8ed66c56b640faee7076ad14a
   depends:
+  - __glibc >=2.17,<3.0.a0
   - alsa-lib >=1.2.10,<1.3.0.0a0
   - gettext >=0.21.1,<1.0a0
-  - gstreamer 1.22.9 hed71854_0
+  - gstreamer 1.22.9 h98fc4e7_0
   - libexpat >=2.5.0,<3.0a0
   - libgcc-ng >=12
   - libglib >=2.78.3,<3.0a0
@@ -5466,63 +6474,18 @@ packages:
   - xorg-libxrender >=0.9.11,<0.10.0a0
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 2667153
-  timestamp: 1706159806777
-- kind: conda
-  name: gstreamer
-  version: 1.22.6
-  build: h98fc4e7_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.6-h98fc4e7_2.conda
-  sha256: 5578119cec4e86b7b607678781026ebe1170cb851b4f784c49b09bed1c92566c
-  md5: 1c95f7c612f9121353c4ef764678113e
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.78.0,<3.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 1972133
-  timestamp: 1696221935494
-- kind: conda
-  name: gstreamer
-  version: 1.22.6
-  build: hb4038d2_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.6-hb4038d2_2.conda
-  sha256: 08600f04d220a43f0ef5c383bb586cdd05ec482aceadb397fcd43a233b946144
-  md5: e6d2009457a1e5d9653fd06873a7a367
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - glib >=2.78.0,<3.0a0
-  - libglib >=2.78.0,<3.0a0
-  - libiconv >=1.17,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: LGPL-2.0-or-later
-  license_family: LGPL
-  size: 1939400
-  timestamp: 1696222270363
+  size: 2709696
+  timestamp: 1706154948546
 - kind: conda
   name: gstreamer
   version: 1.22.9
-  build: hed71854_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_0.conda
-  sha256: 248b95cb18326001b0eccf8aaaa2bd167bab2d95fa05781744ed9bd0e38183f7
-  md5: 076c2e12d015e6b2542bd3e6d6168fee
+  build: h98fc4e7_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gstreamer-1.22.9-h98fc4e7_0.conda
+  sha256: aa2395bf1790f72d2706bac77430f765ec1318ca22e60e791c13ae452c045263
+  md5: bcc7157b06fce7f5e055402a8135dfd8
   depends:
+  - __glibc >=2.17,<3.0.a0
   - gettext >=0.21.1,<1.0a0
   - glib >=2.78.3,<3.0a0
   - libgcc-ng >=12
@@ -5531,8 +6494,49 @@ packages:
   - libstdcxx-ng >=12
   license: LGPL-2.0-or-later
   license_family: LGPL
-  size: 1988942
-  timestamp: 1706157645872
+  size: 1981554
+  timestamp: 1706154826325
+- kind: conda
+  name: gstreamer
+  version: 1.22.9
+  build: hb4038d2_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/gstreamer-1.22.9-hb4038d2_1.conda
+  sha256: 4d42bc24434db62c093748ea3ad0b6ba3872b6810b761363585513ebd79b4f87
+  md5: 70557ab875e72c1f21e8d2351aeb9c54
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.78.4,<3.0a0
+  - libglib >=2.78.4,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 1936661
+  timestamp: 1711211717228
+- kind: conda
+  name: gstreamer
+  version: 1.22.9
+  build: hed71854_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/gstreamer-1.22.9-hed71854_1.conda
+  sha256: e6b0bf83b41348590c17ccf09e06a4575afe736efd7d2e058cca8255db6dc468
+  md5: 04704bf2cbd0aab04553021026427ec6
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - glib >=2.80.0,<3.0a0
+  - libgcc-ng >=12
+  - libglib >=2.80.0,<3.0a0
+  - libiconv >=1.17,<2.0a0
+  - libstdcxx-ng >=12
+  license: LGPL-2.0-or-later
+  license_family: LGPL
+  size: 1986330
+  timestamp: 1711213893994
 - kind: conda
   name: gxx
   version: 12.3.0
@@ -5643,204 +6647,170 @@ packages:
   timestamp: 1710260291746
 - kind: conda
   name: harfbuzz
-  version: 8.2.1
-  build: h3d44ed6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.2.1-h3d44ed6_0.conda
-  sha256: 5ca6585e6a4348bcbe214d57f5d6f560d15d23a6650770a2909475848b214edb
-  md5: 98db5f8813f45e2b29766aff0e4a499c
-  depends:
-  - cairo >=1.16.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2 *
-  - icu >=73.2,<74.0a0
-  - libgcc-ng >=12
-  - libglib >=2.78.0,<3.0a0
-  - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
-  license: MIT
-  license_family: MIT
-  size: 1526592
-  timestamp: 1695089914042
-- kind: conda
-  name: harfbuzz
-  version: 8.2.1
-  build: h7666e2a_0
+  version: 8.5.0
+  build: h053f038_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.2.1-h7666e2a_0.conda
-  sha256: ac6f5304fe824ef7a60c493b14b6aefbb0d6c7f55b49f30e53d5dff2c31ca876
-  md5: 81f8f2aaf6bd4b408a0a8823edf7ce3b
+  url: https://conda.anaconda.org/conda-forge/osx-64/harfbuzz-8.5.0-h053f038_0.conda
+  sha256: 4142a842d97ddbdefbd28b605f1b5092f6ce23fda5229a942aa4a7fb6f510af3
+  md5: 7ef43d914a9727c6ef55164e51a7016d
   depends:
-  - cairo >=1.16.0,<2.0a0
+  - __osx >=10.13
+  - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
-  - graphite2 *
+  - graphite2
   - icu >=73.2,<74.0a0
-  - libcxx >=15.0.7
-  - libglib >=2.78.0,<3.0a0
-  arch: x86_64
-  platform: osx
+  - libcxx >=16
+  - libglib >=2.80.2,<3.0a0
   license: MIT
   license_family: MIT
-  size: 1311638
-  timestamp: 1695090449044
+  size: 1355352
+  timestamp: 1715701241679
 - kind: conda
   name: harfbuzz
-  version: 8.2.1
-  build: h7ab893a_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.2.1-h7ab893a_0.conda
-  sha256: f85cbb3bd32a4fc0f417e23d10197b73de218c6ddcdd9eeae0f05f6bd2eaefaa
-  md5: 4af536fe2938b1734c6378d765404598
+  version: 8.5.0
+  build: h1836168_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.5.0-h1836168_0.conda
+  sha256: 91121ed30fa7d775f1cf7ae5de2f7852d66a604269509c4bb108b143315d8321
+  md5: aa22b942b980c17612d344adcd0f8798
   depends:
-  - cairo >=1.16.0,<2.0a0
+  - __osx >=11.0
+  - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
-  - graphite2 *
+  - graphite2
   - icu >=73.2,<74.0a0
-  - libglib >=2.78.0,<3.0a0
+  - libcxx >=16
+  - libglib >=2.80.2,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 1320454
+  timestamp: 1715701618297
+- kind: conda
+  name: harfbuzz
+  version: 8.5.0
+  build: h81778c3_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/harfbuzz-8.5.0-h81778c3_0.conda
+  sha256: f633a33dfe5c799a571af41e3515fc706a6f4988701d39e7b5d37811a1745bb9
+  md5: 2ff854071c04998038c0e1db4c9232f7
+  depends:
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=73.2,<74.0a0
+  - libglib >=2.80.2,<3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  size: 1043707
-  timestamp: 1695091629366
+  size: 1098168
+  timestamp: 1715702362769
 - kind: conda
   name: harfbuzz
-  version: 8.2.1
-  build: hf1a6348_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-8.2.1-hf1a6348_0.conda
-  sha256: 4f1a8d3f2968d9d76ae1b75e021426f7bc53e88bd1efab82b22eb7fff15ace81
-  md5: 001c9b64c94fb7066525bff0dc0f30c2
-  depends:
-  - cairo >=1.16.0,<2.0a0
-  - freetype >=2.12.1,<3.0a0
-  - graphite2 *
-  - icu >=73.2,<74.0a0
-  - libcxx >=15.0.7
-  - libglib >=2.78.0,<3.0a0
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 1248412
-  timestamp: 1695090912167
-- kind: conda
-  name: harfbuzz
-  version: 8.3.0
-  build: hebeb849_0
+  version: 8.5.0
+  build: h9812418_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.3.0-hebeb849_0.conda
-  sha256: f6f39bb13d0070565e8975ad5f23005ce894655422a1c50089e6d754c69be084
-  md5: 1c06a74f88f085c2af16809fe4c31b73
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/harfbuzz-8.5.0-h9812418_0.conda
+  sha256: 9811d832edd883543575ccdc254b2b6e1a87240347b8f9cdb51b72d7e4662b64
+  md5: fd468e09d7fff9e87e70789e78829933
   depends:
   - cairo >=1.18.0,<2.0a0
   - freetype >=2.12.1,<3.0a0
   - graphite2
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
-  - libglib >=2.78.1,<3.0a0
+  - libglib >=2.80.2,<3.0a0
   - libstdcxx-ng >=12
   license: MIT
   license_family: MIT
-  size: 1583124
-  timestamp: 1699927567410
+  size: 1623653
+  timestamp: 1715705507885
 - kind: conda
-  name: hdf5
-  version: 1.14.2
-  build: nompi_h3aba7b3_100
-  build_number: 100
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.2-nompi_h3aba7b3_100.conda
-  sha256: 2749910e21a7d1f88a81dc4709fc3565a4a3954eadb4409e7a5be1fc13a5b7ca
-  md5: 842c5b010b219058098ebfe5aa5891b9
-  depends:
-  - libaec >=1.0.6,<2.0a0
-  - libcurl >=8.2.1,<9.0a0
-  - libcxx >=15.0.7
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.2,<4.0a0
-  arch: aarch64
-  platform: osx
-  license: LicenseRef-HDF5
-  license_family: BSD
-  size: 3408759
-  timestamp: 1692562818610
-- kind: conda
-  name: hdf5
-  version: 1.14.2
-  build: nompi_h4f84152_100
-  build_number: 100
+  name: harfbuzz
+  version: 8.5.0
+  build: hfac3d4d_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.2-nompi_h4f84152_100.conda
-  sha256: f70f18291f912ba019cbb736bb87b6487021154733cd109147a6d9672790b6b8
-  md5: 2de6a9bc8083b49f09b2f6eb28d3ba3c
+  url: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.5.0-hfac3d4d_0.conda
+  sha256: a141fc55f8bfdab7db03fe9d8e61cb0f8c8b5970ed6540eda2db7186223f4444
+  md5: f5126317dd0ce0ba26945e411ecc6960
   depends:
-  - libaec >=1.0.6,<2.0a0
-  - libcurl >=8.2.1,<9.0a0
+  - cairo >=1.18.0,<2.0a0
+  - freetype >=2.12.1,<3.0a0
+  - graphite2
+  - icu >=73.2,<74.0a0
   - libgcc-ng >=12
-  - libgfortran-ng *
+  - libglib >=2.80.2,<3.0a0
+  - libstdcxx-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 1598244
+  timestamp: 1715701061364
+- kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_h4f84152_101
+  build_number: 101
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.3-nompi_h4f84152_101.conda
+  sha256: e7d2591bc77d47e9f3fc57d94a817dc9385f4079d930a93475fe45aa2ba81d47
+  md5: 7e98860d08eea82c8057abd78864fcb4
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.7.1,<9.0a0
+  - libgcc-ng >=12
+  - libgfortran-ng
   - libgfortran5 >=12.3.0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.2,<4.0a0
-  arch: x86_64
-  platform: linux
-  license: LicenseRef-HDF5
+  - openssl >=3.3.0,<4.0a0
+  license: BSD-3-Clause
   license_family: BSD
-  size: 3726636
-  timestamp: 1692563074131
+  size: 3884115
+  timestamp: 1714575562551
 - kind: conda
   name: hdf5
-  version: 1.14.2
-  build: nompi_h73e8ff5_100
-  build_number: 100
+  version: 1.14.3
+  build: nompi_h73e8ff5_101
+  build_number: 101
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.2-nompi_h73e8ff5_100.conda
-  sha256: 86bab02f1dbc658a15719b27ca5dcd2b50c22905cc2296a31a0ed220dac746f9
-  md5: 7fc095c23e4519a8df15c09f3671d09a
+  url: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.3-nompi_h73e8ff5_101.conda
+  sha256: b4d50137e1f2f2b62e4da626ee64f9233457fef3de62c3a8dbd01f41cf2cebe4
+  md5: b746fce22796d2e2d8b37bdd45d12d78
   depends:
-  - libaec >=1.0.6,<2.0a0
-  - libcurl >=8.2.1,<9.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.7.1,<9.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.2,<4.0a0
+  - openssl >=3.3.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: LicenseRef-HDF5
+  license: BSD-3-Clause
   license_family: BSD
-  size: 2044096
-  timestamp: 1692562772245
+  size: 2041847
+  timestamp: 1714575202830
 - kind: conda
   name: hdf5
-  version: 1.14.2
-  build: nompi_hedada53_100
-  build_number: 100
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.2-nompi_hedada53_100.conda
-  sha256: 08ab97d63ab4be60c92d3f5931effc565ae6ee0cd686eba81b9d20daf5f181ff
-  md5: 2b1d4f355b60eb10c5cb435b9f0e664f
+  version: 1.14.3
+  build: nompi_h751145d_101
+  build_number: 101
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.3-nompi_h751145d_101.conda
+  sha256: a3dddabbcf7be15cf363b5583c0dcaaeedf688e864894cd0531b716627c7707f
+  md5: f5b2b516eb1eabe3897e9fc5f958f4af
   depends:
-  - libaec >=1.0.6,<2.0a0
-  - libcurl >=8.2.1,<9.0a0
-  - libcxx >=15.0.7
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.7.1,<9.0a0
+  - libcxx >=16
   - libgfortran 5.*
   - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.2,<4.0a0
-  arch: x86_64
-  platform: osx
-  license: LicenseRef-HDF5
+  - openssl >=3.3.0,<4.0a0
+  license: BSD-3-Clause
   license_family: BSD
-  size: 3564108
-  timestamp: 1692563939275
+  size: 3460229
+  timestamp: 1714575369873
 - kind: conda
   name: hdf5
   version: 1.14.3
@@ -5864,6 +6834,28 @@ packages:
   size: 4003056
   timestamp: 1701796880476
 - kind: conda
+  name: hdf5
+  version: 1.14.3
+  build: nompi_hb512a33_101
+  build_number: 101
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.3-nompi_hb512a33_101.conda
+  sha256: f3b120d80d47ae9d081d950ac4f568f806d62b40385e23fb743cf351596cbeb3
+  md5: d0138c4f90c0d206e0d8a7a8f7d2882e
+  depends:
+  - libaec >=1.1.3,<2.0a0
+  - libcurl >=8.7.1,<9.0a0
+  - libcxx >=16
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - libgfortran5 >=13.2.0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.3.0,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 3738247
+  timestamp: 1714576725695
+- kind: conda
   name: icu
   version: '73.2'
   build: h59595ed_0
@@ -5874,8 +6866,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 12089150
@@ -5892,8 +6882,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 13422193
@@ -5921,8 +6909,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-73.2-hc8870d7_0.conda
   sha256: ff9cd0c6cd1349954c801fb443c94192b637e1b414514539f3c49c56a39f51b1
   md5: 8521bd47c0e11c5902535bb1a17c565f
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 11997841
@@ -5935,8 +6921,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
   sha256: f66362dc36178ac9b7c7a9b012948a9d2d050b3debec24bbd94aadbc44854185
   md5: 5cc301d759ec03f28328428e28f65591
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 11787527
@@ -5950,99 +6934,87 @@ packages:
   url: https://conda.anaconda.org/conda-forge/win-64/intel-openmp-2023.2.0-h57928b3_50497.conda
   sha256: dd9fded25ebe5c66af30ac6e3685146efdc2d7787035f01bfb546b347f138f6f
   md5: a401f3cae152deb75bbed766a90a6312
-  arch: x86_64
-  platform: win
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
   size: 2523079
   timestamp: 1698351323119
 - kind: conda
   name: jasper
-  version: 4.0.0
-  build: h28f2b1a_2
-  build_number: 2
+  version: 4.2.4
+  build: h536e39c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.4-h536e39c_0.conda
+  sha256: 0a5ca92ea0261f435c27a3c3c5c5bc5e8b4b1af1343b21ef0cbc7c33b62f5239
+  md5: 9518ab7016cf4564778aef08b6bd8792
+  depends:
+  - freeglut >=3.2.2,<4.0a0
+  - libgcc-ng >=12
+  - libglu >=9.0.0,<10.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 675951
+  timestamp: 1714298705230
+- kind: conda
+  name: jasper
+  version: 4.2.4
+  build: h6c4e4ef_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.4-h6c4e4ef_0.conda
+  sha256: 9c874070f201b64d7ca02b59f1348354ae1c834e969cb83259133bb0406ee7fa
+  md5: 9019e1298c84b0185a60c62741d720dd
+  depends:
+  - __osx >=11.0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 583310
+  timestamp: 1714298773123
+- kind: conda
+  name: jasper
+  version: 4.2.4
+  build: ha25e7e8_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.4-ha25e7e8_0.conda
+  sha256: 01cf16b5df4f685ea5952498d2d3cc0bd9ef54460adfed28a43b6fe05e4743e8
+  md5: f888b2805a130afa6f6657acc5afaa1a
+  depends:
+  - freeglut >=3.2.2,<4.0a0
+  - libgcc-ng >=12
+  - libglu >=9.0.0,<10.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 707709
+  timestamp: 1714298735485
+- kind: conda
+  name: jasper
+  version: 4.2.4
+  build: hb10263b_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.4-hb10263b_0.conda
+  sha256: da2c2fa393b89596cf0f81c8e73db2e9b589ae961058317f6fcb4867e05055dd
+  md5: b7a6171ecee244e2b2a19177ec3c34a9
+  depends:
+  - __osx >=10.9
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  license: JasPer-2.0
+  size: 571569
+  timestamp: 1714298729445
+- kind: conda
+  name: jasper
+  version: 4.2.4
+  build: hcb1a123_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.0.0-h28f2b1a_2.conda
-  sha256: 6ecc29a047be92390fb926160f85013d5ec869ce99ea9f8d154c8d500cca3334
-  md5: a6c16a1d54b6ec86e953545906dfc995
+  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.4-hcb1a123_0.conda
+  sha256: ecddfba94b78849dbde3c73fffb7877e9f1e7a8c1a71786135538af0c524b49b
+  md5: 94e32e7c907c6c80c0d0db4c8b163baf
   depends:
   - freeglut >=3.2.2,<4.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: JasPer-2.0
-  size: 441838
-  timestamp: 1695662132361
-- kind: conda
-  name: jasper
-  version: 4.0.0
-  build: h6513c55_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.0.0-h6513c55_2.conda
-  sha256: 94b4a4607c142c832df5cb9040b3df3464e5745ec1eeacd5270f6c8d3ef4d45f
-  md5: a8273b73455e4d820eb7656807cd3ca6
-  depends:
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  arch: x86_64
-  platform: osx
-  license: JasPer-2.0
-  size: 575867
-  timestamp: 1695661668532
-- kind: conda
-  name: jasper
-  version: 4.0.0
-  build: h6a52c50_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.0.0-h6a52c50_2.conda
-  sha256: 615b2e7c8b227af5fd920f1266f5f6553d278d05480337431f7f850b4c1da6b4
-  md5: 7b7d9ce2179d9084bcabc496456ff976
-  depends:
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  arch: aarch64
-  platform: osx
-  license: JasPer-2.0
-  size: 603759
-  timestamp: 1695661769126
-- kind: conda
-  name: jasper
-  version: 4.0.0
-  build: he6dfbbe_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.0.0-he6dfbbe_2.conda
-  sha256: 71be36da8a5836f2d03860fc1b75f25f33e9a5e0c9df5ca986aa7e38240acd5b
-  md5: f654581a7e1c5328e0b9bbe0a3e768e2
-  depends:
-  - freeglut >=3.2.2,<4.0a0
-  - libgcc-ng >=12
-  - libglu >=9.0.0,<10.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  arch: x86_64
-  platform: linux
-  license: JasPer-2.0
-  size: 679132
-  timestamp: 1695661355183
-- kind: conda
-  name: jasper
-  version: 4.2.2
-  build: h381c573_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/jasper-4.2.2-h381c573_0.conda
-  sha256: e4ccd4ad2ce67e6d919c99ae971f8f250c087ba6df15f39982ed7fedf354a72d
-  md5: 7356170c40071693f44e2e72f987b8e8
-  depends:
-  - freeglut >=3.2.2,<4.0a0
-  - libgcc-ng >=12
-  - libglu >=9.0.0,<10.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  license: JasPer-2.0
-  size: 710282
-  timestamp: 1710247626426
+  size: 442367
+  timestamp: 1714299052957
 - kind: conda
   name: kernel-headers_linux-64
   version: 2.6.32
@@ -6089,8 +7061,6 @@ packages:
   md5: 30186d27e2c9fa62b45fb1476b7200e3
   depends:
   - libgcc-ng >=10.3.0
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   size: 117831
   timestamp: 1646151697040
@@ -6119,8 +7089,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 86302
@@ -6135,12 +7103,11 @@ packages:
   md5: cd95826dbd331ed1be26bdf401432844
   depends:
   - keyutils >=1.6.1,<2.0a0
+  - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - openssl >=3.1.2,<4.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 1371181
@@ -6155,10 +7122,9 @@ packages:
   md5: 92f1cff174a538e0722bf2efb16fc0b2
   depends:
   - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - openssl >=3.1.2,<4.0a0
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 1195575
@@ -6173,10 +7139,9 @@ packages:
   md5: 80505a68783f01dc8d7308c075261b2f
   depends:
   - libcxx >=15.0.7
+  - libedit >=3.1.20191231,<3.2.0a0
   - libedit >=3.1.20191231,<4.0a0
   - openssl >=3.1.2,<4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 1183568
@@ -6213,8 +7178,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 710894
@@ -6230,8 +7193,6 @@ packages:
   md5: a8832b479f93521a9e7b5b743803be51
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.0-only
   license_family: LGPL
   size: 508258
@@ -6245,8 +7206,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/lame-3.100-h1a8c8d9_1003.tar.bz2
   sha256: f40ce7324b2cf5338b766d4cdb8e0453e4156a4f83c2f31bbfff750785de304c
   md5: bff0e851d66725f78dc2fd8b032ddb7e
-  arch: aarch64
-  platform: osx
   license: LGPL-2.0-only
   license_family: LGPL
   size: 528805
@@ -6275,8 +7234,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/lame-3.100-hb7f2c08_1003.tar.bz2
   sha256: 0f943b08abb4c748d73207594321b53bad47eea3e7d06b6078e0f6c59ce6771e
   md5: 3342b33c9a0921b22b767ed68ee25861
-  arch: x86_64
-  platform: osx
   license: LGPL-2.0-only
   license_family: LGPL
   size: 542681
@@ -6371,13 +7328,11 @@ packages:
   sha256: 6a4370f5984a429a8695bb4f87b879ec2a4af284b0859de863a938cc4a758b81
   md5: 920d98b2054e806dbe4c5fb8f54cad31
   depends:
-  - ld64_osx-arm64 ==609 hc4dc95b_15
+  - ld64_osx-arm64 609 hc4dc95b_15
   - libllvm15 >=15.0.7,<15.1.0a0
   constrains:
   - cctools 973.0.1.*
   - cctools_osx-arm64 973.0.1.*
-  arch: aarch64
-  platform: osx
   license: APSL-2.0
   license_family: Other
   size: 19147
@@ -6392,13 +7347,11 @@ packages:
   sha256: 5c13ce2916f592adb29301dfbbcfe773437744f2890881615210b041b6276fc2
   md5: 3c27099076bcf8fdde53785efb46dbf1
   depends:
-  - ld64_osx-64 ==609 h0fd476b_15
+  - ld64_osx-64 609 h0fd476b_15
   - libllvm15 >=15.0.7,<15.1.0a0
   constrains:
   - cctools 973.0.1.*
   - cctools_osx-64 973.0.1.*
-  arch: x86_64
-  platform: osx
   license: APSL-2.0
   license_family: Other
   size: 19091
@@ -6413,17 +7366,15 @@ packages:
   sha256: 6d793058554a46ffd4a059bf3bd33741856bfcbdaeab8e11cc1dc2df1137f7f0
   md5: f98d11f8e568521e1e3f88cbe5a4d53c
   depends:
-  - libcxx *
+  - libcxx
   - libllvm15 >=15.0.7,<15.1.0a0
-  - sigtool *
+  - sigtool
   - tapi >=1100.0.11,<1101.0a0
   constrains:
   - cctools 973.0.1.*
   - ld 609.*
   - clang >=15.0.7,<16.0a0
   - cctools_osx-64 973.0.1.*
-  arch: x86_64
-  platform: osx
   license: APSL-2.0
   license_family: Other
   size: 1062203
@@ -6438,17 +7389,15 @@ packages:
   sha256: 78696e68684c8f8e4507bcdf3e072b5c0f6eb7af58383eb339a5035999039cb2
   md5: 19220ad0db4efb72970ab401ebbd7c33
   depends:
-  - libcxx *
+  - libcxx
   - libllvm15 >=15.0.7,<15.1.0a0
-  - sigtool *
+  - sigtool
   - tapi >=1100.0.11,<1101.0a0
   constrains:
   - clang >=15.0.7,<16.0a0
   - cctools 973.0.1.*
   - ld 609.*
   - cctools_osx-arm64 973.0.1.*
-  arch: aarch64
-  platform: osx
   license: APSL-2.0
   license_family: Other
   size: 1046454
@@ -6494,8 +7443,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 281798
@@ -6526,8 +7473,6 @@ packages:
   depends:
   - vc >=14.2,<15
   - vs2015_runtime >=14.29.30037
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 194365
@@ -6542,8 +7487,6 @@ packages:
   md5: de462d5aacda3b30721b512c5da4e742
   depends:
   - libcxx >=13.0.1
-  arch: aarch64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 215721
@@ -6558,8 +7501,6 @@ packages:
   md5: f9d6a4c82889d5ecedec1d90eb673c55
   depends:
   - libcxx >=13.0.1
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 290319
@@ -6578,8 +7519,6 @@ packages:
   - __osx >=10.13
   - libabseil-static =20230802.1=cxx17*
   - abseil-cpp =20230802.1
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 1148356
@@ -6597,8 +7536,6 @@ packages:
   constrains:
   - libabseil-static =20230802.1=cxx17*
   - abseil-cpp =20230802.1
-  arch: aarch64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 1173407
@@ -6635,8 +7572,6 @@ packages:
   constrains:
   - abseil-cpp =20230802.1
   - libabseil-static =20230802.1=cxx17*
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 1263396
@@ -6656,107 +7591,93 @@ packages:
   constrains:
   - abseil-cpp =20230802.1
   - libabseil-static =20230802.1=cxx17*
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 1733638
   timestamp: 1695064265262
 - kind: conda
   name: libaec
-  version: 1.1.2
-  build: h13dd4ca_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
-  sha256: c9d6f01d511bd3686ce590addf829f34031b95e3feb34418496cbb45924c5d17
-  md5: b7962cdc2cedcc9f8d12928824c11fbd
-  depends:
-  - libcxx >=15.0.7
-  arch: aarch64
-  platform: osx
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 29002
-  timestamp: 1696474168895
-- kind: conda
-  name: libaec
-  version: 1.1.2
-  build: h2f0025b_1
-  build_number: 1
+  version: 1.1.3
+  build: h2f0025b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.2-h2f0025b_1.conda
-  sha256: faf1c20e0a0f823c01913ae0243a3fc5ebe822689c95896d24f80492903b497a
-  md5: 35cdc41045e1041d7f3bf29081b3d3cb
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libaec-1.1.3-h2f0025b_0.conda
+  sha256: 9c366233b4f4bf11e64ce886055aaac34445205a178061923300872e0564a4f2
+  md5: e52c4a30901a90354855e40992af907d
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 35153
-  timestamp: 1696474043418
+  size: 35339
+  timestamp: 1711021162162
 - kind: conda
   name: libaec
-  version: 1.1.2
-  build: h59595ed_1
-  build_number: 1
+  version: 1.1.3
+  build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
-  sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
-  md5: 127b0be54c1c90760d7fe02ea7a56426
+  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
+  sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
+  md5: 5e97e271911b8b2001a8b71860c32faa
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
-  size: 35228
-  timestamp: 1696474021700
+  size: 35446
+  timestamp: 1711021212685
 - kind: conda
   name: libaec
-  version: 1.1.2
-  build: h63175ca_1
-  build_number: 1
+  version: 1.1.3
+  build: h63175ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
-  sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
-  md5: 0b252d2bf460364bccb1523bcdbe4af6
+  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
+  md5: 8723000f6ffdbdaef16025f0a01b64c5
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-2-Clause
   license_family: BSD
-  size: 33554
-  timestamp: 1696474526588
+  size: 32567
+  timestamp: 1711021603471
 - kind: conda
   name: libaec
-  version: 1.1.2
-  build: he965462_1
-  build_number: 1
+  version: 1.1.3
+  build: h73e2aa4_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
-  sha256: 1b0a0b9b67e8f155ebdc7205a7421c7aff4850a740fc9f88b3fa23282c98ed72
-  md5: faa179050abc6af1385e0fe9dd074f91
+  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
+  sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
+  md5: 66d3c1f6dd4636216b4fca7a748d50eb
   depends:
-  - libcxx >=15.0.7
-  arch: x86_64
-  platform: osx
+  - libcxx >=16
   license: BSD-2-Clause
   license_family: BSD
-  size: 29027
-  timestamp: 1696474151758
+  size: 28602
+  timestamp: 1711021419744
+- kind: conda
+  name: libaec
+  version: 1.1.3
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
+  sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
+  md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+  depends:
+  - libcxx >=16
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 28451
+  timestamp: 1711021498493
 - kind: conda
   name: libarrow
-  version: 15.0.0
-  build: h1aaacd4_0_cpu
+  version: 14.0.2
+  build: h1aaacd4_3_cpu
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-15.0.0-h1aaacd4_0_cpu.conda
-  sha256: 2b3c0ab8bf1c53456cfe9d4190c0a4cf15c0e13f42a3036f0790a8d32b80fc1d
-  md5: b2e8a2a9cce613511f35a114fd261252
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-14.0.2-h1aaacd4_3_cpu.conda
+  sha256: 18839b6216178244558e835566a9d8b853715dbe6573ae82ca07bcc92ffd1443
+  md5: 5a5a3f32490c2018de14b941d9acf80f
   depends:
   - __osx >=10.13
   - aws-crt-cpp >=0.26.0,<0.26.1.0a0
@@ -6778,21 +7699,22 @@ packages:
   - snappy >=1.1.10,<1.2.0a0
   - zstd >=1.5.5,<1.6.0a0
   constrains:
-  - arrow-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   - parquet-cpp <0.0a0
+  - arrow-cpp <0.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 16085714
-  timestamp: 1706643579672
+  size: 15778237
+  timestamp: 1706610772424
 - kind: conda
   name: libarrow
-  version: 15.0.0
-  build: h4ce3932_0_cpu
+  version: 14.0.2
+  build: h4ce3932_3_cpu
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-15.0.0-h4ce3932_0_cpu.conda
-  sha256: 6bec2ef16855088bb940cf74e4eaf3a5cbe64487e8ffd3f7d9b997dae24b8a69
-  md5: 3ca9fab3389bb627c1fd354f9fa27dde
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-14.0.2-h4ce3932_3_cpu.conda
+  sha256: bfc40fc098db7715245c0aa5809ae2b8489a44e2619b63c1f75a2f9fedbc90ff
+  md5: 65d8be032e978630f715376237e12d95
   depends:
   - aws-crt-cpp >=0.26.0,<0.26.1.0a0
   - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
@@ -6813,21 +7735,22 @@ packages:
   - snappy >=1.1.10,<1.2.0a0
   - zstd >=1.5.5,<1.6.0a0
   constrains:
-  - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 14909855
-  timestamp: 1706643484301
+  size: 14649507
+  timestamp: 1706610614109
 - kind: conda
   name: libarrow
-  version: 15.0.0
-  build: h84dd17c_0_cpu
+  version: 14.0.2
+  build: h84dd17c_3_cpu
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-15.0.0-h84dd17c_0_cpu.conda
-  sha256: ec8ab78c117da8b88f73386c409ecbc8c1f1673bcbb3bde4f47af6ab413a7c8a
-  md5: 5cf2631ef8e74b330cac73309085b271
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-14.0.2-h84dd17c_3_cpu.conda
+  sha256: 576f77973f012f5699dec5ebb6548d1105b52bbb9882b944fdecff8460fcd848
+  md5: e66184f8c6c9c9c5a1a756370c5422f6
   depends:
   - aws-crt-cpp >=0.26.0,<0.26.1.0a0
   - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
@@ -6854,16 +7777,17 @@ packages:
   - parquet-cpp <0.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 23054273
-  timestamp: 1706642682405
+  size: 22694428
+  timestamp: 1706609555801
 - kind: conda
   name: libarrow
-  version: 15.0.0
-  build: he4a0828_0_cpu
+  version: 14.0.2
+  build: he4a0828_3_cpu
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-15.0.0-he4a0828_0_cpu.conda
-  sha256: 23de989684fe343db5db6c56350540e60c0da53b5e7a93bd991b16119cdc7c08
-  md5: 92ac952466fd18164f3b9f49e1d9d73e
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-14.0.2-he4a0828_3_cpu.conda
+  sha256: 03a455a6640969608cae9f3a67c3f0ee4f8b97879b653f3fbeafec19ee9d4c2c
+  md5: ec01fcb741e377ec344f9926bf896f65
   depends:
   - aws-crt-cpp >=0.26.0,<0.26.1.0a0
   - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
@@ -6886,20 +7810,21 @@ packages:
   - zstd >=1.5.5,<1.6.0a0
   constrains:
   - apache-arrow-proc =*=cpu
-  - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 20968202
-  timestamp: 1706642884585
+  size: 20698901
+  timestamp: 1706610555533
 - kind: conda
   name: libarrow
-  version: 15.0.0
-  build: he5f67d5_0_cpu
+  version: 14.0.2
+  build: he5f67d5_3_cpu
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-15.0.0-he5f67d5_0_cpu.conda
-  sha256: b3ee4aff2cd6bf2a57b2d83d19b9af6e1a42f32b8a21e40b787cfdd5194f03f1
-  md5: d21a1d748cb1c83c4045b282a51e06cc
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-14.0.2-he5f67d5_3_cpu.conda
+  sha256: 78984fd0a80687abc6c96975dfe7a3eba93167f35352ac742d7900490d14b40d
+  md5: 3b56876a15a08d854a29367eadba7a7a
   depends:
   - aws-crt-cpp >=0.26.0,<0.26.1.0a0
   - aws-sdk-cpp >=1.11.210,<1.11.211.0a0
@@ -6915,7 +7840,7 @@ packages:
   - libutf8proc >=2.8.0,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - orc >=1.9.2,<1.9.3.0a0
   - re2
   - snappy >=1.1.10,<1.2.0a0
@@ -6924,193 +7849,204 @@ packages:
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.5,<1.6.0a0
   constrains:
-  - parquet-cpp <0.0a0
   - arrow-cpp <0.0a0
+  - parquet-cpp <0.0a0
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 5100079
-  timestamp: 1706643544752
+  size: 5007540
+  timestamp: 1706610667722
 - kind: conda
   name: libarrow-acero
-  version: 15.0.0
-  build: h000cb23_0_cpu
+  version: 14.0.2
+  build: h000cb23_3_cpu
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-15.0.0-h000cb23_0_cpu.conda
-  sha256: dc98876d07ed4ed78421d251796fa87bf9987d6b3c3ea1a008690c063c7b2435
-  md5: 2e846a23df996a8bdad4062625917a71
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-14.0.2-h000cb23_3_cpu.conda
+  sha256: 2d26761ef5d5fa621a4c7fd4aa791714c03dd71ed3853d810cca79ef98f70c19
+  md5: 103a1671065b325dd8ceb5347f6d1b94
   depends:
-  - libarrow 15.0.0 h1aaacd4_0_cpu
+  - libarrow 14.0.2 h1aaacd4_3_cpu
   - libcxx >=14
   license: Apache-2.0
   license_family: APACHE
-  size: 529565
-  timestamp: 1706643711397
+  size: 511565
+  timestamp: 1706610895374
 - kind: conda
   name: libarrow-acero
-  version: 15.0.0
-  build: h13dd4ca_0_cpu
+  version: 14.0.2
+  build: h13dd4ca_3_cpu
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-15.0.0-h13dd4ca_0_cpu.conda
-  sha256: 355d75001711f9ddbd6764a83f1750cf4b5502fcca0e8bcef32ac4125cefa923
-  md5: 701da00ed0056b0236113e03e8ef53d0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-14.0.2-h13dd4ca_3_cpu.conda
+  sha256: 403358dbdf02e5c5dbd4a60d9d8609d64f3f082874bfee34dc09955cd3000cec
+  md5: bb9cf547aa515d6163764e1f0aa43117
   depends:
-  - libarrow 15.0.0 h4ce3932_0_cpu
+  - libarrow 14.0.2 h4ce3932_3_cpu
   - libcxx >=14
   license: Apache-2.0
   license_family: APACHE
-  size: 511862
-  timestamp: 1706643621532
+  size: 495117
+  timestamp: 1706610742772
 - kind: conda
   name: libarrow-acero
-  version: 15.0.0
-  build: h2f0025b_0_cpu
+  version: 14.0.2
+  build: h2f0025b_3_cpu
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-acero-15.0.0-h2f0025b_0_cpu.conda
-  sha256: b8deb1802ec799fc74dbec092a99ab2b28b2315af0acf0e63ec9fdbe898e4ac9
-  md5: 1b5f49de4e3fc779d4ed966c1ac4d5e7
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-acero-14.0.2-h2f0025b_3_cpu.conda
+  sha256: de8955ad8dd9932786ccfd35ae9a032a0f407ca808eeefd926c7c5fcd91cc006
+  md5: b6ff417f67569be210297560822aea93
   depends:
-  - libarrow 15.0.0 he4a0828_0_cpu
+  - libarrow 14.0.2 he4a0828_3_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 560526
-  timestamp: 1706642981285
+  size: 540992
+  timestamp: 1706610638142
 - kind: conda
   name: libarrow-acero
-  version: 15.0.0
-  build: h59595ed_0_cpu
+  version: 14.0.2
+  build: h59595ed_3_cpu
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-15.0.0-h59595ed_0_cpu.conda
-  sha256: 4f305e5fc7350752ac5248fbcd37ba5a0a88a628aadf341c3bcbc9949025a713
-  md5: 3472c8807bff382e938ad85a261738f9
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-14.0.2-h59595ed_3_cpu.conda
+  sha256: 3416eef75f45822772c2929f0173385b1493f7d6f227f364ce9628fc0f2b436b
+  md5: 597608124a4ff726388d71fda3d9b0f0
   depends:
-  - libarrow 15.0.0 h84dd17c_0_cpu
+  - libarrow 14.0.2 h84dd17c_3_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 595661
-  timestamp: 1706642769745
+  size: 576699
+  timestamp: 1706609624860
 - kind: conda
   name: libarrow-acero
-  version: 15.0.0
-  build: h63175ca_0_cpu
+  version: 14.0.2
+  build: h63175ca_3_cpu
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-15.0.0-h63175ca_0_cpu.conda
-  sha256: bf2571fe741b1095981186dcf6f1f3144eaff4047dab6730f56d0cfae12065ee
-  md5: 3f82d2ff5353b9ef198e7d4a4bffdbdc
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-14.0.2-h63175ca_3_cpu.conda
+  sha256: 267b02254be9a0972e4135234b91358572be4190eeaecb94d84f4ad553dbe6d5
+  md5: d84a9a333456e8b7b01c29c783024ed4
   depends:
-  - libarrow 15.0.0 he5f67d5_0_cpu
+  - libarrow 14.0.2 he5f67d5_3_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 443167
-  timestamp: 1706643672248
+  size: 429865
+  timestamp: 1706610755639
 - kind: conda
   name: libarrow-dataset
-  version: 15.0.0
-  build: h000cb23_0_cpu
+  version: 14.0.2
+  build: h000cb23_3_cpu
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-15.0.0-h000cb23_0_cpu.conda
-  sha256: b24739ed304b4e46382234fe1020c0f338b091292a98f707e320f016ec9cd63d
-  md5: 4bd6394431a7bfedf5ef9848e832b69b
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-14.0.2-h000cb23_3_cpu.conda
+  sha256: 505248c4717a4ee574e92585f4d9649dc2732761fbe79f32792878d4886e829a
+  md5: ecfeb174ed37dd1e12e0106c0ed3e503
   depends:
-  - libarrow 15.0.0 h1aaacd4_0_cpu
-  - libarrow-acero 15.0.0 h000cb23_0_cpu
+  - libarrow 14.0.2 h1aaacd4_3_cpu
+  - libarrow-acero 14.0.2 h000cb23_3_cpu
   - libcxx >=14
-  - libparquet 15.0.0 h381d950_0_cpu
+  - libparquet 14.0.2 h381d950_3_cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 512572
-  timestamp: 1706643966279
+  size: 510602
+  timestamp: 1706611131325
 - kind: conda
   name: libarrow-dataset
-  version: 15.0.0
-  build: h13dd4ca_0_cpu
+  version: 14.0.2
+  build: h13dd4ca_3_cpu
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-15.0.0-h13dd4ca_0_cpu.conda
-  sha256: 8062749716dd912b86ebcc055c205961cb5bb97034b35c4e4d5fc94931186423
-  md5: 899b96fd6f030658293225fe503cface
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-14.0.2-h13dd4ca_3_cpu.conda
+  sha256: 6008efbbcdc2d35108cf77556875a37fbcd6a71c7cae7b224f68a00d24706a88
+  md5: c70ccbf60211289adaad09e52103525f
   depends:
-  - libarrow 15.0.0 h4ce3932_0_cpu
-  - libarrow-acero 15.0.0 h13dd4ca_0_cpu
+  - libarrow 14.0.2 h4ce3932_3_cpu
+  - libarrow-acero 14.0.2 h13dd4ca_3_cpu
   - libcxx >=14
-  - libparquet 15.0.0 hf6ce1d5_0_cpu
+  - libparquet 14.0.2 hf6ce1d5_3_cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 528574
-  timestamp: 1706643955809
+  size: 526945
+  timestamp: 1706611070744
 - kind: conda
   name: libarrow-dataset
-  version: 15.0.0
-  build: h2f0025b_0_cpu
+  version: 14.0.2
+  build: h2f0025b_3_cpu
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-dataset-15.0.0-h2f0025b_0_cpu.conda
-  sha256: bf03c68ab05b889752013b4995cfc9733b400d8efd110356a7f99ee1a77be215
-  md5: e4e48cb85eea90df711eb758d2a36201
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-dataset-14.0.2-h2f0025b_3_cpu.conda
+  sha256: ea2b72a9bda7cf1883ccec0bff70e15222507bb89dcbba9ea725852b25f90a28
+  md5: e14ccbaf84866f241eb6c38207b4575a
   depends:
-  - libarrow 15.0.0 he4a0828_0_cpu
-  - libarrow-acero 15.0.0 h2f0025b_0_cpu
+  - libarrow 14.0.2 he4a0828_3_cpu
+  - libarrow-acero 14.0.2 h2f0025b_3_cpu
   - libgcc-ng >=12
-  - libparquet 15.0.0 hb18b541_0_cpu
+  - libparquet 14.0.2 hb18b541_3_cpu
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 553131
-  timestamp: 1706643105990
+  size: 550435
+  timestamp: 1706610768154
 - kind: conda
   name: libarrow-dataset
-  version: 15.0.0
-  build: h59595ed_0_cpu
+  version: 14.0.2
+  build: h59595ed_3_cpu
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-15.0.0-h59595ed_0_cpu.conda
-  sha256: f648faaddf25a697376b407cad4aaf593c14b7d264dc1013c7d75378554f2cc7
-  md5: 77a3299d7f6afb2e274c12d7395346b0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-14.0.2-h59595ed_3_cpu.conda
+  sha256: ae6b08f5693540c69443c930443c7e1e83619d05ff53fcd81c95c2b7552c77aa
+  md5: f03a1731ec0573a5df8637edca64f8ae
   depends:
-  - libarrow 15.0.0 h84dd17c_0_cpu
-  - libarrow-acero 15.0.0 h59595ed_0_cpu
+  - libarrow 14.0.2 h84dd17c_3_cpu
+  - libarrow-acero 14.0.2 h59595ed_3_cpu
   - libgcc-ng >=12
-  - libparquet 15.0.0 h352af49_0_cpu
+  - libparquet 14.0.2 h352af49_3_cpu
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 583329
-  timestamp: 1706642894828
+  size: 581931
+  timestamp: 1706609721028
 - kind: conda
   name: libarrow-dataset
-  version: 15.0.0
-  build: h63175ca_0_cpu
+  version: 14.0.2
+  build: h63175ca_3_cpu
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-15.0.0-h63175ca_0_cpu.conda
-  sha256: a7e4e6b9bfc402c5a6b39a6e5f4b61f0ada85ef3634c6af2da7c1cd10165b730
-  md5: 2744d68aa57aeb889300c9fe4bd4dd85
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-14.0.2-h63175ca_3_cpu.conda
+  sha256: 396fe9f07967ecf88408bfeb70c3c9a3f444b406a6303c25e4f80cfce0325267
+  md5: b06c479e72da604c18ba7149472eb5b5
   depends:
-  - libarrow 15.0.0 he5f67d5_0_cpu
-  - libarrow-acero 15.0.0 h63175ca_0_cpu
-  - libparquet 15.0.0 h7ec3a38_0_cpu
+  - libarrow 14.0.2 he5f67d5_3_cpu
+  - libarrow-acero 14.0.2 h63175ca_3_cpu
+  - libparquet 14.0.2 h7ec3a38_3_cpu
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 428466
-  timestamp: 1706643963629
+  size: 427778
+  timestamp: 1706611012214
 - kind: conda
   name: libarrow-flight
-  version: 15.0.0
-  build: h120cb0d_0_cpu
+  version: 14.0.2
+  build: h120cb0d_3_cpu
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-15.0.0-h120cb0d_0_cpu.conda
-  sha256: f2d5916d993a90c05cbb6830809cb5470af8570bbae0da8784e385577d91a3ab
-  md5: 539c47e0a070a8ac36f1a91cc8b88376
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-14.0.2-h120cb0d_3_cpu.conda
+  sha256: df3ef486f512aea17e81157239579a95a633697d92c8c1ffca785d3adf7e5721
+  md5: 6195c563a4af687b1d090f9fba8fc000
   depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 15.0.0 h84dd17c_0_cpu
+  - libarrow 14.0.2 h84dd17c_3_cpu
   - libgcc-ng >=12
   - libgrpc >=1.59.3,<1.60.0a0
   - libprotobuf >=4.24.4,<4.24.5.0a0
@@ -7118,20 +8054,21 @@ packages:
   - ucx >=1.15.0,<1.16.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 499757
-  timestamp: 1706642800464
+  size: 501085
+  timestamp: 1706609649937
 - kind: conda
   name: libarrow-flight
-  version: 15.0.0
-  build: h43033d3_0_cpu
+  version: 14.0.2
+  build: h43033d3_3_cpu
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-15.0.0-h43033d3_0_cpu.conda
-  sha256: 255779067f17acaa0ed4607077ebf93230f6779bb20c565c946301ff42afe4a1
-  md5: 08441e431609f6bfbad05200f9a946ac
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-14.0.2-h43033d3_3_cpu.conda
+  sha256: d104d949b7e0e2f33b728a6efada4e953ce5a98090d49024d50e7131738082bb
+  md5: b3ba01b1eeae3a24b6933c6ef478d766
   depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 15.0.0 he4a0828_0_cpu
+  - libarrow 14.0.2 he4a0828_3_cpu
   - libgcc-ng >=12
   - libgrpc >=1.59.3,<1.60.0a0
   - libprotobuf >=4.24.4,<4.24.5.0a0
@@ -7139,20 +8076,21 @@ packages:
   - ucx >=1.15.0,<1.16.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 474062
-  timestamp: 1706643012510
+  size: 474717
+  timestamp: 1706610670451
 - kind: conda
   name: libarrow-flight
-  version: 15.0.0
-  build: h53b1db0_0_cpu
+  version: 14.0.2
+  build: h53b1db0_3_cpu
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-15.0.0-h53b1db0_0_cpu.conda
-  sha256: aa4b3d026788be60b1d63ab0f59ecef69555db872ae1e5cbbab4f2f60d9ec69f
-  md5: abc38ede48d2680c4a07ffae9aa4a1eb
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-14.0.2-h53b1db0_3_cpu.conda
+  sha256: c14b3672cb1502572bf26b5ae0afe15776d2e364bd25849fe7440624ec7e6c0b
+  md5: 62868664f278d0fb7a5318ba8ba08d7e
   depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 15.0.0 he5f67d5_0_cpu
+  - libarrow 14.0.2 he5f67d5_3_cpu
   - libgrpc >=1.59.3,<1.60.0a0
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - ucrt >=10.0.20348.0
@@ -7160,338 +8098,467 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 285845
-  timestamp: 1706643747971
+  size: 284784
+  timestamp: 1706610820376
 - kind: conda
   name: libarrow-flight
-  version: 15.0.0
-  build: ha1803ca_0_cpu
+  version: 14.0.2
+  build: ha1803ca_3_cpu
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-15.0.0-ha1803ca_0_cpu.conda
-  sha256: 105551d2c15ce1e61176690644a9f5b22adb87d6e87910f93d7f6299d062bba1
-  md5: 296b77ef6cf42ff01ad0b45bc223eaf6
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-14.0.2-ha1803ca_3_cpu.conda
+  sha256: 7b45ee013be7dae1b1e7502d416334cf5c814ba81993114457dc7ed9d9ec8984
+  md5: c5598691d43341a8fac5a26214dcb95a
   depends:
   - __osx >=10.13
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 15.0.0 h1aaacd4_0_cpu
+  - libarrow 14.0.2 h1aaacd4_3_cpu
   - libcxx >=14
   - libgrpc >=1.59.3,<1.60.0a0
   - libprotobuf >=4.24.4,<4.24.5.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 320695
-  timestamp: 1706643772884
+  size: 319641
+  timestamp: 1706610952789
 - kind: conda
   name: libarrow-flight
-  version: 15.0.0
-  build: ha94d253_0_cpu
+  version: 14.0.2
+  build: ha94d253_3_cpu
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-15.0.0-ha94d253_0_cpu.conda
-  sha256: 43a3fcdc12a9ff2fec70a2626b7b184f6473abc3ffdad26a0e4153287d72e400
-  md5: 1e70940cb025c33b4339c479ce16b4f1
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-14.0.2-ha94d253_3_cpu.conda
+  sha256: d6f60f44fca8ecc79971b521768fa8e481111699c89224e63eff3045c0db2291
+  md5: fbff9a568d02e6b7a236245b7a9d787b
   depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 15.0.0 h4ce3932_0_cpu
+  - libarrow 14.0.2 h4ce3932_3_cpu
   - libcxx >=14
   - libgrpc >=1.59.3,<1.60.0a0
   - libprotobuf >=4.24.4,<4.24.5.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 332048
-  timestamp: 1706643702050
+  size: 332020
+  timestamp: 1706610826254
 - kind: conda
   name: libarrow-flight-sql
-  version: 15.0.0
-  build: h39a9b85_0_cpu
+  version: 14.0.2
+  build: h39a9b85_3_cpu
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-15.0.0-h39a9b85_0_cpu.conda
-  sha256: f0280819844b67efbd3630d6a941670b30c9d380713ce1c552fd00e0247bd162
-  md5: e801d904ab515ea185f733d9e613e15f
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-14.0.2-h39a9b85_3_cpu.conda
+  sha256: 073612f2adf8dd71a24606fdd6fa236fac9bbf38149ddd042e1e0d86e1faff82
+  md5: f5ac9f1a1b9605c7bee83923e5264a73
   depends:
-  - libarrow 15.0.0 h4ce3932_0_cpu
-  - libarrow-flight 15.0.0 ha94d253_0_cpu
+  - libarrow 14.0.2 h4ce3932_3_cpu
+  - libarrow-flight 14.0.2 ha94d253_3_cpu
   - libcxx >=14
   - libprotobuf >=4.24.4,<4.24.5.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 161944
-  timestamp: 1706644035610
+  size: 162201
+  timestamp: 1706611151829
 - kind: conda
   name: libarrow-flight-sql
-  version: 15.0.0
-  build: h61ff412_0_cpu
+  version: 14.0.2
+  build: h61ff412_3_cpu
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-15.0.0-h61ff412_0_cpu.conda
-  sha256: 8485b0af1503429c34c892fd82c9167934c28c95af57b7edb167e0bf3d0ccd00
-  md5: 9d710114caa170858339ed1a99facbe6
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-14.0.2-h61ff412_3_cpu.conda
+  sha256: 6a70f1ad65ccd59d9a5ed10cec9344e97609af2aceac575d67e784d20d847c75
+  md5: 03270d9c7dcce68b796cb164ae644f26
   depends:
-  - libarrow 15.0.0 h84dd17c_0_cpu
-  - libarrow-flight 15.0.0 h120cb0d_0_cpu
+  - libarrow 14.0.2 h84dd17c_3_cpu
+  - libarrow-flight 14.0.2 h120cb0d_3_cpu
   - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 193509
-  timestamp: 1706642924416
+  size: 195809
+  timestamp: 1706609745191
 - kind: conda
   name: libarrow-flight-sql
-  version: 15.0.0
-  build: h78eab7c_0_cpu
+  version: 14.0.2
+  build: h78eab7c_3_cpu
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-15.0.0-h78eab7c_0_cpu.conda
-  sha256: c0d66817e88377f4ae2e3ed84a6923ce4487561a8b82238b17614e4afcdd30e4
-  md5: 52f21060a9421ad6700b18b899bb375c
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-14.0.2-h78eab7c_3_cpu.conda
+  sha256: 8bf8ff83d54c6a27f930234b5fe889722610a3a65212c9dee73b239802600576
+  md5: 03e16024594721abb8aa719ff1151e03
   depends:
-  - libarrow 15.0.0 he5f67d5_0_cpu
-  - libarrow-flight 15.0.0 h53b1db0_0_cpu
+  - libarrow 14.0.2 he5f67d5_3_cpu
+  - libarrow-flight 14.0.2 h53b1db0_3_cpu
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 222022
-  timestamp: 1706644025665
+  size: 221531
+  timestamp: 1706611063619
 - kind: conda
   name: libarrow-flight-sql
-  version: 15.0.0
-  build: h8ec153b_0_cpu
+  version: 14.0.2
+  build: h8ec153b_3_cpu
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-15.0.0-h8ec153b_0_cpu.conda
-  sha256: a49d6c35bc042a046f8213074905518fa2eb559074bde5dcfbade076c40ecf40
-  md5: 380b2bff75201a8b1b9a27b4e645d7b7
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-14.0.2-h8ec153b_3_cpu.conda
+  sha256: 1361ee115b58d3d39d3d5acb76994011c46c9b3610e19d781baa95eca8d79b8a
+  md5: 5249b9546417382b4368bcdd499fd37c
   depends:
   - __osx >=10.13
-  - libarrow 15.0.0 h1aaacd4_0_cpu
-  - libarrow-flight 15.0.0 ha1803ca_0_cpu
+  - libarrow 14.0.2 h1aaacd4_3_cpu
+  - libarrow-flight 14.0.2 ha1803ca_3_cpu
   - libcxx >=14
   - libprotobuf >=4.24.4,<4.24.5.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 153973
-  timestamp: 1706644025913
+  size: 153818
+  timestamp: 1706611190988
 - kind: conda
   name: libarrow-flight-sql
-  version: 15.0.0
-  build: hb5131e1_0_cpu
+  version: 14.0.2
+  build: hb5131e1_3_cpu
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-sql-15.0.0-hb5131e1_0_cpu.conda
-  sha256: 4e56adfc05bdd3f251107bae13c0cc611d84ca28f9f9b08555d9c361f3e35fe2
-  md5: 207d4da2a8dc3de777da86538637b072
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-flight-sql-14.0.2-hb5131e1_3_cpu.conda
+  sha256: ca94b2d76ec05dab6d58df1c0622ccb1f526bf7cbff610fb3d129afa566ea034
+  md5: b61e6a224daf77d8ee574490d45d1928
   depends:
-  - libarrow 15.0.0 he4a0828_0_cpu
-  - libarrow-flight 15.0.0 h43033d3_0_cpu
+  - libarrow 14.0.2 he4a0828_3_cpu
+  - libarrow-flight 14.0.2 h43033d3_3_cpu
   - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 182444
-  timestamp: 1706643135024
+  size: 182527
+  timestamp: 1706610799043
 - kind: conda
   name: libarrow-gandiva
-  version: 15.0.0
-  build: h01dce7f_0_cpu
+  version: 14.0.2
+  build: h01dce7f_3_cpu
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-15.0.0-h01dce7f_0_cpu.conda
-  sha256: 429ff9442149adc528f4d81fa2eeb370990d7601947cf11d829ae084150afd11
-  md5: 93ec7f2b11cbed836f39c70901a308aa
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-14.0.2-h01dce7f_3_cpu.conda
+  sha256: 395bd46364d7c82e02a33012295d62249706ffa70f67943394bf1c675a39dc7f
+  md5: 62e1be174ab7d7e36c5fea8b89428294
   depends:
-  - libarrow 15.0.0 h1aaacd4_0_cpu
+  - libarrow 14.0.2 h1aaacd4_3_cpu
   - libcxx >=14
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - re2
   license: Apache-2.0
   license_family: APACHE
-  size: 706639
-  timestamp: 1706643838884
+  size: 698984
+  timestamp: 1706611013722
 - kind: conda
   name: libarrow-gandiva
-  version: 15.0.0
-  build: h1bc7839_0_cpu
+  version: 14.0.2
+  build: h1bc7839_3_cpu
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-gandiva-15.0.0-h1bc7839_0_cpu.conda
-  sha256: a41a6551f7b66292242f5df207b95950db51485a67a1780b93e6bfee8eab89a7
-  md5: ff58bf6ce4e7ef4998d09111a064a878
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-gandiva-14.0.2-h1bc7839_3_cpu.conda
+  sha256: f2fd9f16f7294fa86efde2317b6889e0a50b4932d8503cf562563d651af7ee82
+  md5: 32baaddf2c2b27ad55722c3d71b501ac
   depends:
-  - libarrow 15.0.0 he4a0828_0_cpu
+  - libarrow 14.0.2 he4a0828_3_cpu
   - libgcc-ng >=12
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libstdcxx-ng >=12
   - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - re2
   license: Apache-2.0
   license_family: APACHE
-  size: 846326
-  timestamp: 1706643044125
+  size: 852899
+  timestamp: 1706610705646
 - kind: conda
   name: libarrow-gandiva
-  version: 15.0.0
-  build: hacb8726_0_cpu
+  version: 14.0.2
+  build: hacb8726_3_cpu
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-15.0.0-hacb8726_0_cpu.conda
-  sha256: ff0c88547635c0947beb5edc9f8fcbdf0f79d9b3b6aeb6614c896e79bc3179f8
-  md5: 70f3d17f20f717d3a6093b0d39b2b958
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-14.0.2-hacb8726_3_cpu.conda
+  sha256: a2f62e378fd618ba4c7f554bb923d72677c70a6b07fe07c5daec5ad26038b912
+  md5: 44be88e1cf0aa51576460d0f268820f6
   depends:
-  - libarrow 15.0.0 h84dd17c_0_cpu
+  - libarrow 14.0.2 h84dd17c_3_cpu
   - libgcc-ng >=12
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libstdcxx-ng >=12
   - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - re2
   license: Apache-2.0
   license_family: APACHE
-  size: 894728
-  timestamp: 1706642834491
+  size: 895232
+  timestamp: 1706609674431
 - kind: conda
   name: libarrow-gandiva
-  version: 15.0.0
-  build: hb2eaab1_0_cpu
+  version: 14.0.2
+  build: hb2eaab1_3_cpu
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-15.0.0-hb2eaab1_0_cpu.conda
-  sha256: b143b66ebc163684126587c61f6004d7269273989c7c2ad178d71f93c863cc4d
-  md5: 520ecf2877422c13dac022f28c8648ce
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-14.0.2-hb2eaab1_3_cpu.conda
+  sha256: 338ee6ab959ba9dd0e95fdfb6a4b752fb0db421dc98dee96636508b88ebb41db
+  md5: 1c11dfcf36c3489e33ba17860b122af8
   depends:
-  - libarrow 15.0.0 he5f67d5_0_cpu
+  - libarrow 14.0.2 he5f67d5_3_cpu
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - re2
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 10346445
-  timestamp: 1706643818124
+  size: 10171963
+  timestamp: 1706610890250
 - kind: conda
   name: libarrow-gandiva
-  version: 15.0.0
-  build: hf757142_0_cpu
+  version: 14.0.2
+  build: hf757142_3_cpu
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-15.0.0-hf757142_0_cpu.conda
-  sha256: 851c6af4fff4146b847618bf6b003973143781880a520de6d2cb41cc1846ef42
-  md5: 9ce11e82d2b971be33b44c83416adea2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-14.0.2-hf757142_3_cpu.conda
+  sha256: 88e7dde29f73ba6120bd6686835c4c5fedd438aef16fdf58902761e227b551f6
+  md5: 5ffcf4f822db993d39996b836306c5a9
   depends:
-  - libarrow 15.0.0 h4ce3932_0_cpu
+  - libarrow 14.0.2 h4ce3932_3_cpu
   - libcxx >=14
   - libllvm15 >=15.0.7,<15.1.0a0
   - libre2-11 >=2023.6.2,<2024.0a0
   - libutf8proc >=2.8.0,<3.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - re2
   license: Apache-2.0
   license_family: APACHE
-  size: 705081
-  timestamp: 1706643792323
+  size: 688245
+  timestamp: 1706610908126
 - kind: conda
   name: libarrow-substrait
-  version: 15.0.0
-  build: h318fca9_0_cpu
+  version: 14.0.2
+  build: h318fca9_3_cpu
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-substrait-15.0.0-h318fca9_0_cpu.conda
-  sha256: f02c14a4f80a135a4a4cf37dcdefe2be38961afaf9fea8c16b17a69960cf308f
-  md5: 27dbdc1b2ddbb0617bf808e37ea1f9df
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libarrow-substrait-14.0.2-h318fca9_3_cpu.conda
+  sha256: 0a7f039a79ef2b5a4c00a26d563f98a3cc439c86b371e238021bf380786c16f9
+  md5: 520e4ab103a9ade9799f241b4239f7a0
   depends:
-  - libarrow 15.0.0 he4a0828_0_cpu
-  - libarrow-acero 15.0.0 h2f0025b_0_cpu
-  - libarrow-dataset 15.0.0 h2f0025b_0_cpu
+  - libarrow 14.0.2 he4a0828_3_cpu
+  - libarrow-acero 14.0.2 h2f0025b_3_cpu
+  - libarrow-dataset 14.0.2 h2f0025b_3_cpu
   - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 504491
-  timestamp: 1706643162928
+  size: 506254
+  timestamp: 1706610831760
 - kind: conda
   name: libarrow-substrait
-  version: 15.0.0
-  build: h61ff412_0_cpu
+  version: 14.0.2
+  build: h61ff412_3_cpu
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-15.0.0-h61ff412_0_cpu.conda
-  sha256: f07e62d97781bbb2584944a4b4426fd4eae1ec3967aa99ade2b874c31af7e360
-  md5: 636da1ef050231a6ace3fbd5b3a4e03e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-14.0.2-h61ff412_3_cpu.conda
+  sha256: e89bd3cd61148f323dbed644b866f198f75486ede297dcde1869a7a83cedcb4d
+  md5: 47a26635aa311e6c1db9c633a0949d53
   depends:
-  - libarrow 15.0.0 h84dd17c_0_cpu
-  - libarrow-acero 15.0.0 h59595ed_0_cpu
-  - libarrow-dataset 15.0.0 h59595ed_0_cpu
+  - libarrow 14.0.2 h84dd17c_3_cpu
+  - libarrow-acero 14.0.2 h59595ed_3_cpu
+  - libarrow-dataset 14.0.2 h59595ed_3_cpu
   - libgcc-ng >=12
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 508507
-  timestamp: 1706642955508
+  size: 509163
+  timestamp: 1706609767216
 - kind: conda
   name: libarrow-substrait
-  version: 15.0.0
-  build: h7fd9903_0_cpu
+  version: 14.0.2
+  build: h7fd9903_3_cpu
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-15.0.0-h7fd9903_0_cpu.conda
-  sha256: 4b7785ae74cadd921c6aead9667293550a0d890226ea7286da331b283a525a49
-  md5: 6b09fe677337fbe43f1d7c58e1b0219f
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-14.0.2-h7fd9903_3_cpu.conda
+  sha256: 0afb9a3229e7ec7206e82fc094cd313c5b95131fdfab5b23fa9fc95a707c51f5
+  md5: aff62cca1464cfac7c7f5f21970b928c
   depends:
-  - libarrow 15.0.0 h4ce3932_0_cpu
-  - libarrow-acero 15.0.0 h13dd4ca_0_cpu
-  - libarrow-dataset 15.0.0 h13dd4ca_0_cpu
+  - libarrow 14.0.2 h4ce3932_3_cpu
+  - libarrow-acero 14.0.2 h13dd4ca_3_cpu
+  - libarrow-dataset 14.0.2 h13dd4ca_3_cpu
   - libcxx >=14
   - libprotobuf >=4.24.4,<4.24.5.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 474460
-  timestamp: 1706644116439
+  size: 472877
+  timestamp: 1706611234135
 - kind: conda
   name: libarrow-substrait
-  version: 15.0.0
-  build: h8ec153b_0_cpu
+  version: 14.0.2
+  build: h8ec153b_3_cpu
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-15.0.0-h8ec153b_0_cpu.conda
-  sha256: f1e224d941b702b3b48107127ee914cb77fb524b1f0bbaefa33dd2c77ff4bf0b
-  md5: 36aa0a4cde810dedeaf96202c389aec8
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-14.0.2-h8ec153b_3_cpu.conda
+  sha256: 0563f885903d0e4370573d1359f8a0957580a23720b119a1480ec12d84808e0c
+  md5: 5185a1fe62dd2e4bf0d422d8b9e797f3
   depends:
   - __osx >=10.13
-  - libarrow 15.0.0 h1aaacd4_0_cpu
-  - libarrow-acero 15.0.0 h000cb23_0_cpu
-  - libarrow-dataset 15.0.0 h000cb23_0_cpu
+  - libarrow 14.0.2 h1aaacd4_3_cpu
+  - libarrow-acero 14.0.2 h000cb23_3_cpu
+  - libarrow-dataset 14.0.2 h000cb23_3_cpu
   - libcxx >=14
   - libprotobuf >=4.24.4,<4.24.5.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 453283
-  timestamp: 1706644088616
+  size: 452971
+  timestamp: 1706611246525
 - kind: conda
   name: libarrow-substrait
-  version: 15.0.0
-  build: hd4c9904_0_cpu
+  version: 14.0.2
+  build: hd4c9904_3_cpu
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-15.0.0-hd4c9904_0_cpu.conda
-  sha256: fa0e0a8ee21272365dc48c666985a91adaa97e101de2cb65c6466bef30ad4333
-  md5: db00139b8b026ea3b9bcadff1d3109c3
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-14.0.2-hd4c9904_3_cpu.conda
+  sha256: e7e6d8388fee46c999e99b8179441d4081540024b927fe2a7aa0f0efd954cc27
+  md5: 3da62f87fdd432b5fc8dcb980b5f8514
   depends:
   - libabseil * cxx17*
   - libabseil >=20230802.1,<20230803.0a0
-  - libarrow 15.0.0 he5f67d5_0_cpu
-  - libarrow-acero 15.0.0 h63175ca_0_cpu
-  - libarrow-dataset 15.0.0 h63175ca_0_cpu
+  - libarrow 14.0.2 he5f67d5_3_cpu
+  - libarrow-acero 14.0.2 h63175ca_3_cpu
+  - libarrow-dataset 14.0.2 h63175ca_3_cpu
   - libprotobuf >=4.24.4,<4.24.5.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 347255
-  timestamp: 1706644089505
+  size: 346984
+  timestamp: 1706611117639
+- kind: conda
+  name: libasprintf
+  version: 0.22.5
+  build: h5ff76d1_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-0.22.5-h5ff76d1_2.conda
+  sha256: 4babb29b8d39ae8b341c094c134a1917c595846e5f974c9d0cb64d3f734b46b1
+  md5: ad803793d7168331f1395685cbdae212
+  license: LGPL-2.1-or-later
+  size: 40438
+  timestamp: 1712512749697
+- kind: conda
+  name: libasprintf
+  version: 0.22.5
+  build: h661eb56_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-0.22.5-h661eb56_2.conda
+  sha256: 31d58af7eb54e2938123200239277f14893c5fa4b5d0280c8cf55ae10000638b
+  md5: dd197c968bf9760bba0031888d431ede
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later
+  size: 43226
+  timestamp: 1712512265295
+- kind: conda
+  name: libasprintf
+  version: 0.22.5
+  build: h7b6a552_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-0.22.5-h7b6a552_2.conda
+  sha256: 8c2b54f0d9fd4331feb995f04eb9d5819de11fa8f33e5c5c392e7ff326106331
+  md5: 1c027a1a3c07fe94729870c85ef44cfd
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-or-later
+  size: 42533
+  timestamp: 1712512336201
+- kind: conda
+  name: libasprintf
+  version: 0.22.5
+  build: h8fbad5d_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-0.22.5-h8fbad5d_2.conda
+  sha256: 04bbe4374719906cd08b639a3f34828030f405c33b47c757b47fd55aa7310179
+  md5: 1b27402397a76115679c4855ab2ece41
+  license: LGPL-2.1-or-later
+  size: 40630
+  timestamp: 1712512727388
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: h5ff76d1_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libasprintf-devel-0.22.5-h5ff76d1_2.conda
+  sha256: 39fa757378b49993142013c1f69dd56248cc3703c2f04c5bcf4cc4acdc644ae3
+  md5: c7182eda3bc727384e2f98f4d680fa7d
+  depends:
+  - libasprintf 0.22.5 h5ff76d1_2
+  license: LGPL-2.1-or-later
+  size: 34702
+  timestamp: 1712512806211
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: h661eb56_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libasprintf-devel-0.22.5-h661eb56_2.conda
+  sha256: 99d26d272a8203d30b3efbe734a99c823499884d7759b4291674438137c4b5ca
+  md5: 02e41ab5834dcdcc8590cf29d9526f50
+  depends:
+  - libasprintf 0.22.5 h661eb56_2
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 34225
+  timestamp: 1712512295117
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: h7b6a552_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libasprintf-devel-0.22.5-h7b6a552_2.conda
+  sha256: 36610080b9dd4022783a9cd47e1028df7ee4f4a541145f6f71ddc66c5a1e021b
+  md5: 47aeae64e19437c16e1c2afdad154cd8
+  depends:
+  - libasprintf 0.22.5 h7b6a552_2
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 34395
+  timestamp: 1712512362335
+- kind: conda
+  name: libasprintf-devel
+  version: 0.22.5
+  build: h8fbad5d_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libasprintf-devel-0.22.5-h8fbad5d_2.conda
+  sha256: f5331486854a5fe80bb837891efb28a28623f762327372cb4cbc264c9c4bf9e2
+  md5: 480c106e87d4c4791e6b55a6d1678866
+  depends:
+  - libasprintf 0.22.5 h8fbad5d_2
+  license: LGPL-2.1-or-later
+  size: 34625
+  timestamp: 1712512769736
 - kind: conda
   name: libass
   version: 0.17.1
@@ -7525,14 +8592,12 @@ packages:
   md5: 9ccad0aebe916aa3715fda9eefe92584
   depends:
   - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
+  - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - fribidi >=1.0.10,<2.0a0
   - harfbuzz >=8.1.1,<9.0a0
   - libexpat >=2.5.0,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: osx
   license: ISC
   license_family: OTHER
   size: 125235
@@ -7548,15 +8613,13 @@ packages:
   md5: c306fd9cc90c0585171167d09135a827
   depends:
   - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
+  - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - fribidi >=1.0.10,<2.0a0
   - harfbuzz >=8.1.1,<9.0a0
   - libexpat >=2.5.0,<3.0a0
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: linux
   license: ISC
   license_family: OTHER
   size: 126896
@@ -7572,14 +8635,12 @@ packages:
   md5: 53fff6fc379154382f5121325c5fe2f5
   depends:
   - fontconfig >=2.14.2,<3.0a0
-  - fonts-conda-ecosystem *
+  - fonts-conda-ecosystem
   - freetype >=2.12.1,<3.0a0
   - fribidi >=1.0.10,<2.0a0
   - harfbuzz >=8.1.1,<9.0a0
   - libexpat >=2.5.0,<3.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  arch: aarch64
-  platform: osx
   license: ISC
   license_family: OTHER
   size: 110763
@@ -7937,8 +8998,6 @@ packages:
   depends:
   - attr >=2.5.1,<2.6.0a0
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 100582
@@ -8246,8 +9305,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 21900199
@@ -8264,8 +9321,6 @@ packages:
   depends:
   - libcxx >=15.0.7
   - libllvm15 >=15.0.7,<15.1.0a0
-  arch: x86_64
-  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 7000324
@@ -8284,8 +9339,6 @@ packages:
   - libllvm15 >=15.0.7,<15.1.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 9557507
@@ -8302,8 +9355,6 @@ packages:
   depends:
   - libcxx >=15.0.7
   - libllvm15 >=15.0.7,<15.1.0a0
-  arch: aarch64
-  platform: osx
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
   size: 6453035
@@ -8430,32 +9481,10 @@ packages:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 4519402
   timestamp: 1689195353551
-- kind: conda
-  name: libcurl
-  version: 8.5.0
-  build: h4e8248e_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.5.0-h4e8248e_0.conda
-  sha256: 4f4f8b884927d0c6fad4a8f5d7afaf789fe4f6554448ac8b416231f2f3dc7490
-  md5: fa0f5edc06ffc25a01eed005c6dc3d8c
-  depends:
-  - krb5 >=1.21.2,<1.22.0a0
-  - libgcc-ng >=12
-  - libnghttp2 >=1.58.0,<2.0a0
-  - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.2.0,<4.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  license: curl
-  license_family: MIT
-  size: 399469
-  timestamp: 1701860213311
 - kind: conda
   name: libcurl
   version: 8.7.1
@@ -8475,6 +9504,26 @@ packages:
   license_family: MIT
   size: 358080
   timestamp: 1711548548174
+- kind: conda
+  name: libcurl
+  version: 8.7.1
+  build: h4e8248e_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libcurl-8.7.1-h4e8248e_0.conda
+  sha256: 2e2c716875ee48947e4e7a56823c810b5a3d98013ae44d0b55cdfd337f77d693
+  md5: 4e38af63e8603414534bbebdd9885021
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - openssl >=3.2.1,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 409751
+  timestamp: 1711548134067
 - kind: conda
   name: libcurl
   version: 8.7.1
@@ -8535,32 +9584,32 @@ packages:
   timestamp: 1711548608132
 - kind: conda
   name: libcxx
-  version: 16.0.6
-  build: h4653b0c_0
+  version: 17.0.6
+  build: h5f092b4_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-16.0.6-h4653b0c_0.conda
-  sha256: 11d3fb51c14832d9e4f6d84080a375dec21ea8a3a381a1910e67ff9cedc20355
-  md5: 9d7d724faf0413bf1dbc5a85935700c8
-  arch: aarch64
-  platform: osx
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-17.0.6-h5f092b4_0.conda
+  sha256: 119d3d9306f537d4c89dc99ed99b94c396d262f0b06f7833243646f68884f2c2
+  md5: a96fd5dda8ce56c86a971e0fa02751d0
+  depends:
+  - __osx >=11.0
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 1160232
-  timestamp: 1686896993785
+  size: 1248885
+  timestamp: 1715020154867
 - kind: conda
   name: libcxx
-  version: 16.0.6
-  build: hd57cbcb_0
+  version: 17.0.6
+  build: h88467a6_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-16.0.6-hd57cbcb_0.conda
-  sha256: 9063271847cf05f3a6cc6cae3e7f0ced032ab5f3a3c9d3f943f876f39c5c2549
-  md5: 7d6972792161077908b62971802f289a
-  arch: x86_64
-  platform: osx
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-17.0.6-h88467a6_0.conda
+  sha256: e7b57062c1edfcbd13d2129467c94cbff7f0a988ee75782bf48b1dc0e6300b8b
+  md5: 0fe355aecb8d24b8bc07c763209adbd9
+  depends:
+  - __osx >=10.13
   license: Apache-2.0 WITH LLVM-exception
   license_family: Apache
-  size: 1142172
-  timestamp: 1686896907750
+  size: 1249309
+  timestamp: 1715020018902
 - kind: conda
   name: libdeflate
   version: '1.19'
@@ -8583,8 +9632,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
   sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
   md5: 6a45f543c2beb40023df5ee7e3cedfbd
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 68962
@@ -8597,8 +9644,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
   sha256: 6a3d188a6ae845a742dc85c5fb3f7eb1e252726cd74f0b8a7fa25ec09db6b87a
   md5: f8c1eb0e99e90b55965c6558578537cc
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 52841
@@ -8615,8 +9660,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 153203
@@ -8631,29 +9674,25 @@ packages:
   md5: 1635570038840ee3f9c71d22aa5b8b6d
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 67080
   timestamp: 1694922285678
 - kind: conda
   name: libdrm
-  version: 2.4.114
-  build: h166bdaf_0
+  version: 2.4.120
+  build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.114-h166bdaf_0.tar.bz2
-  sha256: 9316075084ad66f9f96d31836e83303a8199eec93c12d68661e41c44eed101e3
-  md5: efb58e80f5d0179a783c4e76c3df3b9c
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdrm-2.4.120-hd590300_0.conda
+  sha256: 8622f52e517418ae7234081fac14a3caa8aec5d1ee5f881ca1f3b194d81c3150
+  md5: 7c3071bdf1d28b331a06bda6e85ab607
   depends:
   - libgcc-ng >=12
-  - libpciaccess >=0.17,<0.18.0a0
-  arch: x86_64
-  platform: linux
+  - libpciaccess >=0.18,<0.19.0a0
   license: MIT
   license_family: MIT
-  size: 305197
-  timestamp: 1667566354412
+  size: 303067
+  timestamp: 1708374304366
 - kind: conda
   name: libedit
   version: 3.1.20191231
@@ -8665,8 +9704,6 @@ packages:
   md5: 6016a8a1d0e63cac3de2c352cd40208b
   depends:
   - ncurses >=6.2,<7.0.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 105382
@@ -8682,8 +9719,6 @@ packages:
   md5: 30e4362988a2623e9eb34337b83e01f9
   depends:
   - ncurses >=6.2,<7.0.0a0
-  arch: aarch64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 96607
@@ -8700,8 +9735,6 @@ packages:
   depends:
   - libgcc-ng >=7.5.0
   - ncurses >=6.2,<7.0.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 123878
@@ -8860,82 +9893,10 @@ packages:
   depends:
   - libgcc-ng >=12
   - openssl >=3.1.1,<4.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 427426
   timestamp: 1685725977222
-- kind: conda
-  name: libexpat
-  version: 2.5.0
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
-  sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
-  md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
-  constrains:
-  - expat 2.5.0.*
-  arch: x86_64
-  platform: win
-  license: MIT
-  license_family: MIT
-  size: 138689
-  timestamp: 1680190844101
-- kind: conda
-  name: libexpat
-  version: 2.5.0
-  build: hb7217d7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
-  sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
-  md5: 5a097ad3d17e42c148c9566280481317
-  constrains:
-  - expat 2.5.0.*
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 63442
-  timestamp: 1680190916539
-- kind: conda
-  name: libexpat
-  version: 2.5.0
-  build: hcb278e6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
-  sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  md5: 6305a3dd2752c76335295da4e581f2fd
-  depends:
-  - libgcc-ng >=12
-  constrains:
-  - expat 2.5.0.*
-  arch: x86_64
-  platform: linux
-  license: MIT
-  license_family: MIT
-  size: 77980
-  timestamp: 1680190528313
-- kind: conda
-  name: libexpat
-  version: 2.5.0
-  build: hf0c8a7f_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
-  sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
-  md5: 6c81cb022780ee33435cca0127dd43c9
-  constrains:
-  - expat 2.5.0.*
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 69602
-  timestamp: 1680191040160
 - kind: conda
   name: libexpat
   version: 2.6.2
@@ -8953,6 +9914,64 @@ packages:
   size: 72544
   timestamp: 1710362309065
 - kind: conda
+  name: libexpat
+  version: 2.6.2
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+  sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
+  md5: e7ba12deb7020dd080c6c70e7b6f6a3d
+  depends:
+  - libgcc-ng >=12
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 73730
+  timestamp: 1710362120304
+- kind: conda
+  name: libexpat
+  version: 2.6.2
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
+  sha256: 79f612f75108f3e16bbdc127d4885bb74729cf66a8702fca0373dad89d40c4b7
+  md5: bc592d03f62779511d392c175dcece64
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 139224
+  timestamp: 1710362609641
+- kind: conda
+  name: libexpat
+  version: 2.6.2
+  build: h73e2aa4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+  sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
+  md5: 3d1d51c8f716d97c864d12f7af329526
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 69246
+  timestamp: 1710362566073
+- kind: conda
+  name: libexpat
+  version: 2.6.2
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+  sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
+  md5: e3cde7cfa87f82f7cb13d482d5e0ad09
+  constrains:
+  - expat 2.6.2.*
+  license: MIT
+  license_family: MIT
+  size: 63655
+  timestamp: 1710362424980
+- kind: conda
   name: libffi
   version: 3.4.2
   build: h0d85af4_5
@@ -8961,8 +9980,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
   sha256: 7a2d27a936ceee6942ea4d397f9c7d136f12549d86f7617e8b6bad51e01a941f
   md5: ccb34fb14960ad8b125962d3d79b31a9
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 51348
@@ -8976,8 +9993,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
   sha256: 41b3d13efb775e340e4dba549ab5c029611ea6918703096b2eaa9c015c0750ca
   md5: 086914b672be056eb70fd4285b6783b6
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 39020
@@ -9008,8 +10023,6 @@ packages:
   md5: d645c6d2ac96843a2bfaccd2d62b3ac3
   depends:
   - libgcc-ng >=9.4.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 58292
@@ -9026,8 +10039,6 @@ packages:
   depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 42063
@@ -9061,10 +10072,9 @@ packages:
   depends:
   - gettext >=0.21.1,<1.0a0
   - libgcc-ng >=12
+  - libogg 1.3.*
   - libogg >=1.3.4,<1.4.0a0
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 394383
@@ -9137,23 +10147,6 @@ packages:
   timestamp: 1706820691781
 - kind: conda
   name: libgcrypt
-  version: 1.10.1
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.1-h166bdaf_0.tar.bz2
-  sha256: 8fd7e6db1021cd9298d9896233454de204116840eb66a06fcb712e1015ff132a
-  md5: f967fc95089cd247ceed56eda31de3a9
-  depends:
-  - libgcc-ng >=10.3.0
-  - libgpg-error >=1.44,<2.0a0
-  arch: x86_64
-  platform: linux
-  license: LGPL-2.1-or-later AND GPL-2.0-or-later
-  license_family: GPL
-  size: 719561
-  timestamp: 1649520091125
-- kind: conda
-  name: libgcrypt
   version: 1.10.3
   build: h31becfc_0
   subdir: linux-aarch64
@@ -9167,6 +10160,149 @@ packages:
   license_family: GPL
   size: 619842
   timestamp: 1701383495049
+- kind: conda
+  name: libgcrypt
+  version: 1.10.3
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcrypt-1.10.3-hd590300_0.conda
+  sha256: d1bd47faa29fec7288c7b212198432b07f890d3d6f646078da93b059c2e9daff
+  md5: 32d16ad533c59bb0a3c5ffaf16110829
+  depends:
+  - libgcc-ng >=12
+  - libgpg-error >=1.47,<2.0a0
+  license: LGPL-2.1-or-later AND GPL-2.0-or-later
+  license_family: GPL
+  size: 634887
+  timestamp: 1701383493365
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: h2f0025b_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-0.22.5-h2f0025b_2.conda
+  sha256: 591e448ca1bdc4c77d694ec76178fc693c394813a68149a5d83799e45c89c4c3
+  md5: 0e5887b1c0a764c098102729ed80afee
+  depends:
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 200431
+  timestamp: 1712512353023
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: h59595ed_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-0.22.5-h59595ed_2.conda
+  sha256: e2f784564a2bdc6f753f00f63cc77c97601eb03bc89dccc4413336ec6d95490b
+  md5: 172bcc51059416e7ce99e7b528cede83
+  depends:
+  - libgcc-ng >=12
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 170582
+  timestamp: 1712512286907
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: h5ff76d1_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-0.22.5-h5ff76d1_2.conda
+  sha256: 139d1861e21c41b950ebf9e395db2492839337a3b481ad2901a4a6800c555e37
+  md5: 54cc9d12c29c2f0516f2ef4987de53ae
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5ff76d1_2
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 172506
+  timestamp: 1712512827340
+- kind: conda
+  name: libgettextpo
+  version: 0.22.5
+  build: h8fbad5d_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-0.22.5-h8fbad5d_2.conda
+  sha256: c3f5580e172c3fc03d33e8994024f08b709a239bd599792e51435fa7a06beb64
+  md5: a66fad933e22d22599a6dd149d359d25
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8fbad5d_2
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 159856
+  timestamp: 1712512788407
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: h2f0025b_2
+  build_number: 2
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgettextpo-devel-0.22.5-h2f0025b_2.conda
+  sha256: 83c9e0ab845176a9b1738c0415a007f2b9bcc2f23e5520f9e17d8454b0f92676
+  md5: 63e625fa42d34b50b8814447a17771bd
+  depends:
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 h2f0025b_2
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 36999
+  timestamp: 1712512372984
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: h59595ed_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgettextpo-devel-0.22.5-h59595ed_2.conda
+  sha256: 695eb2439ad4a89e4205dd675cc52fba5cef6b5d41b83f07cdbf4770a336cc15
+  md5: b63d9b6da3653179a278077f0de20014
+  depends:
+  - libgcc-ng >=12
+  - libgettextpo 0.22.5 h59595ed_2
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 36758
+  timestamp: 1712512303244
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: h5ff76d1_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgettextpo-devel-0.22.5-h5ff76d1_2.conda
+  sha256: 57940f6a872ffcf5a3406e96bdbd9d25854943e4dd84acee56178ffb728a9671
+  md5: 1e0384c52cd8b54812912e7234e66056
+  depends:
+  - libgettextpo 0.22.5 h5ff76d1_2
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5ff76d1_2
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 37189
+  timestamp: 1712512859854
+- kind: conda
+  name: libgettextpo-devel
+  version: 0.22.5
+  build: h8fbad5d_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgettextpo-devel-0.22.5-h8fbad5d_2.conda
+  sha256: b1be0bb8a726e2c47a025ff348e6ba8b51ef668f6ace06694657025d84ae66e2
+  md5: 1113aa220b042b7ce8d077ea8f696f98
+  depends:
+  - libgettextpo 0.22.5 h8fbad5d_2
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8fbad5d_2
+  license: GPL-3.0-or-later
+  license_family: GPL
+  size: 37221
+  timestamp: 1712512820461
 - kind: conda
   name: libgfortran
   version: 5.0.0
@@ -9309,103 +10445,54 @@ packages:
   timestamp: 1694172076009
 - kind: conda
   name: libglib
-  version: 2.78.0
-  build: h24e9cb9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.0-h24e9cb9_0.conda
-  sha256: bc2fb2e307889294c15fe4f1f61c2c92832c371781654c17c5483c9e8de14d2e
-  md5: 01c86aa032cbce6aff557de3b9948aa1
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - libcxx >=15.0.7
-  - libffi >=3.4,<4.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.40,<10.41.0a0
-  constrains:
-  - glib 2.78.0 *_0
-  arch: aarch64
-  platform: osx
-  license: LGPL-2.1-or-later
-  size: 2550196
-  timestamp: 1694381376914
-- kind: conda
-  name: libglib
-  version: 2.78.0
-  build: hc62aa5d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.0-hc62aa5d_0.conda
-  sha256: 06baed236c43bc225b76145da50caa61d9a36f919525d3e3ed4e59b0d9b7c78a
-  md5: 2c70095fa74bf95a5fd5c830a1529a8b
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - libcxx >=15.0.7
-  - libffi >=3.4,<4.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.40,<10.41.0a0
-  constrains:
-  - glib 2.78.0 *_0
-  arch: x86_64
-  platform: osx
-  license: LGPL-2.1-or-later
-  size: 2482876
-  timestamp: 1694381399072
-- kind: conda
-  name: libglib
-  version: 2.78.0
-  build: he8f3873_0
+  version: 2.80.2
+  build: h0df6a38_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.0-he8f3873_0.conda
-  sha256: 1417a309e40a2fae41e18170a74bface2ab67fb0d6905caeb34f91c6840edacc
-  md5: 25f5b3502a82ac425c72c3bc0efbecb5
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.2-h0df6a38_0.conda
+  sha256: 941bbe089a7a87fbe88324bfc7970a1688c7a765490e25b829ff73c7abc3fc5a
+  md5: ef9ae80bb2a15aee7a30180c057678ea
   depends:
-  - gettext >=0.21.1,<1.0a0
   - libffi >=3.4,<4.0a0
   - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.40,<10.41.0a0
+  - pcre2 >=10.43,<10.44.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - glib 2.78.0 *_0
-  arch: x86_64
-  platform: win
+  - glib 2.80.2 *_0
   license: LGPL-2.1-or-later
-  size: 2637097
-  timestamp: 1694381512139
+  size: 3749179
+  timestamp: 1715253077632
 - kind: conda
   name: libglib
-  version: 2.78.0
-  build: hebfc3b9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.0-hebfc3b9_0.conda
-  sha256: 96ec4dc5e38f434aa5862cb46d74923cce1445de3cd0b9d61e3e63102b163af6
-  md5: e618003da3547216310088478e475945
+  version: 2.80.2
+  build: h0f68cf7_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.2-h0f68cf7_0.conda
+  sha256: 236c5e42058a985a069c46a5145673f1082b8724fcf45c5b265e2cfda39304c5
+  md5: b3947a5dfc6c63b1f479268e75643090
   depends:
-  - gettext >=0.21.1,<1.0a0
+  - __osx >=10.13
   - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
-  - libstdcxx-ng >=12
+  - libintl >=0.22.5,<1.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - pcre2 >=10.40,<10.41.0a0
+  - pcre2 >=10.43,<10.44.0a0
   constrains:
-  - glib 2.78.0 *_0
-  arch: x86_64
-  platform: linux
+  - glib 2.80.2 *_0
   license: LGPL-2.1-or-later
-  size: 2701539
-  timestamp: 1694381226310
+  size: 3677360
+  timestamp: 1715253329377
 - kind: conda
   name: libglib
-  version: 2.80.0
-  build: h9d8fbc1_0
+  version: 2.80.2
+  build: h34bac0b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.0-h9d8fbc1_0.conda
-  sha256: 0310894943afc2230eed6919b67cce683ff5edc4b67fa2616e338a45d8e96098
-  md5: 487ed388865271d769bb274c65ec7b4d
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libglib-2.80.2-h34bac0b_0.conda
+  sha256: 21088a09ac0efd28660fd86c8de60d7cdd81726d2ebd41364ab317c6d8bcd811
+  md5: 8cb9a8fb29f3d33aaee8c209a98e7212
   depends:
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
@@ -9413,10 +10500,49 @@ packages:
   - libzlib >=1.2.13,<1.3.0a0
   - pcre2 >=10.43,<10.44.0a0
   constrains:
-  - glib 2.80.0 *_0
+  - glib 2.80.2 *_0
   license: LGPL-2.1-or-later
-  size: 2981052
-  timestamp: 1710249289688
+  size: 3965054
+  timestamp: 1715252780825
+- kind: conda
+  name: libglib
+  version: 2.80.2
+  build: h535f939_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.2-h535f939_0.conda
+  sha256: 3f0c9f25748787ab5475c5ce8267184d6637e8a5b7ca55ef2f3a0d7bff2f537f
+  md5: 4ac7cb698ca919924e205af3ab3aacf3
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - libiconv >=1.17,<2.0a0
+  - libintl >=0.22.5,<1.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.43,<10.44.0a0
+  constrains:
+  - glib 2.80.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3623970
+  timestamp: 1715252979767
+- kind: conda
+  name: libglib
+  version: 2.80.2
+  build: hf974151_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.2-hf974151_0.conda
+  sha256: 93e03b6cf4765bc06d64fa3dac65f22c53ae4a30247bb0e2dea0bd9c47a3fb26
+  md5: 72724f6a78ecb15559396966226d5838
+  depends:
+  - libffi >=3.4,<4.0a0
+  - libgcc-ng >=12
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - pcre2 >=10.43,<10.44.0a0
+  constrains:
+  - glib 2.80.2 *_0
+  license: LGPL-2.1-or-later
+  size: 3912673
+  timestamp: 1715252654366
 - kind: conda
   name: libglu
   version: 9.0.0
@@ -9433,8 +10559,6 @@ packages:
   - xorg-libx11 >=1.8.6,<2.0a0
   - xorg-libxext >=1.3.4,<2.0a0
   - xorg-xextproto >=7.3.0,<8.0a0
-  arch: x86_64
-  platform: linux
   license: SGI-2
   size: 331249
   timestamp: 1694431884320
@@ -9617,38 +10741,40 @@ packages:
   timestamp: 1698982048456
 - kind: conda
   name: libgpg-error
-  version: '1.47'
-  build: h71f35ed_0
+  version: '1.49'
+  build: h4f305b6_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.47-h71f35ed_0.conda
-  sha256: 0306b3c2d65863048983a50bd8b86f6f26e457ef55d1da745a5796af25093f5a
-  md5: c2097d0b46367996f09b4e8e4920384a
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgpg-error-1.49-h4f305b6_0.conda
+  sha256: b2664c2c11211a63856f23278efb49d3e65d902297989a0c12dcd228b5d97110
+  md5: dfcfd72c7a430d3616763ecfbefe4ca9
   depends:
-  - gettext >=0.21.1,<1.0a0
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
   - libgcc-ng >=12
+  - libgettextpo >=0.22.5,<1.0a0
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-only
   license_family: GPL
-  size: 260794
-  timestamp: 1686979818648
+  size: 263319
+  timestamp: 1714121531915
 - kind: conda
   name: libgpg-error
-  version: '1.48'
-  build: h5ce24db_0
+  version: '1.49'
+  build: hb13efb6_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.48-h5ce24db_0.conda
-  sha256: c559389a67d3102410671b5ad8d9457e671dcb719aaedf151c2a9e8c13443ccd
-  md5: b4139dba81278589ea67408962cf8cdf
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libgpg-error-1.49-hb13efb6_0.conda
+  sha256: 622bad371e0ffc8a7f725e050ac2243329cd26f3e711ee7ed47803b9547110ef
+  md5: 0d63dfe88641e1211696a35c47a671d7
   depends:
-  - gettext >=0.21.1,<1.0a0
+  - gettext
+  - libasprintf >=0.22.5,<1.0a0
   - libgcc-ng >=12
+  - libgettextpo >=0.22.5,<1.0a0
   - libstdcxx-ng >=12
   license: GPL-2.0-only
   license_family: GPL
-  size: 278143
-  timestamp: 1708702398068
+  size: 279571
+  timestamp: 1714121549270
 - kind: conda
   name: libgrpc
   version: 1.59.3
@@ -9778,6 +10904,40 @@ packages:
 - kind: conda
   name: libhwloc
   version: 2.9.3
+  build: default_h24e0189_1009
+  build_number: 1009
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libhwloc-2.9.3-default_h24e0189_1009.conda
+  sha256: a9fc54b481d0477cdf5700d702d44fc04fe00ffe63fc253aa0c6d2944abe8f3f
+  md5: 22fcbfd2a4cdf941b074a00b773b43dd
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libxml2 >=2.11.5,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2555838
+  timestamp: 1699473547291
+- kind: conda
+  name: libhwloc
+  version: 2.9.3
+  build: default_h4394839_1009
+  build_number: 1009
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libhwloc-2.9.3-default_h4394839_1009.conda
+  sha256: b9a0574f8919f3943a4f5c81d2d40da94913afcbe02098685abce001a526141c
+  md5: 8c30d3b6ed7c46fce04cc623d83b6c22
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  - libxml2 >=2.11.5,<3.0.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2530597
+  timestamp: 1699473469798
+- kind: conda
+  name: libhwloc
+  version: 2.9.3
   build: default_h554bfaf_1009
   build_number: 1009
   subdir: linux-64
@@ -9787,51 +10947,47 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxml2 >=2.11.5,<2.12.0a0
-  arch: x86_64
-  platform: linux
+  - libxml2 >=2.11.5,<3.0.0a0
   license: BSD-3-Clause
   license_family: BSD
   size: 2615665
   timestamp: 1694532603730
 - kind: conda
   name: libhwloc
-  version: 2.9.3
-  build: default_haede6df_1009
-  build_number: 1009
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
-  sha256: 2e8c4bb7173f281a8e13f333a23c9fb7a1c86d342d7dccdd74f2eb583ddde450
-  md5: 87da045f6d26ce9fe20ad76a18f6a18a
-  depends:
-  - libxml2 >=2.11.5,<2.12.0a0
-  - pthreads-win32 *
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2578462
-  timestamp: 1694533393675
-- kind: conda
-  name: libhwloc
-  version: 2.9.3
-  build: default_hda148da_1009
-  build_number: 1009
+  version: 2.10.0
+  build: default_h3030c0e_1001
+  build_number: 1001
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.9.3-default_hda148da_1009.conda
-  sha256: 7eaf20be9a5a21bcc8ca3d6a9cddffb78f70ba9314e9149ac9add1b28dce5973
-  md5: 28766712d1b5eeb1d20b3e45facf3a72
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libhwloc-2.10.0-default_h3030c0e_1001.conda
+  sha256: 5d8a4cfe2d1de8851400bc2e15f23205b4171bb263b0ea083ca091cacc9307b1
+  md5: 93453ae8b0c0c87ab18cdf9eb56c9fc6
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - libxml2 >=2.11.5,<3.0.0a0
+  - libxml2 >=2.12.7,<3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2625499
-  timestamp: 1694532579760
+  size: 2423455
+  timestamp: 1715973071524
+- kind: conda
+  name: libhwloc
+  version: 2.10.0
+  build: default_h8125262_1001
+  build_number: 1001
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.10.0-default_h8125262_1001.conda
+  sha256: 7f1aa1b071269df72e88297c046ec153b7f9a81e6f135d2da4401c96f41b5052
+  md5: e761885eb4c181074d172220d46319a0
+  depends:
+  - libxml2 >=2.12.7,<3.0a0
+  - pthreads-win32
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2373948
+  timestamp: 1715973819139
 - kind: conda
   name: libiconv
   version: '1.17'
@@ -9905,53 +11061,18 @@ packages:
   timestamp: 1652700956112
 - kind: conda
   name: libidn2
-  version: 2.3.4
-  build: h166bdaf_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.4-h166bdaf_0.tar.bz2
-  sha256: 888848ae85be9df86f56407639c63bdce8e7651f0b2517be9bc0ac6e38b2d21d
-  md5: 7440fbafd870b8bab68f83a064875d34
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - libgcc-ng >=12
-  - libunistring >=0,<1.0a0
-  arch: x86_64
-  platform: linux
-  license: LGPLv2
-  size: 160409
-  timestamp: 1666574022481
-- kind: conda
-  name: libidn2
-  version: 2.3.4
-  build: h1a8c8d9_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.4-h1a8c8d9_0.tar.bz2
-  sha256: 3f2990c33c57559fbf03c5e5b3f3c8e95886548ab4c7fc10314e4514d6632703
-  md5: 7fdc11b6fd3ea4ce92886df855fc7085
-  depends:
-  - gettext >=0.21.1,<1.0a0
-  - libunistring >=0,<1.0a0
-  arch: aarch64
-  platform: osx
-  license: LGPLv2
-  size: 173494
-  timestamp: 1666574243937
-- kind: conda
-  name: libidn2
-  version: 2.3.4
-  build: hb7f2c08_0
+  version: 2.3.7
+  build: h10d778d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.4-hb7f2c08_0.tar.bz2
-  sha256: a85127270c37fe2046372d706c44b7c707605dc1f8b97f80e8a1e1978bd3f8f5
-  md5: bd109fd705b4ce40a62759129bc4ef5a
+  url: https://conda.anaconda.org/conda-forge/osx-64/libidn2-2.3.7-h10d778d_0.conda
+  sha256: 54430e45dffa8cbe3cbf12a3f4376947e7e2d50c67db90a90e91c3350510823e
+  md5: a985867eae03167666bba45c2a297da1
   depends:
   - gettext >=0.21.1,<1.0a0
   - libunistring >=0,<1.0a0
-  arch: x86_64
-  platform: osx
   license: LGPLv2
-  size: 173894
-  timestamp: 1666574251642
+  size: 133237
+  timestamp: 1706368325339
 - kind: conda
   name: libidn2
   version: 2.3.7
@@ -9968,6 +11089,122 @@ packages:
   size: 138303
   timestamp: 1706370220301
 - kind: conda
+  name: libidn2
+  version: 2.3.7
+  build: h93a5062_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libidn2-2.3.7-h93a5062_0.conda
+  sha256: ae6be1c42fa18cb76fb1d17093f5b467b7a9bcf402da91081a9126c8843c004d
+  md5: 6e4a21ef7a8e4c0cc65381854848e232
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libunistring >=0,<1.0a0
+  license: LGPLv2
+  size: 134491
+  timestamp: 1706368362998
+- kind: conda
+  name: libidn2
+  version: 2.3.7
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libidn2-2.3.7-hd590300_0.conda
+  sha256: 253f9be445c58bf07b39d8f67ac08bccc5010c75a8c2070cddfb6c20e1ca4f4f
+  md5: 2b7b0d827c6447cc1d85dc06d5b5de46
+  depends:
+  - gettext >=0.21.1,<1.0a0
+  - libgcc-ng >=12
+  - libunistring >=0,<1.0a0
+  license: LGPLv2
+  size: 126515
+  timestamp: 1706368269716
+- kind: conda
+  name: libintl
+  version: 0.22.5
+  build: h5728263_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libintl-0.22.5-h5728263_2.conda
+  sha256: 1b95335af0a3e278b31e16667fa4e51d1c3f5e22d394d982539dfd5d34c5ae19
+  md5: aa622c938af057adc119f8b8eecada01
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 95745
+  timestamp: 1712516102666
+- kind: conda
+  name: libintl
+  version: 0.22.5
+  build: h5ff76d1_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-0.22.5-h5ff76d1_2.conda
+  sha256: 280aaef0ed84637ee869012ad9ad9ed208e068dd9b8cf010dafeea717dad7203
+  md5: 3fb6774cb8cdbb93a6013b67bcf9716d
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 74307
+  timestamp: 1712512790983
+- kind: conda
+  name: libintl
+  version: 0.22.5
+  build: h8fbad5d_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-0.22.5-h8fbad5d_2.conda
+  sha256: 21bc79bdf34ffd20cb84d2a8bd82d7d0e2a1b94b9e72773f0fb207e5b4f1ff63
+  md5: 3d216d0add050129007de3342be7b8c5
+  depends:
+  - libiconv >=1.17,<2.0a0
+  license: LGPL-2.1-or-later
+  size: 81206
+  timestamp: 1712512755390
+- kind: conda
+  name: libintl-devel
+  version: 0.22.5
+  build: h5728263_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libintl-devel-0.22.5-h5728263_2.conda
+  sha256: 6164fd51abfc7294477c58da77ee1ff9ebc63b9a33404b646407f7fbc3cc7d0d
+  md5: a2ad82fae23975e4ccbfab2847d31d48
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5728263_2
+  license: LGPL-2.1-or-later
+  size: 40772
+  timestamp: 1712516363413
+- kind: conda
+  name: libintl-devel
+  version: 0.22.5
+  build: h5ff76d1_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libintl-devel-0.22.5-h5ff76d1_2.conda
+  sha256: e3f15a85c6e63633a5ff503d56366bab31cd2e07ea21559889bc7eb19564106d
+  md5: ea0a07e556d6b238db685cae6e3585d0
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h5ff76d1_2
+  license: LGPL-2.1-or-later
+  size: 38422
+  timestamp: 1712512843420
+- kind: conda
+  name: libintl-devel
+  version: 0.22.5
+  build: h8fbad5d_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libintl-devel-0.22.5-h8fbad5d_2.conda
+  sha256: e52b2d0c5711f64b523756ccd9b800ee6f10a6317432b20a417dc3792e0a794a
+  md5: 962b3348c68efd25da253e94590ea9a2
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libintl 0.22.5 h8fbad5d_2
+  license: LGPL-2.1-or-later
+  size: 38616
+  timestamp: 1712512805567
+- kind: conda
   name: libjpeg-turbo
   version: 3.0.0
   build: h0dc2134_1
@@ -9978,8 +11215,6 @@ packages:
   md5: 72507f8e3961bc968af17435060b6dd6
   constrains:
   - jpeg <0.0.0a
-  arch: x86_64
-  platform: osx
   license: IJG AND BSD-3-Clause AND Zlib
   size: 579748
   timestamp: 1694475265912
@@ -10010,8 +11245,6 @@ packages:
   md5: 3ff1e053dc3a2b8e36b9bfa4256a58d1
   constrains:
   - jpeg <0.0.0a
-  arch: aarch64
-  platform: osx
   license: IJG AND BSD-3-Clause AND Zlib
   size: 547541
   timestamp: 1694475104253
@@ -10030,8 +11263,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - jpeg <0.0.0a
-  arch: x86_64
-  platform: win
   license: IJG AND BSD-3-Clause AND Zlib
   size: 822966
   timestamp: 1694475223854
@@ -10048,8 +11279,6 @@ packages:
   - libgcc-ng >=12
   constrains:
   - jpeg <0.0.0a
-  arch: x86_64
-  platform: linux
   license: IJG AND BSD-3-Clause AND Zlib
   size: 618575
   timestamp: 1694474974816
@@ -10473,8 +11702,6 @@ packages:
   md5: 30fd6e37fe21f86f4bd26d6ee73eeec7
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-only
   license_family: GPL
   size: 33408
@@ -10505,8 +11732,6 @@ packages:
   md5: 6e8cc2173440d77708196c5b93771680
   depends:
   - libgcc-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 210550
@@ -10523,72 +11748,10 @@ packages:
   depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 35187
   timestamp: 1610382533961
-- kind: conda
-  name: libopenblas
-  version: 0.3.24
-  build: openmp_h48a4ad5_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
-  sha256: ff2c14f7ed121f1df3ad06bea353288eade77c12fb891212a27af88a61483490
-  md5: 077718837dd06cf0c3089070108869f6
-  depends:
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - llvm-openmp >=15.0.7
-  constrains:
-  - openblas >=0.3.24,<0.3.25.0a0
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6157393
-  timestamp: 1693785988209
-- kind: conda
-  name: libopenblas
-  version: 0.3.24
-  build: openmp_hd76b1f2_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.24-openmp_hd76b1f2_0.conda
-  sha256: 21edfdf620ac5c93571aab452199b6b4622c445441dad88ab4d2eb326a7b91b3
-  md5: aacb05989f358affe1bafd4ea7294db4
-  depends:
-  - libgfortran 5.*
-  - libgfortran5 >=12.3.0
-  - llvm-openmp >=15.0.7
-  constrains:
-  - openblas >=0.3.24,<0.3.25.0a0
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2849225
-  timestamp: 1693784744674
-- kind: conda
-  name: libopenblas
-  version: 0.3.24
-  build: pthreads_h413a1c8_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
-  sha256: c8e080ae4d57506238023e98869928ae93564e6407ef5b0c4d3a337e8c2b7662
-  md5: 6e4ef6ca28655124dcde9bd500e44c32
-  depends:
-  - libgcc-ng >=12
-  - libgfortran-ng *
-  - libgfortran5 >=12.3.0
-  constrains:
-  - openblas >=0.3.24,<0.3.25.0a0
-  arch: x86_64
-  platform: linux
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5492091
-  timestamp: 1693785223074
 - kind: conda
   name: libopenblas
   version: 0.3.26
@@ -10607,6 +11770,60 @@ packages:
   license_family: BSD
   size: 4306237
   timestamp: 1704951018697
+- kind: conda
+  name: libopenblas
+  version: 0.3.27
+  build: openmp_h6c19121_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libopenblas-0.3.27-openmp_h6c19121_0.conda
+  sha256: feb2662444fc98a4842fe54cc70b1f109b2146108e7bac2b3bbad1f219cede90
+  md5: 82eba59f4eca26a9fc904d584f8761c0
+  depends:
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.27,<0.3.28.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 2925015
+  timestamp: 1712364212874
+- kind: conda
+  name: libopenblas
+  version: 0.3.27
+  build: openmp_hfef2a42_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.27-openmp_hfef2a42_0.conda
+  sha256: 45519189c0295296268cb7eabeeaa03ef54d780416c9a24be1d2a21db63a7848
+  md5: 00237c9c7f2cb6725fe2960680a6e225
+  depends:
+  - libgfortran 5.*
+  - libgfortran5 >=12.3.0
+  - llvm-openmp >=16.0.6
+  constrains:
+  - openblas >=0.3.27,<0.3.28.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6047531
+  timestamp: 1712366254156
+- kind: conda
+  name: libopenblas
+  version: 0.3.27
+  build: pthreads_h413a1c8_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.27-pthreads_h413a1c8_0.conda
+  sha256: 2ae7559aed0705deb3f716c7b247c74fd1b5e35b64e39834ce8b95f7564d4a3e
+  md5: a356024784da6dfd4683dc5ecf45b155
+  depends:
+  - libgcc-ng >=12
+  - libgfortran-ng
+  - libgfortran5 >=12.3.0
+  constrains:
+  - openblas >=0.3.27,<0.3.28.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 5598747
+  timestamp: 1712364444346
 - kind: conda
   name: libopencv
   version: 4.8.1
@@ -11673,7 +12890,7 @@ packages:
   - libgcc-ng >=12
   - libopenvino 2023.1.0 h2f0025b_2
   - libstdcxx-ng >=12
-  - snappy >=1.1.10,<2.0a0
+  - snappy >=1.1.10,<1.2.0a0
   size: 1444493
   timestamp: 1699595316570
 - kind: conda
@@ -11842,8 +13059,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libopus-1.3.1-h27ca646_1.tar.bz2
   sha256: e9912101a58cbc609a1917c5289f3bd1f600c82ed3a1c90a6dd4ca02df77958a
   md5: 3d0dbee0ccd2f6d6781d270313627b62
-  arch: aarch64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 252854
@@ -11859,8 +13074,6 @@ packages:
   md5: 15345e56d527b330e1cacbdf58676e8f
   depends:
   - libgcc-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 260658
@@ -11877,8 +13090,6 @@ packages:
   depends:
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 260615
@@ -11892,8 +13103,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/libopus-1.3.1-hc929b4f_1.tar.bz2
   sha256: c126fc225bece591a8f010e95ca7d010ea2d02df9251830bec24a19bf823fc31
   md5: 380b9ea5f6a7a277e6c1ac27d034369b
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 279983
@@ -11915,109 +13124,112 @@ packages:
   timestamp: 1606823775764
 - kind: conda
   name: libparquet
-  version: 15.0.0
-  build: h352af49_0_cpu
+  version: 14.0.2
+  build: h352af49_3_cpu
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-15.0.0-h352af49_0_cpu.conda
-  sha256: 505672cb7ec1e42a7e60fcee9f6cad38b35227186b2dbcf3d5f4686a4339c13a
-  md5: d187f0119f9fbb9b1f3b46bde565bd01
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-14.0.2-h352af49_3_cpu.conda
+  sha256: 268bf653c6ac0b029d160a72bcd92d0c06d9481d6176f2b4f06af76f04ebe0f0
+  md5: 408dc790a615a9768051c7810dad45f0
   depends:
-  - libarrow 15.0.0 h84dd17c_0_cpu
+  - libarrow 14.0.2 h84dd17c_3_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 1183418
-  timestamp: 1706642863844
+  size: 1159814
+  timestamp: 1706609697302
 - kind: conda
   name: libparquet
-  version: 15.0.0
-  build: h381d950_0_cpu
+  version: 14.0.2
+  build: h381d950_3_cpu
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-15.0.0-h381d950_0_cpu.conda
-  sha256: fab9fa004d0dab465969f5f02c4091d6ec5f6f9f7023529e1c0ce8ac01f366b8
-  md5: 8af9454451433ecef89a6baadd8575e7
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-14.0.2-h381d950_3_cpu.conda
+  sha256: c05ac1f70724fd8a07fc5e306c5c4b80b95fdce9b2bb0e24d1183f00e8974efc
+  md5: e9824233a7db871fcc0a66816433ff92
   depends:
-  - libarrow 15.0.0 h1aaacd4_0_cpu
+  - libarrow 14.0.2 h1aaacd4_3_cpu
   - libcxx >=14
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 941867
-  timestamp: 1706643910659
+  size: 929650
+  timestamp: 1706611072859
 - kind: conda
   name: libparquet
-  version: 15.0.0
-  build: h7ec3a38_0_cpu
+  version: 14.0.2
+  build: h7ec3a38_3_cpu
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-15.0.0-h7ec3a38_0_cpu.conda
-  sha256: a043079699a519f01702890dbfcd8b38b362fa600fa33c2bed5bb944a71055b1
-  md5: d79422cf74d6ac4d3650f1dc7a616f33
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-14.0.2-h7ec3a38_3_cpu.conda
+  sha256: 29e556a763bdefef0557b648e62330f3820f0e6cbdc926f3bcaed1cf5b0340ff
+  md5: 28e34171a1936f9f526bf57798de6082
   depends:
-  - libarrow 15.0.0 he5f67d5_0_cpu
+  - libarrow 14.0.2 he5f67d5_3_cpu
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 792893
-  timestamp: 1706643899298
+  size: 780972
+  timestamp: 1706610959216
 - kind: conda
   name: libparquet
-  version: 15.0.0
-  build: hb18b541_0_cpu
+  version: 14.0.2
+  build: hb18b541_3_cpu
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-15.0.0-hb18b541_0_cpu.conda
-  sha256: 48380f77effd29b243bce29dcf726bbbabffad2f1599b991fa1399d3f680daf9
-  md5: f071c6acee04335a819e3c48f5bf0dea
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-14.0.2-hb18b541_3_cpu.conda
+  sha256: 9923c00c0a0d31f7f25a2f18594d9f0135f0759b668b3a8769876fbed3034355
+  md5: 62232f39e4a69c12bdb408cf604ca42d
   depends:
-  - libarrow 15.0.0 he4a0828_0_cpu
+  - libarrow 14.0.2 he4a0828_3_cpu
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 1095877
-  timestamp: 1706643073851
+  size: 1075236
+  timestamp: 1706610736609
 - kind: conda
   name: libparquet
-  version: 15.0.0
-  build: hf6ce1d5_0_cpu
+  version: 14.0.2
+  build: hf6ce1d5_3_cpu
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-15.0.0-hf6ce1d5_0_cpu.conda
-  sha256: 72ee8b091a0fcb3df18dc7c1b0c4cb3ea1011135dc39a2121a415ddf841e2ef0
-  md5: bcba51f02dff1f1bb181dcf2b2d56a08
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-14.0.2-hf6ce1d5_3_cpu.conda
+  sha256: afda474356be7e28cdf781f3a1f8ed6536965e8047678d3d354f082584ed32cd
+  md5: 6aefbbd7cd5b14aad7c6654995cc1bfb
   depends:
-  - libarrow 15.0.0 h4ce3932_0_cpu
+  - libarrow 14.0.2 h4ce3932_3_cpu
   - libcxx >=14
   - libthrift >=0.19.0,<0.19.1.0a0
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.2.0,<4.0a0
   license: Apache-2.0
   license_family: APACHE
-  size: 922605
-  timestamp: 1706643875055
+  size: 911201
+  timestamp: 1706610991147
 - kind: conda
   name: libpciaccess
-  version: '0.17'
-  build: h166bdaf_0
+  version: '0.18'
+  build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.17-h166bdaf_0.tar.bz2
-  sha256: 9fe4aaf5629b4848d9407b9ed4da941ba7e5cebada63ee0becb9aa82259dc6e2
-  md5: b7463391cf284065294e2941dd41ab95
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpciaccess-0.18-hd590300_0.conda
+  sha256: c0a30ac74eba66ea76a4f0a39acc7833f5ed783a632ca3bb6665b2d81aabd2fb
+  md5: 48f4330bfcd959c3cfb704d424903c82
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
-  size: 39750
-  timestamp: 1666091838440
+  size: 28361
+  timestamp: 1707101388552
 - kind: conda
   name: libpng
   version: 1.6.43
@@ -12090,38 +13302,34 @@ packages:
   timestamp: 1708780496420
 - kind: conda
   name: libpq
-  version: '16.0'
-  build: hfc447b1_1
-  build_number: 1
+  version: '16.3'
+  build: ha72fbe1_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.0-hfc447b1_1.conda
-  sha256: 2eef51449f61f93579452715cda6b306f8e5107f9a5f8441365b8ad49095c37b
-  md5: e4a9a5ba40123477db33e02a78dffb01
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.3-ha72fbe1_0.conda
+  sha256: 117ba1e11f07b1ca0671641bd6d1f2e7fc6e27db1c317a0cdb4799ffa69f47db
+  md5: bac737ae28b79cfbafd515258d97d29e
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.3,<4.0a0
-  arch: x86_64
-  platform: linux
+  - openssl >=3.3.0,<4.0a0
   license: PostgreSQL
-  size: 2570515
-  timestamp: 1696003990258
+  size: 2500439
+  timestamp: 1715266400833
 - kind: conda
   name: libpq
-  version: '16.2'
-  build: h58720eb_0
+  version: '16.3'
+  build: hcf0348d_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.2-h58720eb_0.conda
-  sha256: 439633fee193ad250d97da135a7fb1c497b4f496ec6baabcb73bdba554926943
-  md5: ca0572c11209701741812f657ebeef82
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libpq-16.3-hcf0348d_0.conda
+  sha256: 8f4f0be9e86cce1a51423ccb9bfe559fb3778e2c2d62176ee52c31a029cc8d6d
+  md5: 7dd46e914b037824b9a9629ca6586fc3
   depends:
   - krb5 >=1.21.2,<1.22.0a0
   - libgcc-ng >=12
-  - openssl >=3.2.1,<4.0a0
+  - openssl >=3.3.0,<4.0a0
   license: PostgreSQL
-  size: 2528613
-  timestamp: 1707415354953
+  size: 2539253
+  timestamp: 1715266429766
 - kind: conda
   name: libprotobuf
   version: 4.24.4
@@ -12313,6 +13521,94 @@ packages:
   size: 216397
   timestamp: 1708945219858
 - kind: conda
+  name: librerun-sdk
+  version: 0.16.0
+  build: h181fc98_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/librerun-sdk-0.16.0-h181fc98_0.conda
+  sha256: 662c3ae8628edf112eeebce968e3c611153937b50d54155aaa603691097b8442
+  md5: c34bcb0771e578b99ca4cabaedb38721
+  depends:
+  - libarrow >=14.0.2,<15.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - rerun-sdk 0.16.0
+  license: MIT OR Apache-2.0
+  size: 3924945
+  timestamp: 1715999357485
+- kind: conda
+  name: librerun-sdk
+  version: 0.16.0
+  build: h2ac1e90_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/librerun-sdk-0.16.0-h2ac1e90_0.conda
+  sha256: 73a77eb791e89036a8869b1bd243b1fdca3ed6b31973af53a51bab26567c3054
+  md5: b9c8031ed9d1ab1a95858ddc0ccdcace
+  depends:
+  - libarrow >=14.0.2,<15.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  constrains:
+  - rerun-sdk 0.16.0
+  license: MIT OR Apache-2.0
+  size: 4288454
+  timestamp: 1715999829038
+- kind: conda
+  name: librerun-sdk
+  version: 0.16.0
+  build: h68b577a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/librerun-sdk-0.16.0-h68b577a_0.conda
+  sha256: b639097a121f3e0b3790843025e7fc29e46ccd8e83247ed6e8b35e896f495cd4
+  md5: ab08a04e2920f72c77c927173c601589
+  depends:
+  - libarrow >=14.0.2,<15.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - rerun-sdk 0.16.0
+  license: MIT OR Apache-2.0
+  size: 1555879
+  timestamp: 1716000258645
+- kind: conda
+  name: librerun-sdk
+  version: 0.16.0
+  build: ha45f3c2_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/librerun-sdk-0.16.0-ha45f3c2_0.conda
+  sha256: 20b64b8449ced5b7938d1ab86bd1cfe5bac904ac73b331e5611418508d97e9b8
+  md5: b6daac4a9825fe018338fb0a7efb02e9
+  depends:
+  - __osx >=10.13
+  - libarrow >=14.0.2,<15.0a0
+  - libcxx >=16
+  constrains:
+  - __osx >=10.12
+  - rerun-sdk 0.16.0
+  license: MIT OR Apache-2.0
+  size: 3083046
+  timestamp: 1715999573241
+- kind: conda
+  name: librerun-sdk
+  version: 0.16.0
+  build: hda85e2d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/librerun-sdk-0.16.0-hda85e2d_0.conda
+  sha256: c6ac93576d757d3ca443f84262c570e7bfe22466420330b8ed95bf881405d7e0
+  md5: bb990465cf97711e7f1930c94ab89bea
+  depends:
+  - __osx >=11.0
+  - libarrow >=14.0.2,<15.0a0
+  - libcxx >=16
+  constrains:
+  - rerun-sdk 0.16.0
+  - __osx >=11.0
+  license: MIT OR Apache-2.0
+  size: 2940596
+  timestamp: 1715999617290
+- kind: conda
   name: libsanitizer
   version: 12.3.0
   build: h0f45ef3_2
@@ -12384,26 +13680,10 @@ packages:
   - libstdcxx-ng >=12
   - libvorbis >=1.3.7,<1.4.0a0
   - mpg123 >=1.32.1,<1.33.0a0
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   license_family: LGPL
   size: 354372
   timestamp: 1695747735668
-- kind: conda
-  name: libsqlite
-  version: 3.45.2
-  build: h194ca79_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.2-h194ca79_0.conda
-  sha256: 0ce6de6369c04386cfc8696b1f795f425843789609ae2e04e7a1eb7deae62a8b
-  md5: bf4c96a21fbfc6a6ef6a7781a534a4e0
-  depends:
-  - libgcc-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: Unlicense
-  size: 1038462
-  timestamp: 1710253998432
 - kind: conda
   name: libsqlite
   version: 3.45.3
@@ -12417,6 +13697,20 @@ packages:
   license: Unlicense
   size: 824794
   timestamp: 1713367748819
+- kind: conda
+  name: libsqlite
+  version: 3.45.3
+  build: h194ca79_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libsqlite-3.45.3-h194ca79_0.conda
+  sha256: be87d8b67bdf892665c709d82c48011991fbf2fa15c19b006379b03ed494b070
+  md5: fb35b8afbe9e92467ac7b5608d60b775
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: Unlicense
+  size: 1036705
+  timestamp: 1713367400740
 - kind: conda
   name: libsqlite
   version: 3.45.3
@@ -12471,8 +13765,6 @@ packages:
   - libgcc-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.1,<4.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 271133
@@ -12504,8 +13796,6 @@ packages:
   depends:
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.1,<4.0a0
-  arch: aarch64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 255610
@@ -12524,8 +13814,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 266806
@@ -12541,8 +13829,6 @@ packages:
   depends:
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.1.1,<4.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 259556
@@ -12606,25 +13892,24 @@ packages:
   timestamp: 1706820778418
 - kind: conda
   name: libsystemd0
-  version: '254'
-  build: h3516f8a_0
+  version: '255'
+  build: h3516f8a_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-254-h3516f8a_0.conda
-  sha256: e4732b9bc6acbdd3308cd0abd0860c9ea44e37127cd78acb797c996c20e4f42f
-  md5: df4b1cd0c91b4234fb02b5701a4cdddc
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsystemd0-255-h3516f8a_1.conda
+  sha256: af27b0d225435d03f378a119f8eab6b280c53557a3c84cdb3bb8fd3167615aed
+  md5: 3366af27f0b593544a6cd453c7932ac5
   depends:
   - __glibc >=2.17,<3.0.a0
   - libcap >=2.69,<2.70.0a0
   - libgcc-ng >=12
-  - libgcrypt >=1.10.1,<2.0a0
+  - libgcrypt >=1.10.3,<2.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - xz >=5.2.6,<6.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  arch: x86_64
-  platform: linux
+  - zstd >=1.5.5,<1.6.0a0
   license: LGPL-2.1-or-later
-  size: 400372
-  timestamp: 1690575436367
+  size: 402592
+  timestamp: 1709568499820
 - kind: conda
   name: libsystemd0
   version: '255'
@@ -12654,8 +13939,6 @@ packages:
   md5: 93840744a8552e9ebf6bb1a5dffc125a
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-or-later
   license_family: GPL
   size: 116878
@@ -12668,8 +13951,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libtasn1-4.19.0-h1a8c8d9_0.tar.bz2
   sha256: 912e96644ea22b49921c71c9c94bcdd2b6463e9313da895c2fcee298a8c0e44c
   md5: c35bc17c31579789c76739486fc6d27a
-  arch: aarch64
-  platform: osx
   license: GPL-3.0-or-later
   license_family: GPL
   size: 116745
@@ -12696,8 +13977,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/libtasn1-4.19.0-hb7f2c08_0.tar.bz2
   sha256: 4197c155fb460fae65288c6c098c39f22495a53838356d29b79b31b8e33486dc
   md5: 73f67fb011b4477b101a95a082c74f0a
-  arch: x86_64
-  platform: osx
   license: GPL-3.0-or-later
   license_family: GPL
   size: 118785
@@ -12920,8 +14199,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/libunistring-0.9.10-h0d85af4_0.tar.bz2
   sha256: c5805a58cd2b211bffdc8b7cdeba9af3cee456196ab52ab9a30e0353bc95beb7
   md5: 40f27dc16f73256d7b93e53c4f03d92f
-  arch: x86_64
-  platform: osx
   license: GPL-3.0-only OR LGPL-3.0-only
   size: 1392865
   timestamp: 1626955817826
@@ -12933,8 +14210,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libunistring-0.9.10-h3422bc3_0.tar.bz2
   sha256: a1afe12ab199f82f339eae83405d293d197f2485d45346a709703bc7e8299949
   md5: d88e77a4861e20bd96bde6628ee7a5ae
-  arch: aarch64
-  platform: osx
   license: GPL-3.0-only OR LGPL-3.0-only
   size: 1577561
   timestamp: 1626955172521
@@ -12948,8 +14223,6 @@ packages:
   md5: 7245a044b4a1980ed83196176b78b73a
   depends:
   - libgcc-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only OR LGPL-3.0-only
   size: 1433436
   timestamp: 1626955018689
@@ -13044,8 +14317,6 @@ packages:
   md5: 40b61aab5c7ba9ff276c41cfffe6b80b
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 33601
@@ -13066,69 +14337,6 @@ packages:
   timestamp: 1680113474501
 - kind: conda
   name: libuv
-  version: 1.44.2
-  build: hcfcfb64_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.44.2-hcfcfb64_1.conda
-  sha256: d602dc13e1b0a955aa5f14772a3b8dc5ee72a4f68a4d63adb82a1ee105ffe4b2
-  md5: db1816a489a1b69dd1fd93e523cf026a
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: MIT
-  license_family: MIT
-  size: 285183
-  timestamp: 1690371821520
-- kind: conda
-  name: libuv
-  version: 1.46.0
-  build: h0c2f820_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.46.0-h0c2f820_0.conda
-  sha256: e51667c756f15580d3ce131d6157f0238d931c05af118c89f019854f2a7c125e
-  md5: 27664a5d39d9c32ae38880fec2b33b36
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 396101
-  timestamp: 1693539567563
-- kind: conda
-  name: libuv
-  version: 1.46.0
-  build: hb547adb_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.46.0-hb547adb_0.conda
-  sha256: f2fe8e22a99f91761c16dc7b00408bff0f5c30d4cccc6ea562db00a4041c5579
-  md5: 5f1d535f82e8210ac80d191610b92325
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 402723
-  timestamp: 1693539587068
-- kind: conda
-  name: libuv
-  version: 1.46.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.46.0-hd590300_0.conda
-  sha256: 4bc4c946e9a532c066442714eeeeb1ffbd03cd89789c4047293f5e782b5fedd7
-  md5: d23c76f7e6dcd6243d1b6ef5e62d17d2
-  depends:
-  - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
-  license: MIT
-  license_family: MIT
-  size: 893348
-  timestamp: 1693539405436
-- kind: conda
-  name: libuv
   version: 1.48.0
   build: h31becfc_0
   subdir: linux-aarch64
@@ -13142,25 +14350,76 @@ packages:
   size: 635472
   timestamp: 1709913320273
 - kind: conda
-  name: libva
-  version: 2.20.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.20.0-hd590300_0.conda
-  sha256: 972d6f67d854d0f0fc2593f8bddc8d411859437ace7248c374e1a85a9ea9d410
-  md5: 933bcea637569c6cea6084957028cb53
-  depends:
-  - libdrm >=2.4.114,<2.5.0a0
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-libxext >=1.3.4,<2.0a0
-  - xorg-libxfixes *
-  arch: x86_64
-  platform: linux
+  name: libuv
+  version: 1.48.0
+  build: h67532ce_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.48.0-h67532ce_0.conda
+  sha256: fb87f7bfd464a3a841d23f418c86a206818da0c4346984392071d9342c9ea367
+  md5: c8e7344c74f0d86584f7ecdc9f25c198
   license: MIT
   license_family: MIT
-  size: 188151
-  timestamp: 1694689905260
+  size: 407040
+  timestamp: 1709913680478
+- kind: conda
+  name: libuv
+  version: 1.48.0
+  build: h93a5062_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.48.0-h93a5062_0.conda
+  sha256: 60bed2a7a85096387ab0381cbc32ea2da7f8dd99bd90e440983019c0cdd96ad1
+  md5: abfd49e80f13453b62a56be226120ea8
+  license: MIT
+  license_family: MIT
+  size: 405988
+  timestamp: 1709913494015
+- kind: conda
+  name: libuv
+  version: 1.48.0
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libuv-1.48.0-hcfcfb64_0.conda
+  sha256: 6151c51857c2407139ce22fdc956022353e675b2bc96991a9201d51cceaa90b4
+  md5: 485e49e1d500d996844df14cabf64d73
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 289753
+  timestamp: 1709913743184
+- kind: conda
+  name: libuv
+  version: 1.48.0
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.48.0-hd590300_0.conda
+  sha256: b7c0e8a0c93c2621be7645b37123d4e8d27e8a974da26a3fba47a9c37711aa7f
+  md5: 7e8b914b1062dd4386e3de4d82a3ead6
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 899979
+  timestamp: 1709913354710
+- kind: conda
+  name: libva
+  version: 2.21.0
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libva-2.21.0-hd590300_0.conda
+  sha256: b4e3a3fa523a5ddd1eca7981c9d6a9b831a182950116cc5bda18c94a040b63bc
+  md5: e50a2609159a3e336fe4092738c00687
+  depends:
+  - libdrm >=2.4.120,<2.5.0a0
+  - xorg-libx11 >=1.8.7,<2.0a0
+  - xorg-libxext >=1.3.4,<2.0a0
+  - xorg-libxfixes
+  license: MIT
+  license_family: MIT
+  size: 189313
+  timestamp: 1710242676665
 - kind: conda
   name: libvorbis
   version: 1.3.7
@@ -13189,8 +14448,6 @@ packages:
   - libogg >=1.3.4,<1.4.0a0
   - vc >=14.1,<15.0a0
   - vs2015_runtime >=14.16.27012
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 273721
@@ -13207,8 +14464,6 @@ packages:
   - libgcc-ng >=9.3.0
   - libogg >=1.3.4,<1.4.0a0
   - libstdcxx-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 286280
@@ -13239,8 +14494,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
   size: 1006029
@@ -13255,8 +14508,6 @@ packages:
   md5: d62a0d3d8c01bd9fad3fd17d720d0cf5
   depends:
   - libcxx >=15.0.7
-  arch: aarch64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 1134986
@@ -13271,98 +14522,88 @@ packages:
   md5: 217e20148014ce0118f7d10852ac2fec
   depends:
   - libcxx >=15.0.7
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
   size: 1285936
   timestamp: 1696342600631
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
-  build: h0dc2134_0
+  version: 1.4.0
+  build: h10d778d_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
-  sha256: fa7580f26fec4c28321ec2ece1257f3293e0c646c635e9904679f4a8369be401
-  md5: 4e7e9d244e87d66c18d36894fd6a8ae5
+  url: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.4.0-h10d778d_0.conda
+  sha256: 7bafd8f4c637778cd0aa390bf3a894feef0e1fcf6ea6000c7ffc25c4c5a65538
+  md5: b2c0047ea73819d992484faacbbe1c24
   constrains:
-  - libwebp 1.3.2
-  arch: x86_64
-  platform: osx
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 346599
-  timestamp: 1694709233836
+  size: 355099
+  timestamp: 1713200298965
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
+  version: 1.4.0
   build: h31becfc_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.3.2-h31becfc_0.conda
-  sha256: a85484d8399bfa310512fe94863c8da3b224ac13f5e97736da65be6f509a8bf8
-  md5: 1490de434d2a2c06a98af27641a2ffff
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libwebp-base-1.4.0-h31becfc_0.conda
+  sha256: 10dded60f274e29c573cfacf6e96f5d0fc374ee431250374a44cbd773916ab9d
+  md5: 5fd7ab3e5f382c70607fbac6335e6e19
   depends:
   - libgcc-ng >=12
   constrains:
-  - libwebp 1.3.2
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 363462
-  timestamp: 1694710436617
+  size: 363577
+  timestamp: 1713201785160
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
-  build: hb547adb_0
+  version: 1.4.0
+  build: h93a5062_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.2-hb547adb_0.conda
-  sha256: a159b848193043fb58465ae6a449361615dadcf27babfe0b18db2bd3eb59e958
-  md5: 85dbc11098cdbe4244cd73f29a3ab795
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.4.0-h93a5062_0.conda
+  sha256: 0d4bad713a512d79bfeb4d61821f447afab8b0792aca823f505ce6b195e9fde5
+  md5: c0af0edfebe780b19940e94871f1a765
   constrains:
-  - libwebp 1.3.2
-  arch: aarch64
-  platform: osx
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 273844
-  timestamp: 1694709510635
+  size: 287750
+  timestamp: 1713200194013
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
+  version: 1.4.0
   build: hcfcfb64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
-  sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
-  md5: dcde8820959e64378d4e06147ffecfdd
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - libwebp 1.3.2
-  arch: x86_64
-  platform: win
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 268870
-  timestamp: 1694709461733
+  size: 274359
+  timestamp: 1713200524021
 - kind: conda
   name: libwebp-base
-  version: 1.3.2
+  version: 1.4.0
   build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
-  sha256: 68764a760fa81ef35dacb067fe8ace452bbb41476536a4a147a1051df29525f0
-  md5: 30de3fd9b3b602f7473f30e684eeea8c
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.4.0-hd590300_0.conda
+  sha256: 49bc5f6b1e11cb2babf2a2a731d1a680a5e08a858280876a779dbda06c78c35f
+  md5: b26e8aa824079e1be0294e7152ca4559
   depends:
   - libgcc-ng >=12
   constrains:
-  - libwebp 1.3.2
-  arch: x86_64
-  platform: linux
+  - libwebp 1.4.0
   license: BSD-3-Clause
   license_family: BSD
-  size: 401830
-  timestamp: 1694709121323
+  size: 438953
+  timestamp: 1713199854503
 - kind: conda
   name: libxcb
   version: '1.15'
@@ -13373,11 +14614,9 @@ packages:
   md5: 33277193f5b92bad9fdd230eb700929c
   depends:
   - libgcc-ng >=12
-  - pthread-stubs *
-  - xorg-libxau *
-  - xorg-libxdmcp *
-  arch: x86_64
-  platform: linux
+  - pthread-stubs
+  - xorg-libxau
+  - xorg-libxdmcp
   license: MIT
   license_family: MIT
   size: 384238
@@ -13480,26 +14719,6 @@ packages:
 - kind: conda
   name: libxkbcommon
   version: 1.6.0
-  build: h217f472_1
-  build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.6.0-h217f472_1.conda
-  sha256: 1d027bfb83ca1dd2007a5e0f8f96e8abe0e5b0fbccb26393d354d40301e37998
-  md5: 2517505a8ffdf02518e3ccb67e1ec30b
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.12.1,<3.0.0a0
-  - xkeyboard-config
-  - xorg-libxau >=1.0.11,<2.0a0
-  license: MIT/X11 Derivative
-  license_family: MIT
-  size: 578444
-  timestamp: 1701352615055
-- kind: conda
-  name: libxkbcommon
-  version: 1.6.0
   build: h5d7e998_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libxkbcommon-1.6.0-h5d7e998_0.conda
@@ -13509,105 +14728,110 @@ packages:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libxcb >=1.15,<1.16.0a0
-  - libxml2 >=2.11.5,<2.12.0a0
-  - xkeyboard-config *
+  - libxml2 >=2.11.5,<3.0.0a0
+  - xkeyboard-config
   - xorg-libxau >=1.0.11,<2.0a0
-  arch: x86_64
-  platform: linux
   license: MIT/X11 Derivative
   license_family: MIT
   size: 573385
   timestamp: 1696808339408
 - kind: conda
+  name: libxkbcommon
+  version: 1.7.0
+  build: h2555907_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxkbcommon-1.7.0-h2555907_0.conda
+  sha256: 5075106adf56dfd586d889be9c151692a8507a2d00df8ba4a9e28a6aaac6074d
+  md5: 3663134cd650738ad46bd0d643246f51
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libxcb >=1.15,<1.16.0a0
+  - libxml2 >=2.12.6,<3.0a0
+  - xkeyboard-config
+  - xorg-libxau >=1.0.11,<2.0a0
+  license: MIT/X11 Derivative
+  license_family: MIT
+  size: 595967
+  timestamp: 1711303495028
+- kind: conda
   name: libxml2
-  version: 2.11.5
-  build: h232c23b_1
-  build_number: 1
+  version: 2.11.6
+  build: h0d0cfa8_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.6-h0d0cfa8_0.conda
+  sha256: 07d2da8f3fb00fb6f84cd36b5329174b878105889f0fe21e79981f27573b47af
+  md5: 37e112ce9494adfcee6c0c7bf3b5d98d
+  depends:
+  - icu >=73.2,<74.0a0
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - xz >=5.2.6,<6.0a0
+  license: MIT
+  license_family: MIT
+  size: 588705
+  timestamp: 1700245318212
+- kind: conda
+  name: libxml2
+  version: 2.11.6
+  build: h232c23b_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.5-h232c23b_1.conda
-  sha256: 1b3cb6864de1a558ea5fb144c780121d52507837d15df0600491d8ed92cff90c
-  md5: f3858448893839820d4bcfb14ad3ecdf
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.11.6-h232c23b_0.conda
+  sha256: e6183d5e57ee48cc1fc4340477c31a6bd8be4d3ba5dded82cbca0d5280591086
+  md5: 427a3e59d66cb5d145020bd9c6493334
   depends:
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - xz >=5.2.6,<6.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
-  size: 705542
-  timestamp: 1692960341690
+  size: 705641
+  timestamp: 1700244910106
 - kind: conda
   name: libxml2
-  version: 2.11.5
-  build: h25269f3_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.11.5-h25269f3_1.conda
-  sha256: 8291549b87aca48e9cd4aec124af01b5037acd16f8ad14083d7af23c8bb6bebe
-  md5: 627b5d1377536b5b632ba53cd1455555
-  depends:
-  - icu >=73.2,<74.0a0
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 614831
-  timestamp: 1692960705224
-- kind: conda
-  name: libxml2
-  version: 2.11.5
-  build: h3346baf_1
-  build_number: 1
+  version: 2.11.6
+  build: hc0ae0f7_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.5-h3346baf_1.conda
-  sha256: d901fab32e57a43c44e630fb1c4d0a163d23b109eecd6c68b9ee371800760bca
-  md5: 7584dee6af7de378aed0ae49aebedb8a
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.11.6-hc0ae0f7_0.conda
+  sha256: b5b1c3df3e6d0d294764938e79d7f413191cc5b1af2ede49f42b1df04d068a18
+  md5: 2b6ec8c6366ea74db4b910469addad1d
   depends:
   - icu >=73.2,<74.0a0
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - xz >=5.2.6,<6.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
-  size: 623399
-  timestamp: 1692960844532
+  size: 620717
+  timestamp: 1700245256960
 - kind: conda
   name: libxml2
-  version: 2.11.5
-  build: hc3477c8_1
-  build_number: 1
+  version: 2.12.7
+  build: h283a6d9_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
-  sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
-  md5: 27974f880a010b1441093d9f737a949f
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.7-h283a6d9_0.conda
+  sha256: e246fefa745b56c022063ba1b69ff2965f280c6eee3de9821184e7c8f2475eab
+  md5: 1451be68a5549561979125c1827b79ed
   depends:
   - libiconv >=1.17,<2.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  size: 1600640
-  timestamp: 1692960798126
+  size: 1615693
+  timestamp: 1715606533379
 - kind: conda
   name: libxml2
-  version: 2.12.5
-  build: h3091e33_0
+  version: 2.12.7
+  build: h49dc7a2_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.5-h3091e33_0.conda
-  sha256: 34f7a007fa23b70c56358738d7ba801df9a923422f2dcd23f3b2ca790ea2460a
-  md5: 2fcb5d64474a337f2a4213ec1dd40ce2
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/libxml2-2.12.7-h49dc7a2_0.conda
+  sha256: 658fba82346e14cebe0d7972b84510e5cc4c3abd6c59be28405170cb442584fd
+  md5: 3201713ddfaa8daba3702eeddf690d25
   depends:
   - icu >=73.2,<74.0a0
   - libgcc-ng >=12
@@ -13616,8 +14840,8 @@ packages:
   - xz >=5.2.6,<6.0a0
   license: MIT
   license_family: MIT
-  size: 752149
-  timestamp: 1707084726972
+  size: 751856
+  timestamp: 1715606356653
 - kind: conda
   name: libzlib
   version: 1.2.13
@@ -13646,8 +14870,6 @@ packages:
   md5: 1a47f5236db2e06a320ffa0392f81bd8
   constrains:
   - zlib 1.2.13 *_5
-  arch: aarch64
-  platform: osx
   license: Zlib
   license_family: Other
   size: 48102
@@ -13663,8 +14885,6 @@ packages:
   md5: 4a3ad23f6e16f99c04e166767193d700
   constrains:
   - zlib 1.2.13 *_5
-  arch: x86_64
-  platform: osx
   license: Zlib
   license_family: Other
   size: 59404
@@ -13684,8 +14904,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - zlib 1.2.13 *_5
-  arch: x86_64
-  platform: win
   license: Zlib
   license_family: Other
   size: 55800
@@ -13703,44 +14921,42 @@ packages:
   - libgcc-ng >=12
   constrains:
   - zlib 1.2.13 *_5
-  arch: x86_64
-  platform: linux
   license: Zlib
   license_family: Other
   size: 61588
   timestamp: 1686575217516
 - kind: conda
   name: llvm-openmp
-  version: 17.0.3
-  build: hb6ac08f_0
+  version: 18.1.5
+  build: h39e0ece_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.3-hb6ac08f_0.conda
-  sha256: 5bded7aa593e4d5dea89fc19ef2aa48b531cbe455452877ef9bd5a698cf35e53
-  md5: b70adc70bc7527a207c81c2e6b43532c
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.5-h39e0ece_0.conda
+  sha256: 9efba1424726d83271727c494138ad1d519d5fed301f1ee5825019eae56f5570
+  md5: ee12a644568269838b91f901b2537425
+  depends:
+  - __osx >=10.9
   constrains:
-  - openmp 17.0.3|17.0.3.*
-  arch: x86_64
-  platform: osx
+  - openmp 18.1.5|18.1.5.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 299798
-  timestamp: 1697651995182
+  size: 300438
+  timestamp: 1714984682878
 - kind: conda
   name: llvm-openmp
-  version: 17.0.3
-  build: hcd81f8e_0
+  version: 18.1.5
+  build: hde57baf_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.3-hcd81f8e_0.conda
-  sha256: e744ecb793c1e991e93855b6e6b26c43b2b6fef2ecc340f9f54f7a650ed5e41a
-  md5: bc4b8795976aae9c1ea5eb4ba26eafd8
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.5-hde57baf_0.conda
+  sha256: c9ecaaa3d83215753a54f66038480582eff632196ed0df7763ca320154d00526
+  md5: 5b0ef7f8e9f413cbfd53573da96cae1b
+  depends:
+  - __osx >=11.0
   constrains:
-  - openmp 17.0.3|17.0.3.*
-  arch: aarch64
-  platform: osx
+  - openmp 18.1.5|18.1.5.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 274678
-  timestamp: 1697652011036
+  size: 276522
+  timestamp: 1714984701521
 - kind: conda
   name: llvm-tools
   version: 15.0.7
@@ -13815,8 +15031,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 143402
@@ -13955,44 +15169,40 @@ packages:
   depends:
   - intel-openmp 2023.*
   - tbb 2021.*
-  arch: x86_64
-  platform: win
   license: LicenseRef-ProprietaryIntel
   license_family: Proprietary
   size: 144749783
   timestamp: 1695995252418
 - kind: conda
   name: mpg123
-  version: 1.32.3
-  build: h59595ed_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.3-h59595ed_0.conda
-  sha256: f02b8ed16b3a488938b5f9453d19ea315ce6ed0d46cc389ecfaa28f2a4c3cb16
-  md5: bdadff838d5437aea83607ced8b37f75
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
-  license: LGPL-2.1-only
-  license_family: LGPL
-  size: 491969
-  timestamp: 1696265613952
-- kind: conda
-  name: mpg123
-  version: 1.32.4
+  version: 1.32.6
   build: h2f0025b_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.4-h2f0025b_0.conda
-  sha256: 5e0e3585a050b4e0412a55521ab7a739275f33aaed38f97a537edcb2fa6c4c54
-  md5: 6ccb0eb784f3c544f6c1f48e61787de4
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/mpg123-1.32.6-h2f0025b_0.conda
+  sha256: 5488d0dc1c638790e9d74f3e0c53b6e9cd5ef6939ecd7bd4b21136bde4937523
+  md5: bff99ad1c59a066d18a07be0e6309b8a
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   license: LGPL-2.1-only
   license_family: LGPL
-  size: 559635
-  timestamp: 1704980202901
+  size: 561472
+  timestamp: 1712327090852
+- kind: conda
+  name: mpg123
+  version: 1.32.6
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/mpg123-1.32.6-h59595ed_0.conda
+  sha256: 8895a5ce5122a3b8f59afcba4b032f198e8a690a0efc95ef61f2135357ef0d72
+  md5: 9160cdeb523a1b20cf8d2a0bf821f45d
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: LGPL-2.1-only
+  license_family: LGPL
+  size: 491811
+  timestamp: 1712327176955
 - kind: conda
   name: msys2-conda-epoch
   version: '20160418'
@@ -14022,40 +15232,36 @@ packages:
 - kind: conda
   name: mysql-common
   version: 8.0.33
-  build: hf1915f5_5
-  build_number: 5
+  build: hf1915f5_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_5.conda
-  sha256: 1b5114244f28e416d42e9ac0c61dfdabdfd7255b9fe752a07ca157a3e3893d2a
-  md5: 1e8ef4090ca4f0d66404a7441e1dbf3c
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-common-8.0.33-hf1915f5_6.conda
+  sha256: c8b2c5c9d0d013a4f6ef96cb4b339bfdc53a74232d8c61ed08178e5b1ec4eb63
+  md5: 80bf3b277c120dd294b51d404b931a75
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - openssl >=3.1.3,<4.0a0
-  arch: x86_64
-  platform: linux
-  size: 757936
-  timestamp: 1696767534589
+  - openssl >=3.1.4,<4.0a0
+  size: 753467
+  timestamp: 1698937026421
 - kind: conda
   name: mysql-libs
   version: 8.0.33
-  build: hca2cd23_5
-  build_number: 5
+  build: hca2cd23_6
+  build_number: 6
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_5.conda
-  sha256: 90a5c105e35990cac53f45366c256d88f4c8f66a360afd37dcae1357e370ade6
-  md5: b72f016c910ff9295b1377d3e17da3f2
+  url: https://conda.anaconda.org/conda-forge/linux-64/mysql-libs-8.0.33-hca2cd23_6.conda
+  sha256: 78c905637dac79b197395065c169d452b8ca2a39773b58e45e23114f1cb6dcdb
+  md5: e87530d1b12dd7f4e0f856dc07358d60
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  - mysql-common ==8.0.33 hf1915f5_5
-  - openssl >=3.1.3,<4.0a0
+  - mysql-common 8.0.33 hf1915f5_6
+  - openssl >=3.1.4,<4.0a0
   - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: linux
-  size: 1529906
-  timestamp: 1696767629434
+  size: 1530126
+  timestamp: 1698937116126
 - kind: conda
   name: mysql-libs
   version: 8.0.33
@@ -14076,106 +15282,90 @@ packages:
   timestamp: 1698937846157
 - kind: conda
   name: ncurses
-  version: '6.4'
-  build: h0425590_2
-  build_number: 2
+  version: '6.5'
+  build: h0425590_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.4-h0425590_2.conda
-  sha256: d71cf2f2b1a9fae7ee2455a35a890423838e9594294beb4a002fe7c7b10bc086
-  md5: 4ff0a396150dedad4269e16e5810f769
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.5-h0425590_0.conda
+  sha256: f8002feaa9e0eb929cd123f1275d8c0b3c6ffb7fd9269b192927009df19dc89e
+  md5: 38362af7bfac0efef69675acee564458
   depends:
   - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
-  size: 920540
-  timestamp: 1698751239554
+  size: 925099
+  timestamp: 1715194843316
 - kind: conda
   name: ncurses
-  version: '6.4'
-  build: h7ea286d_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
-  sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
-  md5: 318337fb9d0c53ba635efb7888242373
-  arch: aarch64
-  platform: osx
-  license: X11 AND BSD-3-Clause
-  size: 799196
-  timestamp: 1686077139703
-- kind: conda
-  name: ncurses
-  version: '6.4'
-  build: hcb278e6_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-hcb278e6_0.conda
-  sha256: ccf61e61d58a8a7b2d66822d5568e2dc9387883dd9b2da61e1d787ece4c4979a
-  md5: 681105bccc2a3f7f1a837d47d39c9179
-  depends:
-  - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
-  license: X11 AND BSD-3-Clause
-  size: 880967
-  timestamp: 1686076725450
-- kind: conda
-  name: ncurses
-  version: '6.4'
-  build: hf0c8a7f_0
+  version: '6.5'
+  build: h5846eda_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-hf0c8a7f_0.conda
-  sha256: 7841b1fce1ffb0bfb038f9687b92f04d64acab1f7cb96431972386ea98c7b2fd
-  md5: c3dbae2411164d9b02c69090a9a91857
-  arch: x86_64
-  platform: osx
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-h5846eda_0.conda
+  sha256: 6ecc73db0e49143092c0934355ac41583a5d5a48c6914c5f6ca48e562d3a4b79
+  md5: 02a888433d165c99bf09784a7b14d900
   license: X11 AND BSD-3-Clause
-  size: 828118
-  timestamp: 1686077056765
+  size: 823601
+  timestamp: 1715195267791
 - kind: conda
-  name: nettle
-  version: 3.8.1
-  build: h63371fa_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.8.1-h63371fa_1.tar.bz2
-  sha256: 712b4e836060ab26772c343a05d243e7486bb44a39bb5b35f3371e72d7b38a24
-  md5: 0da3266889a3febbb9840a7a89d29da9
-  arch: aarch64
-  platform: osx
-  license: GPL 2 and LGPL3
-  license_family: GPL
-  size: 537453
-  timestamp: 1659085354893
-- kind: conda
-  name: nettle
-  version: 3.8.1
-  build: h96f3785_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.8.1-h96f3785_1.tar.bz2
-  sha256: d8b3ffa9595e04a28c7cecb482548c868ec1d5d1937a40ac508ff97d0343d3dc
-  md5: 99558b9df4c337a0bf82bc8e0090533a
-  arch: x86_64
-  platform: osx
-  license: GPL 2 and LGPL3
-  license_family: GPL
-  size: 547875
-  timestamp: 1659085424759
-- kind: conda
-  name: nettle
-  version: 3.8.1
-  build: hc379101_1
-  build_number: 1
+  name: ncurses
+  version: '6.5'
+  build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.8.1-hc379101_1.tar.bz2
-  sha256: 49c569a69608eee784e815179a70c6ae4d088dac42b7df999044f68058d593bb
-  md5: 3cb2c7df59990bd37c2ce27fd906de68
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h59595ed_0.conda
+  sha256: 4fc3b384f4072b68853a0013ea83bdfd3d66b0126e2238e1d6e1560747aa7586
+  md5: fcea371545eda051b6deafb24889fc69
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
+  license: X11 AND BSD-3-Clause
+  size: 887465
+  timestamp: 1715194722503
+- kind: conda
+  name: ncurses
+  version: '6.5'
+  build: hb89a1cb_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-hb89a1cb_0.conda
+  sha256: 87d7cf716d9d930dab682cb57b3b8d3a61940b47d6703f3529a155c938a6990a
+  md5: b13ad5724ac9ae98b6b4fd87e4500ba4
+  license: X11 AND BSD-3-Clause
+  size: 795131
+  timestamp: 1715194898402
+- kind: conda
+  name: nettle
+  version: 3.9.1
+  build: h40ed0f5_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nettle-3.9.1-h40ed0f5_0.conda
+  sha256: 5de149b6e35adac11e22ae02516a7466412348690da52049f80ea07fe544896d
+  md5: b157977e1ec1dde3ba7ebc6e0dde363f
   license: GPL 2 and LGPL3
   license_family: GPL
-  size: 1195508
-  timestamp: 1659085101126
+  size: 510164
+  timestamp: 1686310071126
+- kind: conda
+  name: nettle
+  version: 3.9.1
+  build: h7ab15ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/nettle-3.9.1-h7ab15ed_0.conda
+  sha256: 1ef1b7efa69c7fb4e2a36a88316f307c115713698d1c12e19f55ae57c0482995
+  md5: 2bf1915cc107738811368afcb0993a59
+  depends:
+  - libgcc-ng >=12
+  license: GPL 2 and LGPL3
+  license_family: GPL
+  size: 1011638
+  timestamp: 1686309814836
+- kind: conda
+  name: nettle
+  version: 3.9.1
+  build: h8e11ae5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/nettle-3.9.1-h8e11ae5_0.conda
+  sha256: 62de51fc44f1595a06c5b24bb717b949b4b9fb4c4acaf127b92ce99ddb546ca7
+  md5: 400dffe5d2fbb9813b51948d3e9e9ab1
+  license: GPL 2 and LGPL3
+  license_family: GPL
+  size: 509519
+  timestamp: 1686310097670
 - kind: conda
   name: nettle
   version: 3.9.1
@@ -14201,8 +15391,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: Apache
   size: 2251263
@@ -14217,8 +15405,6 @@ packages:
   md5: 49ad513efe39447aa51affd47e3aa68f
   depends:
   - libcxx >=14.0.6
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 121284
@@ -14248,8 +15434,6 @@ packages:
   md5: fdecec4002f41cf6ea1eea5b52947ee0
   depends:
   - libcxx >=14.0.6
-  arch: aarch64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
   size: 107047
@@ -14265,8 +15449,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: MPL-2.0
   license_family: MOZILLA
   size: 226848
@@ -14288,43 +15470,41 @@ packages:
   timestamp: 1669784904844
 - kind: conda
   name: nss
-  version: '3.94'
-  build: h1d7d5a4_0
+  version: '3.100'
+  build: h8c4e863_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.100-h8c4e863_0.conda
+  sha256: a11d29bee156be646897cdd95c99b207889dd55b7f5c80519987e138f70a1730
+  md5: 6029b52dd71a51b08ecf62cbf374ac5e
+  depends:
+  - libgcc-ng >=12
+  - libsqlite >=3.45.3,<4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  - nspr >=4.35,<5.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2036728
+  timestamp: 1715188636956
+- kind: conda
+  name: nss
+  version: '3.100'
+  build: hca3bf56_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.94-h1d7d5a4_0.conda
-  sha256: c9b7910fc554c6550905b9150f4c8230e973ca63f41b42f2c18a49e8aa458e78
-  md5: 7caef74bbfa730e014b20f0852068509
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.100-hca3bf56_0.conda
+  sha256: a4146d2b6636999a21afcaf957029d066637bf26239fd3170242501e38fb1fa4
+  md5: 949c4a82290ee58b3c970cef4bcfd4ad
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
-  - libsqlite >=3.43.0,<4.0a0
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  - nspr >=4.35,<5.0a0
-  arch: x86_64
-  platform: linux
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 2003539
-  timestamp: 1696290024389
-- kind: conda
-  name: nss
-  version: '3.98'
-  build: hc5a5cc2_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/nss-3.98-hc5a5cc2_0.conda
-  sha256: d1506d21d8375c1dbdd5fee11cbb6799f8f129a54bc837ca5b8baa43fbe3d36d
-  md5: 7b72650a6c08894c36bed9aebb3b32dc
-  depends:
-  - libgcc-ng >=12
-  - libsqlite >=3.45.1,<4.0a0
+  - libsqlite >=3.45.3,<4.0a0
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
   - nspr >=4.35,<5.0a0
   license: MPL-2.0
   license_family: MOZILLA
-  size: 2011672
-  timestamp: 1708065149436
+  size: 2047723
+  timestamp: 1715184444840
 - kind: conda
   name: numpy
   version: 1.26.4
@@ -14438,20 +15618,19 @@ packages:
   timestamp: 1707225809722
 - kind: conda
   name: ocl-icd
-  version: 2.3.1
-  build: h7f98852_0
+  version: 2.3.2
+  build: hd590300_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.1-h7f98852_0.tar.bz2
-  sha256: b4db0e12f0c5d988be154bb469235a216dc3d63836d784308507eb101463344e
-  md5: a9b00e3aa7ecf158ed8e34ef91915f16
+  url: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.2-hd590300_1.conda
+  sha256: 0e01384423e48e5011eb6b224da8dc5e3567c87dbcefbe60cd9d5cead276cdcd
+  md5: c66f837ac65e4d1cdeb80e2a1d5fcc3d
   depends:
-  - libgcc-ng >=9.4.0
-  arch: x86_64
-  platform: linux
+  - libgcc-ng >=12
   license: BSD-2-Clause
   license_family: BSD
-  size: 121465
-  timestamp: 1629253199482
+  size: 135681
+  timestamp: 1710946531879
 - kind: conda
   name: ocl-icd-system
   version: 1.0.0
@@ -14462,9 +15641,7 @@ packages:
   sha256: cb0ce5ce5ede1be2fd9edf88abd3ce3e6c2b7397c0283d623e4d8ccf96a1ed09
   md5: 577a4bd049737b11a24524e39a16a1f3
   depends:
-  - ocl-icd *
-  arch: x86_64
-  platform: linux
+  - ocl-icd
   license: BSD 3-Clause
   license_family: BSD
   size: 4253
@@ -14562,77 +15739,6 @@ packages:
   timestamp: 1698894410587
 - kind: conda
   name: openh264
-  version: 2.3.1
-  build: h63175ca_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openh264-2.3.1-h63175ca_2.conda
-  sha256: 251566b5326a292215a3db5a184c255a092242a371431b617c7baf300fa9d170
-  md5: 76e822d93cdc32b00b61810d3fa030e0
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vs2015_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 410812
-  timestamp: 1675882258839
-- kind: conda
-  name: openh264
-  version: 2.3.1
-  build: hb7217d7_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.3.1-hb7217d7_2.conda
-  sha256: 36c6dc71bb10245ed93f3cb13280948cc8c6ca525f1639aac9d541726e4c80af
-  md5: 6ce0517e73640933cf5916deb21d4f23
-  depends:
-  - libcxx >=14.0.6
-  arch: aarch64
-  platform: osx
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 587729
-  timestamp: 1675880932590
-- kind: conda
-  name: openh264
-  version: 2.3.1
-  build: hcb278e6_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.3.1-hcb278e6_2.conda
-  sha256: 3be6de15d40f02c9bb34d5095c65b6b3f07e04fc21a0fb63d1885f1a31de5ae2
-  md5: 37d01894f256b2a6921c5a218f42f8a2
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 718775
-  timestamp: 1675880590512
-- kind: conda
-  name: openh264
-  version: 2.3.1
-  build: hf0c8a7f_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.3.1-hf0c8a7f_2.conda
-  sha256: 5f39b97f048d72b149627993072e15d37428338a9fe83600db5d09ae7ca9f7b4
-  md5: 989ba22b08353c5ca0e6fba80bcd4321
-  depends:
-  - libcxx >=14.0.6
-  arch: x86_64
-  platform: osx
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 671537
-  timestamp: 1675880810146
-- kind: conda
-  name: openh264
   version: 2.4.0
   build: h2f0025b_0
   subdir: linux-aarch64
@@ -14646,6 +15752,67 @@ packages:
   license_family: BSD
   size: 761063
   timestamp: 1700931496192
+- kind: conda
+  name: openh264
+  version: 2.4.0
+  build: h59595ed_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.4.0-h59595ed_0.conda
+  sha256: 321a8920f401bf0a5200b12bc1abe2dbd32190c382897a7631d3251425d67e37
+  md5: bfdc3111edbb41be5b44a0e7b21030c5
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 736306
+  timestamp: 1700931377539
+- kind: conda
+  name: openh264
+  version: 2.4.0
+  build: h93d8f39_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/openh264-2.4.0-h93d8f39_0.conda
+  sha256: 624b810166de3c3f95a9d0a3f50738863fea93df8a8dc91e378726b6b4e2e57a
+  md5: 57bdc2884f64cf1e59fc05d8fd14ca79
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 658346
+  timestamp: 1700931590689
+- kind: conda
+  name: openh264
+  version: 2.4.0
+  build: h965bd2d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openh264-2.4.0-h965bd2d_0.conda
+  sha256: 1b91b42ead7154ca79abf2e50bfab9ce62f55104dcbe529346f807b463347867
+  md5: 605fdd0c5d365da08802fc3b000a1542
+  depends:
+  - __osx >=10.9
+  - libcxx >=16.0.6
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 601776
+  timestamp: 1700931606673
+- kind: conda
+  name: openh264
+  version: 2.4.1
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openh264-2.4.1-h63175ca_0.conda
+  sha256: 37c954a1235531499c45439c602dda6f788e3683795e12fb6e1e4c86074386c7
+  md5: 01d1a98fd9ac45d49040ad8cdd62083a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 409185
+  timestamp: 1706874444698
 - kind: conda
   name: openjpeg
   version: 2.5.2
@@ -14737,29 +15904,28 @@ packages:
   timestamp: 1709159627299
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: h0d3ecfb_1
-  build_number: 1
+  version: 3.3.0
+  build: h0d3ecfb_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
-  sha256: 519dc941d7ab0ebf31a2878d85c2f444450e7c5f6f41c4d07252c6bb3417b78b
-  md5: eb580fb888d93d5d550c557323ac5cee
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.0-h0d3ecfb_0.conda
+  sha256: 51f9be8fe929c2bb3243cd0707b6dfcec27541f8284b4bd9b063c288fc46f482
+  md5: 25b0e522c3131886a637e347b2ca0c0f
   depends:
   - ca-certificates
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2855250
-  timestamp: 1710793435903
+  size: 2888226
+  timestamp: 1714466346030
 - kind: conda
   name: openssl
-  version: 3.2.1
+  version: 3.3.0
   build: h31becfc_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.2.1-h31becfc_0.conda
-  sha256: 952ef5de4e3913621a89ca2eb8186683bb73832527219c6443c260a6b46cd149
-  md5: b7e7c53240214ae96f52a440c0b0126a
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.3.0-h31becfc_0.conda
+  sha256: 5aee0fc6e07ec60e01023a8d3e034773534bfd1df1a8dd83f446da03ae98b333
+  md5: 36ca60a3afaf2ea2c460daeebd67430e
   depends:
   - ca-certificates
   - libgcc-ng >=12
@@ -14767,17 +15933,16 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 3382700
-  timestamp: 1706635800272
+  size: 3423479
+  timestamp: 1714465928572
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: hcfcfb64_1
-  build_number: 1
+  version: 3.3.0
+  build: hcfcfb64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
-  sha256: 61ce4e11c3c26ed4e4d9b7e7e2483121a1741ad0f9c8db0a91a28b6e05182ce6
-  md5: 958e0418e93e50c575bff70fbcaa12d8
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.0-hcfcfb64_0.conda
+  sha256: ca7573b7503711b53b2464fa35e4efa6f89dcd3d436fb5f128722b853e356dfd
+  md5: a6c544c9f060740c625dbf6d92cf3495
   depends:
   - ca-certificates
   - ucrt >=10.0.20348.0
@@ -14787,17 +15952,16 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 8230112
-  timestamp: 1710796158475
+  size: 8358240
+  timestamp: 1714468180752
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: hd590300_1
-  build_number: 1
+  version: 3.3.0
+  build: hd590300_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
-  sha256: 2c689444ed19a603be457284cf2115ee728a3fafb7527326e96054dee7cdc1a7
-  md5: 9d731343cff6ee2e5a25c4a091bf8e2a
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.0-hd590300_0.conda
+  sha256: fdbf05e4db88c592366c90bb82e446edbe33c6e49e5130d51c580b2629c0b5d5
+  md5: c0f3abb4a16477208bbd43a39bd56f18
   depends:
   - ca-certificates
   - libgcc-ng >=12
@@ -14805,25 +15969,24 @@ packages:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2865379
-  timestamp: 1710793235846
+  size: 2895187
+  timestamp: 1714466138265
 - kind: conda
   name: openssl
-  version: 3.2.1
-  build: hd75f5a5_1
-  build_number: 1
+  version: 3.3.0
+  build: hd75f5a5_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
-  sha256: 7ae0ac6a1673584a8a380c2ff3d46eca48ed53bc7174c0d4eaa0dd2f247a0984
-  md5: 570a6f04802df580be529f3a72d2bbf7
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.0-hd75f5a5_0.conda
+  sha256: d3889b0c89c2742e92e20f01e8f298b64c221df5d577c639b823a0bfe314e2e3
+  md5: eb8c33aa7929a7714eab8b90c1d88afe
   depends:
   - ca-certificates
   constrains:
   - pyopenssl >=22.1
   license: Apache-2.0
   license_family: Apache
-  size: 2506344
-  timestamp: 1710793930515
+  size: 2541802
+  timestamp: 1714467068742
 - kind: conda
   name: orc
   version: 1.9.2
@@ -14937,8 +16100,6 @@ packages:
   depends:
   - libffi >=3.4.2,<3.5.0a0
   - libtasn1 >=4.18.0,<5.0a0
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 890711
@@ -14954,8 +16115,6 @@ packages:
   depends:
   - libffi >=3.4.2,<3.5.0a0
   - libtasn1 >=4.18.0,<5.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 834487
@@ -14988,84 +16147,74 @@ packages:
   - libffi >=3.4.2,<3.5.0a0
   - libgcc-ng >=12
   - libtasn1 >=4.18.0,<5.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 4702497
   timestamp: 1654868759643
 - kind: conda
   name: pcre2
-  version: '10.40'
+  version: '10.43'
+  build: h0ad2156_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
+  sha256: 226714bbf89d45bf7da4c7551e21b8a833f51d33379fe3dfbfe31b72832d4dba
+  md5: 9c8651803886ce9d5983e107a0df4ea8
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 836581
+  timestamp: 1708118455741
+- kind: conda
+  name: pcre2
+  version: '10.43'
   build: h17e33f8_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.40-h17e33f8_0.tar.bz2
-  sha256: 5833c63548e4fae91da6d77739eab7dc9bf6542e43f105826b23c01bfdd9cb57
-  md5: 2519de0d9620dc2bc7e19caf6867136d
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
+  sha256: 9a82c7d49c4771342b398661862975efb9c30e7af600b5d2e08a0bf416fda492
+  md5: d0485b8aa2cedb141a7bd27b4efa4c9c
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.12,<1.3.0a0
+  - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
-  - vs2015_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
+  - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 2001630
-  timestamp: 1665563527916
+  size: 818317
+  timestamp: 1708118868321
 - kind: conda
   name: pcre2
-  version: '10.40'
-  build: h1c4e4bc_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.40-h1c4e4bc_0.tar.bz2
-  sha256: 60265b48c96decbea89a19a7bc34be88d9b95d4725fd4dbdae158529c601875a
-  md5: e0f80c8f3a0352a54eddfe59cd2b25b1
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.12,<1.3.0a0
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 2552113
-  timestamp: 1665563254214
-- kind: conda
-  name: pcre2
-  version: '10.40'
-  build: hb34f9b4_0
+  version: '10.43'
+  build: h26f9a81_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.40-hb34f9b4_0.tar.bz2
-  sha256: 93503b5e05470ccc87f696c0fdf0d47938e0305b5047eacb85c15d78dcf641fe
-  md5: 721b7288270bafc83586b0f01c2a67f2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
+  sha256: 4bf7b5fa091f5e7ab0b78778458be1e81c1ffa182b63795734861934945a63a7
+  md5: 1ddc87f00014612830f3235b5ad6d821
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libzlib >=1.2.12,<1.3.0a0
-  arch: aarch64
-  platform: osx
+  - libzlib >=1.2.13,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1161688
-  timestamp: 1665563317371
+  size: 615219
+  timestamp: 1708118184900
 - kind: conda
   name: pcre2
-  version: '10.40'
-  build: hc3806b6_0
+  version: '10.43'
+  build: hcad00b1_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.40-hc3806b6_0.tar.bz2
-  sha256: 7a29ec847556eed4faa1646010baae371ced69059a4ade43851367a076d6108a
-  md5: 69e2c796349cd9b273890bee0febfe1b
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
+  sha256: 766dd986a7ed6197676c14699000bba2625fd26c8a890fcb7a810e5cf56155bc
+  md5: 8292dea9e022d9610a11fce5e0896ed8
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libgcc-ng >=12
-  - libzlib >=1.2.12,<1.3.0a0
-  arch: x86_64
-  platform: linux
+  - libzlib >=1.2.13,<1.3.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 2412495
-  timestamp: 1665562915343
+  size: 950847
+  timestamp: 1708118050286
 - kind: conda
   name: pcre2
   version: '10.43'
@@ -15205,71 +16354,19 @@ packages:
   timestamp: 1712154634705
 - kind: conda
   name: pixman
-  version: 0.42.2
-  build: h13dd4ca_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.42.2-h13dd4ca_0.conda
-  sha256: 90e60dc5604e356d47ef97b23b13759ef3d8b70fa2c637f4809d29851435d7d7
-  md5: f96347021db6f33ccabe314ddeab62d4
-  depends:
-  - libcxx >=15.0.7
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 213843
-  timestamp: 1695736518800
-- kind: conda
-  name: pixman
-  version: 0.42.2
+  version: 0.43.2
   build: h59595ed_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.42.2-h59595ed_0.conda
-  sha256: ae917851474eb3b08812b02c9e945d040808523ec53f828aa74a90b0cdf15f57
-  md5: 700edd63ccd5fc66b70b1c028cea9a68
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.43.2-h59595ed_0.conda
+  sha256: 366d28e2a0a191d6c535e234741e0cd1d94d713f76073d8af4a5ccb2a266121e
+  md5: 71004cbf7924e19c02746ccde9fd7123
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
-  size: 385309
-  timestamp: 1695736061006
-- kind: conda
-  name: pixman
-  version: 0.42.2
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.42.2-h63175ca_0.conda
-  sha256: bc663647468255781e3fba488372b0e699b717a63fa2450b9c282e68b6eb9543
-  md5: fb6fe034c742dc8562d3197c2d91423d
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: MIT
-  license_family: MIT
-  size: 455866
-  timestamp: 1695736519750
-- kind: conda
-  name: pixman
-  version: 0.42.2
-  build: he965462_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.42.2-he965462_0.conda
-  sha256: d9181736d4b3260a03443e8fd1c47c491e189b2344913eaf5dead27947a274e4
-  md5: e4180dcfd3e3621560fe1ad522997520
-  depends:
-  - libcxx >=15.0.7
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 336190
-  timestamp: 1695736270076
+  size: 386826
+  timestamp: 1706549500138
 - kind: conda
   name: pixman
   version: 0.43.4
@@ -15285,6 +16382,50 @@ packages:
   license_family: MIT
   size: 295064
   timestamp: 1709240909660
+- kind: conda
+  name: pixman
+  version: 0.43.4
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
+  sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
+  md5: b98135614135d5f458b75ab9ebb9558c
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 461854
+  timestamp: 1709239971654
+- kind: conda
+  name: pixman
+  version: 0.43.4
+  build: h73e2aa4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
+  sha256: 3ab44e12e566c67a6e9fd831f557ab195456aa996b8dd9af19787ca80caa5cd1
+  md5: cb134c1e03fd32f4e6bea3f6de2614fd
+  depends:
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 323904
+  timestamp: 1709239931160
+- kind: conda
+  name: pixman
+  version: 0.43.4
+  build: hebf3989_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
+  sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
+  md5: 0308c68e711cd295aaa026a4f8c4b1e5
+  depends:
+  - libcxx >=16
+  license: MIT
+  license_family: MIT
+  size: 198755
+  timestamp: 1709239846651
 - kind: conda
   name: pthread-stubs
   version: '0.4'
@@ -15309,8 +16450,6 @@ packages:
   md5: 22dad4df6e8630e8dff2428f6f6a7036
   depends:
   - libgcc-ng >=7.5.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 5625
@@ -15369,8 +16508,6 @@ packages:
   md5: e2da8758d7d51ff6aa78a14dfb9dbed4
   depends:
   - vc 14.*
-  arch: x86_64
-  platform: win
   license: LGPL 2
   size: 144301
   timestamp: 1537755684331
@@ -15384,8 +16521,6 @@ packages:
   md5: 4de774bb04e03af9704ec1a2618c636c
   depends:
   - libcxx >=15.0.7
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 92472
@@ -15416,8 +16551,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 114871
@@ -15434,8 +16567,6 @@ packages:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 111324
@@ -15450,8 +16581,6 @@ packages:
   md5: 92f9416f48c010bf04c34c9841c84b09
   depends:
   - libcxx >=15.0.7
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 94175
@@ -15494,8 +16623,6 @@ packages:
   - libsystemd0 >=254
   constrains:
   - pulseaudio 16.1 *_5
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1-or-later
   license_family: LGPL
   size: 754844
@@ -15598,22 +16725,23 @@ packages:
   timestamp: 1698894318257
 - kind: conda
   name: pyarrow
-  version: 15.0.0
-  build: py312h14a4a34_0_cpu
+  version: 14.0.2
+  build: py312h14a4a34_3_cpu
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-15.0.0-py312h14a4a34_0_cpu.conda
-  sha256: 7564d7e7e95587e014182a034c42c47e1e25e5932e2520040d5143bb16f174ba
-  md5: 066e94cea5740555db7b946577e350fd
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-14.0.2-py312h14a4a34_3_cpu.conda
+  sha256: 223cd95eb039e5ab95f057605985d2cead2a42fe42464cbe8c81dcf35d143aad
+  md5: e85ccaf933f407f401e967a85fe2b919
   depends:
-  - libarrow 15.0.0 h4ce3932_0_cpu
-  - libarrow-acero 15.0.0 h13dd4ca_0_cpu
-  - libarrow-dataset 15.0.0 h13dd4ca_0_cpu
-  - libarrow-flight 15.0.0 ha94d253_0_cpu
-  - libarrow-flight-sql 15.0.0 h39a9b85_0_cpu
-  - libarrow-gandiva 15.0.0 hf757142_0_cpu
-  - libarrow-substrait 15.0.0 h7fd9903_0_cpu
+  - libarrow 14.0.2 h4ce3932_3_cpu
+  - libarrow-acero 14.0.2 h13dd4ca_3_cpu
+  - libarrow-dataset 14.0.2 h13dd4ca_3_cpu
+  - libarrow-flight 14.0.2 ha94d253_3_cpu
+  - libarrow-flight-sql 14.0.2 h39a9b85_3_cpu
+  - libarrow-gandiva 14.0.2 hf757142_3_cpu
+  - libarrow-substrait 14.0.2 h7fd9903_3_cpu
   - libcxx >=14
-  - libparquet 15.0.0 hf6ce1d5_0_cpu
+  - libparquet 14.0.2 hf6ce1d5_3_cpu
   - numpy >=1.26.3,<2.0a0
   - python >=3.12,<3.13.0a0
   - python >=3.12,<3.13.0a0 *_cpython
@@ -15622,26 +16750,27 @@ packages:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 4053619
-  timestamp: 1706644981928
+  size: 4033583
+  timestamp: 1706614151282
 - kind: conda
   name: pyarrow
-  version: 15.0.0
-  build: py312h176e3d2_0_cpu
+  version: 14.0.2
+  build: py312h176e3d2_3_cpu
+  build_number: 3
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-15.0.0-py312h176e3d2_0_cpu.conda
-  sha256: 03cf44791e6f64dcbc920fda9f8d5746a30601c0610c3c646cef3d6f9a4880ff
-  md5: dd9fd47a7e8d13cc37dc1d884c3db3b4
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-14.0.2-py312h176e3d2_3_cpu.conda
+  sha256: 1305f6bf1f260b19c9cb86d9d073e39a9dd6d3b3cad83345100349218805f98b
+  md5: b74bdf6ac6fcfb7319ce6ecbd4364508
   depends:
-  - libarrow 15.0.0 h84dd17c_0_cpu
-  - libarrow-acero 15.0.0 h59595ed_0_cpu
-  - libarrow-dataset 15.0.0 h59595ed_0_cpu
-  - libarrow-flight 15.0.0 h120cb0d_0_cpu
-  - libarrow-flight-sql 15.0.0 h61ff412_0_cpu
-  - libarrow-gandiva 15.0.0 hacb8726_0_cpu
-  - libarrow-substrait 15.0.0 h61ff412_0_cpu
+  - libarrow 14.0.2 h84dd17c_3_cpu
+  - libarrow-acero 14.0.2 h59595ed_3_cpu
+  - libarrow-dataset 14.0.2 h59595ed_3_cpu
+  - libarrow-flight 14.0.2 h120cb0d_3_cpu
+  - libarrow-flight-sql 14.0.2 h61ff412_3_cpu
+  - libarrow-gandiva 14.0.2 hacb8726_3_cpu
+  - libarrow-substrait 14.0.2 h61ff412_3_cpu
   - libgcc-ng >=12
-  - libparquet 15.0.0 h352af49_0_cpu
+  - libparquet 14.0.2 h352af49_3_cpu
   - libstdcxx-ng >=12
   - numpy >=1.26.3,<2.0a0
   - python >=3.12,<3.13.0a0
@@ -15650,26 +16779,27 @@ packages:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 4533629
-  timestamp: 1706644193722
+  size: 4490737
+  timestamp: 1706611015723
 - kind: conda
   name: pyarrow
-  version: 15.0.0
-  build: py312h2f65cca_0_cpu
+  version: 14.0.2
+  build: py312h2f65cca_3_cpu
+  build_number: 3
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-15.0.0-py312h2f65cca_0_cpu.conda
-  sha256: 0db64a150a11facad44aa78217ba5d00a323b08a138eebda8fa0d80b4ffbf9c5
-  md5: 85f2cd13f50ac3c149199bf77778715f
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-14.0.2-py312h2f65cca_3_cpu.conda
+  sha256: 0618a3099e572d11c475f0bad1b7ebe6e09aa028bc3b414cf0dc20b930cb333c
+  md5: 0b3329097e24643c7fc1abd408e55efa
   depends:
-  - libarrow 15.0.0 he4a0828_0_cpu
-  - libarrow-acero 15.0.0 h2f0025b_0_cpu
-  - libarrow-dataset 15.0.0 h2f0025b_0_cpu
-  - libarrow-flight 15.0.0 h43033d3_0_cpu
-  - libarrow-flight-sql 15.0.0 hb5131e1_0_cpu
-  - libarrow-gandiva 15.0.0 h1bc7839_0_cpu
-  - libarrow-substrait 15.0.0 h318fca9_0_cpu
+  - libarrow 14.0.2 he4a0828_3_cpu
+  - libarrow-acero 14.0.2 h2f0025b_3_cpu
+  - libarrow-dataset 14.0.2 h2f0025b_3_cpu
+  - libarrow-flight 14.0.2 h43033d3_3_cpu
+  - libarrow-flight-sql 14.0.2 hb5131e1_3_cpu
+  - libarrow-gandiva 14.0.2 h1bc7839_3_cpu
+  - libarrow-substrait 14.0.2 h318fca9_3_cpu
   - libgcc-ng >=12
-  - libparquet 15.0.0 hb18b541_0_cpu
+  - libparquet 14.0.2 hb18b541_3_cpu
   - libstdcxx-ng >=12
   - numpy >=1.26.3,<2.0a0
   - python >=3.12,<3.13.0a0
@@ -15679,26 +16809,27 @@ packages:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 4381306
-  timestamp: 1706647431079
+  size: 4335414
+  timestamp: 1706614427706
 - kind: conda
   name: pyarrow
-  version: 15.0.0
-  build: py312h40fbfea_0_cpu
+  version: 14.0.2
+  build: py312h40fbfea_3_cpu
+  build_number: 3
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-15.0.0-py312h40fbfea_0_cpu.conda
-  sha256: 0fed8b6d0a24971ac3d14d39589935e3a0c5580bcc6527b1809140e86be11e5a
-  md5: 92c3eae66aa477a8678e69c920d2725d
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-14.0.2-py312h40fbfea_3_cpu.conda
+  sha256: cc6b4b1a5938d2267ffeee5c821ce47bc15c1e1923d4e8077ee46909bdc11781
+  md5: df049d2b499bf4944a2e6a9884c74f6f
   depends:
-  - libarrow 15.0.0 h1aaacd4_0_cpu
-  - libarrow-acero 15.0.0 h000cb23_0_cpu
-  - libarrow-dataset 15.0.0 h000cb23_0_cpu
-  - libarrow-flight 15.0.0 ha1803ca_0_cpu
-  - libarrow-flight-sql 15.0.0 h8ec153b_0_cpu
-  - libarrow-gandiva 15.0.0 h01dce7f_0_cpu
-  - libarrow-substrait 15.0.0 h8ec153b_0_cpu
+  - libarrow 14.0.2 h1aaacd4_3_cpu
+  - libarrow-acero 14.0.2 h000cb23_3_cpu
+  - libarrow-dataset 14.0.2 h000cb23_3_cpu
+  - libarrow-flight 14.0.2 ha1803ca_3_cpu
+  - libarrow-flight-sql 14.0.2 h8ec153b_3_cpu
+  - libarrow-gandiva 14.0.2 h01dce7f_3_cpu
+  - libarrow-substrait 14.0.2 h8ec153b_3_cpu
   - libcxx >=14
-  - libparquet 15.0.0 h381d950_0_cpu
+  - libparquet 14.0.2 h381d950_3_cpu
   - numpy >=1.26.3,<2.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -15706,25 +16837,26 @@ packages:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 4016659
-  timestamp: 1706645411591
+  size: 3994233
+  timestamp: 1706612474921
 - kind: conda
   name: pyarrow
-  version: 15.0.0
-  build: py312h85e32bb_0_cpu
+  version: 14.0.2
+  build: py312h85e32bb_3_cpu
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-15.0.0-py312h85e32bb_0_cpu.conda
-  sha256: b1ff7856aafa7142cf6518d6a5b039a8b9b7eef60676a3eac58c61342583e2a3
-  md5: 7c61b729ceb993913ec65d051a8541aa
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-14.0.2-py312h85e32bb_3_cpu.conda
+  sha256: 3cc26129e5f87914a8c461f79fd673a20254a9129e0809d814471d0465d4eed7
+  md5: d266a5ed8dc6d1e0cdd72dc25a007152
   depends:
-  - libarrow 15.0.0 he5f67d5_0_cpu
-  - libarrow-acero 15.0.0 h63175ca_0_cpu
-  - libarrow-dataset 15.0.0 h63175ca_0_cpu
-  - libarrow-flight 15.0.0 h53b1db0_0_cpu
-  - libarrow-flight-sql 15.0.0 h78eab7c_0_cpu
-  - libarrow-gandiva 15.0.0 hb2eaab1_0_cpu
-  - libarrow-substrait 15.0.0 hd4c9904_0_cpu
-  - libparquet 15.0.0 h7ec3a38_0_cpu
+  - libarrow 14.0.2 he5f67d5_3_cpu
+  - libarrow-acero 14.0.2 h63175ca_3_cpu
+  - libarrow-dataset 14.0.2 h63175ca_3_cpu
+  - libarrow-flight 14.0.2 h53b1db0_3_cpu
+  - libarrow-flight-sql 14.0.2 h78eab7c_3_cpu
+  - libarrow-gandiva 14.0.2 hb2eaab1_3_cpu
+  - libarrow-substrait 14.0.2 hd4c9904_3_cpu
+  - libparquet 14.0.2 h7ec3a38_3_cpu
   - numpy >=1.26.3,<2.0a0
   - python >=3.12,<3.13.0a0
   - python_abi 3.12.* *_cp312
@@ -15735,21 +16867,47 @@ packages:
   - apache-arrow-proc =*=cpu
   license: Apache-2.0
   license_family: APACHE
-  size: 3451675
-  timestamp: 1706646976287
+  size: 3425099
+  timestamp: 1706612237454
 - kind: conda
   name: python
-  version: 3.12.2
+  version: 3.12.3
+  build: h1411813_0_cpython
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.3-h1411813_0_cpython.conda
+  sha256: 3b327ffc152a245011011d1d730781577a8274fde1cf6243f073749ead8f1c2a
+  md5: df1448ec6cbf8eceb03d29003cf72ae6
+  depends:
+  - __osx >=10.9
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
+  - libzlib >=1.2.13,<1.3.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.12.* *_cp312
+  license: Python-2.0
+  size: 14557341
+  timestamp: 1713208068012
+- kind: conda
+  name: python
+  version: 3.12.3
   build: h2628c8c_0_cpython
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.2-h2628c8c_0_cpython.conda
-  sha256: b8eda863b48ae4531635e23fd15e759d93212b6204c6847d591e25fa5fd67477
-  md5: be8803e9f75a477df61d4aabea3c1246
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.3-h2628c8c_0_cpython.conda
+  sha256: 1a95494abe572a8819c933f978df89f00bde72ea9432d46a70632599e8029ea4
+  md5: f07c8c5dd98767f9a652de5d039b284e
   depends:
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
+  - libexpat >=2.6.2,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.1,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
   - openssl >=3.2.1,<4.0a0
   - tk >=8.6.13,<8.7.0a0
@@ -15761,28 +16919,28 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 16083296
-  timestamp: 1708116662336
+  size: 16179248
+  timestamp: 1713205644673
 - kind: conda
   name: python
-  version: 3.12.2
+  version: 3.12.3
   build: h43d1f9e_0_cpython
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.2-h43d1f9e_0_cpython.conda
-  sha256: 16c8e77c01b814d836af632ef77eac21b64b9e398a11e1403a3a1802bb5be366
-  md5: 3a41090f2ef0868f119825593948ed46
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.3-h43d1f9e_0_cpython.conda
+  sha256: e186f3ee570464241c844adff6a3ba8f395cef15c5d46c0a8f784cfd97b3bdca
+  md5: dc93ad1d2ba17ebc948bf5434ffa864b
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-aarch64 >=2.36.1
-  - libexpat >=2.5.0,<3.0a0
+  - libexpat >=2.6.2,<3.0a0
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.45.1,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libuuid >=2.38.1,<3.0a0
   - libxcrypt >=4.4.36
   - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
+  - ncurses >=6.4.20240210,<7.0a0
   - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
@@ -15791,23 +16949,24 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 13823577
-  timestamp: 1708116074721
+  size: 14051797
+  timestamp: 1713205211165
 - kind: conda
   name: python
-  version: 3.12.2
-  build: h9f0c242_0_cpython
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.2-h9f0c242_0_cpython.conda
-  sha256: 7647ac06c3798a182a4bcb1ff58864f1ef81eb3acea6971295304c23e43252fb
-  md5: 0179b8007ba008cf5bec11f3b3853902
+  version: 3.12.3
+  build: h4a7b5fc_0_cpython
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.3-h4a7b5fc_0_cpython.conda
+  sha256: c761fb3713ea66bce3889b33b6f400afb2dd192d1fc2686446e9d8166cfcec6b
+  md5: 8643ab37bece6ae8f112464068d9df9c
   depends:
+  - __osx >=11.0
   - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
+  - libexpat >=2.6.2,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.1,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
+  - ncurses >=6.4.20240210,<7.0a0
   - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
@@ -15816,28 +16975,28 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 14596811
-  timestamp: 1708118065292
+  size: 13207557
+  timestamp: 1713206576646
 - kind: conda
   name: python
-  version: 3.12.2
+  version: 3.12.3
   build: hab00c5b_0_cpython
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.2-hab00c5b_0_cpython.conda
-  sha256: ddb7a2d8d78046bda5d7631e6814f9468d2eb054e10f86f4648c9d1fdaa30c0f
-  md5: ad7b68400f3a6ebe72b00be093c7f301
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.3-hab00c5b_0_cpython.conda
+  sha256: f9865bcbff69f15fd89a33a2da12ad616e98d65ce7c83c644b92e66e5016b227
+  md5: 2540b74d304f71d3e89c81209db4db84
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - ld_impl_linux-64 >=2.36.1
-  - libexpat >=2.5.0,<3.0a0
+  - libexpat >=2.6.2,<3.0a0
   - libffi >=3.4,<4.0a0
   - libgcc-ng >=12
   - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.45.1,<4.0a0
+  - libsqlite >=3.45.2,<4.0a0
   - libuuid >=2.38.1,<3.0a0
   - libxcrypt >=4.4.36
   - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
+  - ncurses >=6.4.20240210,<7.0a0
   - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
@@ -15846,33 +17005,8 @@ packages:
   constrains:
   - python_abi 3.12.* *_cp312
   license: Python-2.0
-  size: 32312631
-  timestamp: 1708118077305
-- kind: conda
-  name: python
-  version: 3.12.2
-  build: hdf0ec26_0_cpython
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.2-hdf0ec26_0_cpython.conda
-  sha256: ccd6c55a286d51d907c878ed2bfa7d1becce0fee71374a9386c5eb90d803ac72
-  md5: 85e91138ae921a2771f57a50120272bd
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.5.0,<3.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.45.1,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.2.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.12.* *_cp312
-  license: Python-2.0
-  size: 13085901
-  timestamp: 1708117361381
+  size: 31991381
+  timestamp: 1713208036041
 - kind: conda
   name: python_abi
   version: '3.12'
@@ -16222,8 +17356,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - ncurses >=6.3,<7.0a0
-  arch: x86_64
-  platform: linux
   license: GPL-3.0-only
   license_family: GPL
   size: 281456
@@ -16255,8 +17387,6 @@ packages:
   md5: 8cbb776a2f641b943d413b3e19df71f4
   depends:
   - ncurses >=6.3,<7.0a0
-  arch: aarch64
-  platform: osx
   license: GPL-3.0-only
   license_family: GPL
   size: 250351
@@ -16272,20 +17402,108 @@ packages:
   md5: f17f77f2acf4d344734bda76829ce14e
   depends:
   - ncurses >=6.3,<7.0a0
-  arch: x86_64
-  platform: osx
   license: GPL-3.0-only
   license_family: GPL
   size: 255870
   timestamp: 1679532707590
 - kind: conda
   name: rerun-sdk
-  version: 0.15.1
-  build: py312h60fbdae_0
+  version: 0.16.0
+  build: py312h0329a8d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/rerun-sdk-0.16.0-py312h0329a8d_0.conda
+  sha256: 337f58e162541944a623a19688a79a6220daaa79bd2768a7989abdc4979740fc
+  md5: 631b46046390ca1153ca46fe246e733e
+  depends:
+  - __osx >=10.13
+  - attrs >=23.1.0
+  - libcxx >=16
+  - numpy >=1.23
+  - pillow
+  - pyarrow >=14.0.2
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.5
+  constrains:
+  - __osx >=10.12
+  license: MIT OR Apache-2.0
+  size: 16568686
+  timestamp: 1716000024007
+- kind: conda
+  name: rerun-sdk
+  version: 0.16.0
+  build: py312h18b2cab_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/rerun-sdk-0.16.0-py312h18b2cab_0.conda
+  sha256: 0e13fe4a5956c66856d8868618e2ff0e7aa40cada424b91c0640ed4dd1c8c854
+  md5: ae5dccc0bd8ff37cb00bf93458c5f209
+  depends:
+  - attrs >=23.1.0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.23
+  - pillow
+  - pyarrow >=14.0.2
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.5
+  license: MIT OR Apache-2.0
+  size: 20558850
+  timestamp: 1716000438907
+- kind: conda
+  name: rerun-sdk
+  version: 0.16.0
+  build: py312h5715c7c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/rerun-sdk-0.16.0-py312h5715c7c_0.conda
+  sha256: 6cc29b72df46a5c6b574ee83085e3550e0b86442cd7a0143ae22479259c01962
+  md5: a8d3d911c8f6dfebeead09c4da40806c
+  depends:
+  - attrs >=23.1.0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.23
+  - pillow
+  - pyarrow >=14.0.2
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.5
+  license: MIT OR Apache-2.0
+  size: 20343781
+  timestamp: 1716000242889
+- kind: conda
+  name: rerun-sdk
+  version: 0.16.0
+  build: py312h5c2e7bc_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rerun-sdk-0.16.0-py312h5c2e7bc_0.conda
+  sha256: b63273ae093ea8a33902d0142c66d21176480a86fbdbd443d9a6f62eef52523e
+  md5: 95ce933c6f89e809976187a74a735253
+  depends:
+  - __osx >=11.0
+  - attrs >=23.1.0
+  - libcxx >=16
+  - numpy >=1.23
+  - pillow
+  - pyarrow >=14.0.2
+  - python >=3.12,<3.13.0a0
+  - python >=3.12,<3.13.0a0 *_cpython
+  - python_abi 3.12.* *_cp312
+  - typing_extensions >=4.5
+  constrains:
+  - __osx >=10.13
+  license: MIT OR Apache-2.0
+  size: 16159056
+  timestamp: 1716000246896
+- kind: conda
+  name: rerun-sdk
+  version: 0.16.0
+  build: py312h7a6832a_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/rerun-sdk-0.15.1-py312h60fbdae_0.conda
-  sha256: 1a857d5a75bad0888a7a40f0b12ea45d4dda72c326f73330ffd7efb3a0dbeb67
-  md5: 99030e0c0559f206e87ebb84c08c4dcf
+  url: https://conda.anaconda.org/conda-forge/win-64/rerun-sdk-0.16.0-py312h7a6832a_0.conda
+  sha256: 54857771f1bcc9b08d0e3138ebc37cb5b66d56ab460e04753d704fcdd7dcebb0
+  md5: c1f7304604fa86b2f65efdd7893e0273
   depends:
   - attrs >=23.1.0
   - numpy >=1.23
@@ -16298,96 +17516,8 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT OR Apache-2.0
-  size: 12952186
-  timestamp: 1712880287686
-- kind: conda
-  name: rerun-sdk
-  version: 0.15.1
-  build: py312h6a27564_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rerun-sdk-0.15.1-py312h6a27564_0.conda
-  sha256: bbc853221e0ed539aea6c79461fe560596104b4c185a5ddf615e1e6e70c3ba7f
-  md5: f304e041479a766c8028857b64cb6b43
-  depends:
-  - __osx >=11.0
-  - attrs >=23.1.0
-  - libcxx >=16
-  - numpy >=1.23
-  - pillow
-  - pyarrow >=14.0.2
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.5
-  license: MIT OR Apache-2.0
-  size: 13880331
-  timestamp: 1712879507112
-- kind: conda
-  name: rerun-sdk
-  version: 0.15.1
-  build: py312h9118e91_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rerun-sdk-0.15.1-py312h9118e91_0.conda
-  sha256: 3855e0380082867211429d4a471641a9d58f633a4aad093788aa0732319d5f0c
-  md5: 40e8c4f71e29e3e5d519808dae3846cd
-  depends:
-  - attrs >=23.1.0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.23
-  - pillow
-  - pyarrow >=14.0.2
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.5
-  license: MIT OR Apache-2.0
-  size: 17729984
-  timestamp: 1712878040716
-- kind: conda
-  name: rerun-sdk
-  version: 0.15.1
-  build: py312hb434743_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/rerun-sdk-0.15.1-py312hb434743_0.conda
-  sha256: a5fabdf6bf27b9b5a6a1f672088ca749909831a2a2c3e15fd6ecf4325f3d053e
-  md5: 6dc97b671a9b2ad469c27c3788f10c03
-  depends:
-  - attrs >=23.1.0
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.23
-  - pillow
-  - pyarrow >=14.0.2
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.5
-  license: MIT OR Apache-2.0
-  size: 17974314
-  timestamp: 1712878274598
-- kind: conda
-  name: rerun-sdk
-  version: 0.15.1
-  build: py312hbe1a6d7_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/rerun-sdk-0.15.1-py312hbe1a6d7_0.conda
-  sha256: 23d8652df7519fea5545e7dc5d98a48a5a0442f9a7b6c101a0995a12a03e4f20
-  md5: 0a3ff653cb20e0c9f2c58be93f8143e7
-  depends:
-  - __osx >=10.12
-  - attrs >=23.1.0
-  - libcxx >=16
-  - numpy >=1.23
-  - pillow
-  - pyarrow >=14.0.2
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - typing_extensions >=4.5
-  constrains:
-  - __osx >=10.12
-  license: MIT OR Apache-2.0
-  size: 14290714
-  timestamp: 1712878954432
+  size: 14911731
+  timestamp: 1716004005438
 - kind: conda
   name: rhash
   version: 1.4.4
@@ -16396,8 +17526,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/rhash-1.4.4-h0dc2134_0.conda
   sha256: f1ae47e8c4e46f856faf5d8ee1e5291f55627aa93401b61a877f18ade5780c87
   md5: 55a2ada70c8a208c01f77978f2783121
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 177229
@@ -16424,8 +17552,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/rhash-1.4.4-hb547adb_0.conda
   sha256: 3ab595e2280ed2118b6b1e8ce7e5949da2047846c81b6af1bbf5ac859d062edd
   md5: 710c4b1abf65b697c1d9716eba16dbb0
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 177491
@@ -16440,8 +17566,6 @@ packages:
   md5: ec972a9a2925ac8d7a19eb9606561fff
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 185144
@@ -16486,8 +17610,6 @@ packages:
   md5: 4a2cac04f86a4540b8c9b8d8f597848f
   depends:
   - openssl >=3.0.0,<4.0a0
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 210264
@@ -16502,8 +17624,6 @@ packages:
   md5: fbfb84b9de9a6939cb165c02c69b1865
   depends:
   - openssl >=3.0.0,<4.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
   size: 213817
@@ -16601,30 +17721,10 @@ packages:
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: BSD-2-Clause
   license_family: BSD
   size: 2641420
   timestamp: 1692966629866
-- kind: conda
-  name: svt-av1
-  version: 1.7.0
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.7.0-h63175ca_0.conda
-  sha256: 3d52d959e9b4e4654c36d03765fb4e8dbebfc1d17f271a46033bf301737a25cc
-  md5: fe5d2314e6fc3be8f8e3e2e73c14ab02
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 2353906
-  timestamp: 1692967156046
 - kind: conda
   name: svt-av1
   version: 1.7.0
@@ -16635,8 +17735,6 @@ packages:
   md5: e90a180c1ad53fe8e170db74e544cbf6
   depends:
   - libcxx >=15.0.7
-  arch: aarch64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 1229909
@@ -16651,8 +17749,6 @@ packages:
   md5: 0f15584eeb93b270ac297cc3990d5e95
   depends:
   - libcxx >=15.0.7
-  arch: x86_64
-  platform: osx
   license: BSD-2-Clause
   license_family: BSD
   size: 2429529
@@ -16672,6 +17768,22 @@ packages:
   license_family: BSD
   size: 1798999
   timestamp: 1702362756845
+- kind: conda
+  name: svt-av1
+  version: 2.0.0
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.0.0-h63175ca_0.conda
+  sha256: 0ece693f79e90819958e9e265b2b19409f36b4434aa132a58c993264a927d029
+  md5: b3c5c51269efb1bc04502c6231506707
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2354231
+  timestamp: 1710374384723
 - kind: conda
   name: sysroot_linux-64
   version: '2.12'
@@ -16717,8 +17829,6 @@ packages:
   md5: f9ff42ccf809a21ba6f8607f8de36108
   depends:
   - libcxx >=10.0.0.a0
-  arch: x86_64
-  platform: osx
   license: NCSA
   license_family: MIT
   size: 201044
@@ -16733,98 +17843,92 @@ packages:
   md5: d83362e7d0513f35f454bc50b0ca591d
   depends:
   - libcxx >=11.0.0.a0
-  arch: aarch64
-  platform: osx
   license: NCSA
   license_family: MIT
   size: 191416
   timestamp: 1602687595316
 - kind: conda
   name: tbb
-  version: 2021.10.0
-  build: h00ab1b0_2
-  build_number: 2
+  version: 2021.11.0
+  build: h00ab1b0_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.10.0-h00ab1b0_2.conda
-  sha256: 79a6c48fa1df661af7ab3e4f5fa444dd305d87921be017413a8b97fd6d642328
-  md5: eb0d5c122f42714f86a7058d1ce7b2e6
+  url: https://conda.anaconda.org/conda-forge/linux-64/tbb-2021.11.0-h00ab1b0_1.conda
+  sha256: ded4de0d5a3eb7b47ed829f0ed0e3c61ccd428308bde52d8d22ced228038223b
+  md5: 4531d2927578e7e254ff3bcf6457518c
   depends:
   - libgcc-ng >=12
   - libhwloc >=2.9.3,<2.9.4.0a0
   - libstdcxx-ng >=12
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
-  size: 186022
-  timestamp: 1697713416932
-- kind: conda
-  name: tbb
-  version: 2021.10.0
-  build: h1995070_2
-  build_number: 2
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.10.0-h1995070_2.conda
-  sha256: 5acedf2ba0d18217a6387f4788086e51cac56cef12ac120335fc3b31d40c0417
-  md5: 245760f53d4fa23bfb58ffbf89a4edc8
-  arch: aarch64
-  platform: osx
-  license: Apache-2.0
-  license_family: APACHE
-  size: 125356
-  timestamp: 1697713774680
-- kind: conda
-  name: tbb
-  version: 2021.10.0
-  build: h1c7c39f_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.10.0-h1c7c39f_2.conda
-  sha256: 81e3fae041696a9a74d493e49ab08ceda0022b4bd3716c1d88c0dae5435af94a
-  md5: 73434bcf87082942e938352afae9b0fa
-  arch: x86_64
-  platform: osx
-  license: Apache-2.0
-  license_family: APACHE
-  size: 159786
-  timestamp: 1697713666733
-- kind: conda
-  name: tbb
-  version: 2021.10.0
-  build: h91493d7_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
-  sha256: e55a2f1324f0fc8916ab8d590a3944ba1af62de727bb66e3019cf2744d26e679
-  md5: 5b8c97cf8f0e81d6c22c0bda9978790d
-  depends:
-  - libhwloc >=2.9.3,<2.9.4.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: Apache-2.0
-  license_family: APACHE
-  size: 156566
-  timestamp: 1697713986066
+  size: 195540
+  timestamp: 1706163436794
 - kind: conda
   name: tbb
   version: 2021.11.0
-  build: h2a328a1_1
+  build: h2ffa867_1
   build_number: 1
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.11.0-h2a328a1_1.conda
-  sha256: eb8a3fb326828c2ff7ba8e2879bf11b3bd52f34c317d0faebe59772533d7d1de
-  md5: 4e385c984b98c7cbf28af64041d21cc4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tbb-2021.11.0-h2ffa867_1.conda
+  sha256: 35aa1918c901fb784c74f3d322f21a87d5bf57fbf02e5586778152b5c4cd82da
+  md5: e5584996979b373d50560a28321547e9
   depends:
-  - libgcc-ng >=12
+  - libcxx >=15
   - libhwloc >=2.9.3,<2.9.4.0a0
-  - libstdcxx-ng >=12
   license: Apache-2.0
   license_family: APACHE
-  size: 161613
-  timestamp: 1706166156098
+  size: 128174
+  timestamp: 1706163796739
+- kind: conda
+  name: tbb
+  version: 2021.11.0
+  build: h7728843_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/tbb-2021.11.0-h7728843_1.conda
+  sha256: 6d531daba5ccf150b58d434fa72b1da0da04e8f14ab71bdad289a90d355f47e8
+  md5: 29e29beba9deb0ef66bee015c5bf3c14
+  depends:
+  - libcxx >=15
+  - libhwloc >=2.9.3,<2.9.4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 173117
+  timestamp: 1706163682083
+- kind: conda
+  name: tbb
+  version: 2021.12.0
+  build: h70be974_1
+  build_number: 1
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/tbb-2021.12.0-h70be974_1.conda
+  sha256: fae554fbe95be9ae17f4e233613ea7f18bb293dd5fce695848ea1a5acd9c78ec
+  md5: ea7d4337db9d66216dbfd59035916aaf
+  depends:
+  - libgcc-ng >=12
+  - libhwloc >=2.10.0,<2.10.1.0a0
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  size: 162627
+  timestamp: 1716033199474
+- kind: conda
+  name: tbb
+  version: 2021.12.0
+  build: hc790b64_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.12.0-hc790b64_1.conda
+  sha256: 87461c83a4f0d4f119af7368f20c47bbe0c27d963a7c22a3d08c71075077f855
+  md5: e98333643abc739ebea1bac97a479828
+  depends:
+  - libhwloc >=2.10.0,<2.10.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  size: 161771
+  timestamp: 1716031112705
 - kind: conda
   name: tk
   version: 8.6.13
@@ -16924,20 +18028,6 @@ packages:
   timestamp: 1712330089194
 - kind: conda
   name: tzdata
-  version: 2023c
-  build: h71feb2d_0
-  subdir: win-64
-  noarch: generic
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
-  sha256: 0449138224adfa125b220154408419ec37c06b0b49f63c5954724325903ecf55
-  md5: 939e3e74d8be4dac89ce83b20de2492a
-  arch: x86_64
-  platform: win
-  license: LicenseRef-Public-Domain
-  size: 117580
-  timestamp: 1680041306008
-- kind: conda
-  name: tzdata
   version: 2024a
   build: h0c530f3_0
   subdir: noarch
@@ -16958,8 +18048,6 @@ packages:
   md5: 72608f6cd3e5898229c3ea16deb1ac43
   constrains:
   - vs2015_runtime >=14.29.30037
-  arch: x86_64
-  platform: win
   license: LicenseRef-Proprietary
   license_family: PROPRIETARY
   size: 1283972
@@ -17023,40 +18111,36 @@ packages:
   timestamp: 1688020629925
 - kind: conda
   name: vc14_runtime
-  version: 14.36.32532
-  build: hdcecf7f_17
-  build_number: 17
+  version: 14.38.33130
+  build: h82b7239_18
+  build_number: 18
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.36.32532-hdcecf7f_17.conda
-  sha256: b317d49af32d5c031828e62c08d56f01d9a64cd3f40d4cccb052bc38c7a9e62e
-  md5: d0de20f2f3fc806a81b44fcdd941aaf7
+  url: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.38.33130-h82b7239_18.conda
+  sha256: bf94c9af4b2e9cba88207001197e695934eadc96a5c5e4cd7597e950aae3d8ff
+  md5: 8be79fdd2725ddf7bbf8a27a4c1f79ba
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.36.32532.* *_17
-  arch: x86_64
-  platform: win
+  - vs2015_runtime 14.38.33130.* *_18
   license: LicenseRef-ProprietaryMicrosoft
   license_family: Proprietary
-  size: 739437
-  timestamp: 1694292382336
+  size: 749868
+  timestamp: 1702511239004
 - kind: conda
   name: vs2015_runtime
-  version: 14.36.32532
-  build: h05e6639_17
-  build_number: 17
+  version: 14.38.33130
+  build: hcb4865c_18
+  build_number: 18
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.36.32532-h05e6639_17.conda
-  sha256: 5ecbd731dc7f13762d67be0eadc47eb7f14713005e430d9b5fc680e965ac0f81
-  md5: 4618046c39f7c81861e53ded842e738a
+  url: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.38.33130-hcb4865c_18.conda
+  sha256: a2fec221f361d6263c117f4ea6d772b21c90a2f8edc6f3eb0eadec6bfe8843db
+  md5: 10d42885e3ed84e575b454db30f1aa93
   depends:
-  - vc14_runtime >=14.36.32532
-  arch: x86_64
-  platform: win
+  - vc14_runtime >=14.38.33130
   license: BSD-3-Clause
   license_family: BSD
-  size: 17207
-  timestamp: 1688020635322
+  size: 16988
+  timestamp: 1702511261442
 - kind: conda
   name: vs2022_win-64
   version: 19.37.32822
@@ -17067,9 +18151,9 @@ packages:
   sha256: 259b5d4ac07b131bf15bf1a2d101eb9eb039e32cfef57de79061cb4c8f1889fe
   md5: 8b02594cf497f7516a3ed20a164de75e
   depends:
-  - vswhere *
-  arch: x86_64
-  platform: win
+  - vswhere
+  constrains:
+  - vs_win-64 2022.*
   track_features:
   - vc14
   license: BSD-3-Clause
@@ -17084,8 +18168,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/win-64/vswhere-3.1.4-h57928b3_0.conda
   sha256: 553c41fc1a883415a39444313f8d99236685529776fdd04e8d97288b73496002
   md5: b1d1d6a1f874d8c93a57b5efece52f03
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
   size: 218421
@@ -17101,8 +18183,6 @@ packages:
   md5: 6c99772d483f566d59e25037fea2c4b1
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL
   size: 897548
@@ -17131,8 +18211,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/x264-1!164.3095-h57fd34a_2.tar.bz2
   sha256: debdf60bbcfa6a60201b12a1d53f36736821db281a28223a09e0685edcce105a
   md5: b1f6dccde5d3a1f911960b6e567113ff
-  arch: aarch64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL
   size: 717038
@@ -17146,8 +18224,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/x264-1!164.3095-h775f41a_2.tar.bz2
   sha256: de611da29f4ed0733a330402e163f9260218e6ba6eae593a5f945827d0ee1069
   md5: 23e9c3180e2c0f9449bb042914ec2200
-  arch: x86_64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL
   size: 937077
@@ -17164,8 +18240,6 @@ packages:
   depends:
   - vc >=14.1,<15
   - vs2015_runtime >=14.16.27033
-  arch: x86_64
-  platform: win
   license: GPL-2.0-or-later
   license_family: GPL
   size: 1041889
@@ -17182,8 +18256,6 @@ packages:
   depends:
   - vc >=14.1,<15
   - vs2015_runtime >=14.16.27033
-  arch: x86_64
-  platform: win
   license: GPL-2.0-or-later
   license_family: GPL
   size: 5517425
@@ -17200,8 +18272,6 @@ packages:
   depends:
   - libgcc-ng >=10.3.0
   - libstdcxx-ng >=10.3.0
-  arch: x86_64
-  platform: linux
   license: GPL-2.0-or-later
   license_family: GPL
   size: 3357188
@@ -17217,8 +18287,6 @@ packages:
   md5: a3bf3e95b7795871a6734a784400fcea
   depends:
   - libcxx >=12.0.1
-  arch: x86_64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL
   size: 3433205
@@ -17234,8 +18302,6 @@ packages:
   md5: b1f7f2780feffe310b068c021e8ff9b2
   depends:
   - libcxx >=12.0.1
-  arch: aarch64
-  platform: osx
   license: GPL-2.0-or-later
   license_family: GPL
   size: 1832744
@@ -17284,9 +18350,8 @@ packages:
   md5: 9bfac7ccd94d54fd21a0501296d60424
   depends:
   - libgcc-ng >=12
+  - libxcb >=1.13
   - libxcb >=1.15,<1.16.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 19728
@@ -17304,8 +18369,6 @@ packages:
   - libgcc-ng >=12
   - libxcb >=1.15,<1.16.0a0
   - xcb-util >=0.4.0,<0.5.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 24474
@@ -17339,8 +18402,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libxcb >=1.15,<1.16.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 14186
@@ -17389,9 +18450,8 @@ packages:
   md5: e995b155d938b6779da6ace6c6b13816
   depends:
   - libgcc-ng >=12
+  - libxcb >=1.13
   - libxcb >=1.15,<1.16.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 16955
@@ -17408,8 +18468,6 @@ packages:
   depends:
   - libgcc-ng >=12
   - libxcb >=1.15,<1.16.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 52114
@@ -17432,23 +18490,6 @@ packages:
   timestamp: 1684680157286
 - kind: conda
   name: xkeyboard-config
-  version: '2.40'
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.40-hd590300_0.conda
-  sha256: a01fcb9c3346ee08aa24b3900a08896f2e8f80c891378a57d71764e16bbd6141
-  md5: 07c15d846a2e4d673da22cbd85fdb6d2
-  depends:
-  - libgcc-ng >=12
-  - xorg-libx11 >=1.8.6,<2.0a0
-  arch: x86_64
-  platform: linux
-  license: MIT
-  license_family: MIT
-  size: 895713
-  timestamp: 1696647097478
-- kind: conda
-  name: xkeyboard-config
   version: '2.41'
   build: h31becfc_0
   subdir: linux-aarch64
@@ -17462,6 +18503,21 @@ packages:
   license_family: MIT
   size: 896792
   timestamp: 1707104436982
+- kind: conda
+  name: xkeyboard-config
+  version: '2.41'
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.41-hd590300_0.conda
+  sha256: 56955610c0747ea7cb026bb8aa9ef165ff41d616e89894538173b8b7dd2ee49a
+  md5: 81f740407b45e3f9047b3174fa94eb9e
+  depends:
+  - libgcc-ng >=12
+  - xorg-libx11 >=1.8.7,<2.0a0
+  license: MIT
+  license_family: MIT
+  size: 898045
+  timestamp: 1707104384997
 - kind: conda
   name: xorg-fixesproto
   version: '5.0'
@@ -17489,9 +18545,7 @@ packages:
   md5: 65ad6e1eb4aed2b0611855aff05e04f6
   depends:
   - libgcc-ng >=9.3.0
-  - xorg-xextproto *
-  arch: x86_64
-  platform: linux
+  - xorg-xextproto
   license: MIT
   license_family: MIT
   size: 9122
@@ -17522,8 +18576,6 @@ packages:
   md5: bcd1b3396ec6960cbc1d2855a9e60b2b
   depends:
   - libgcc-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 19602
@@ -17554,8 +18606,6 @@ packages:
   md5: 4b230e8381279d76131116660f5a241a
   depends:
   - libgcc-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 27338
@@ -17584,8 +18634,6 @@ packages:
   md5: b462a33c0be1421532f28bfe8f4a7514
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 58469
@@ -17618,20 +18666,18 @@ packages:
   - libgcc-ng >=12
   - libuuid >=2.38.1,<3.0a0
   - xorg-libice >=1.1.1,<2.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 27433
   timestamp: 1685453649160
 - kind: conda
   name: xorg-libx11
-  version: 1.8.7
+  version: 1.8.9
   build: h055a233_0
   subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.7-h055a233_0.conda
-  sha256: dc688480f6afa3b5880b9d4e11e25e6c8dd10e961a07cfa30b2dc5e529e250bb
-  md5: b3ff774afbb2cd7678044e1fed24f59e
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/xorg-libx11-1.8.9-h055a233_0.conda
+  sha256: fe6adc8f0ab7ea026b8ccd5c8c8843e5a01f49bcd193eacec9af1626f0db1194
+  md5: d5f0529d3568a2ce38a9aed44a9a8029
   depends:
   - libgcc-ng >=12
   - libxcb >=1.15,<1.16.0a0
@@ -17640,28 +18686,26 @@ packages:
   - xorg-xproto
   license: MIT
   license_family: MIT
-  size: 854309
-  timestamp: 1697056918786
+  size: 851567
+  timestamp: 1712415736293
 - kind: conda
   name: xorg-libx11
-  version: 1.8.7
+  version: 1.8.9
   build: h8ee46fc_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.7-h8ee46fc_0.conda
-  sha256: 7a02a7beac472ae2759498550b5fc5261bf5be7a9a2b4648a3f67818a7bfefcf
-  md5: 49e482d882669206653b095f5206c05b
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.9-h8ee46fc_0.conda
+  sha256: 3e53ba247f1ad68353f18aceba5bf8ce87e3dea930de85d36946844a7658c9fb
+  md5: 077b6e8ad6a3ddb741fce2496dd01bec
   depends:
   - libgcc-ng >=12
   - libxcb >=1.15,<1.16.0a0
-  - xorg-kbproto *
+  - xorg-kbproto
   - xorg-xextproto >=7.3.0,<8.0a0
-  - xorg-xproto *
-  arch: x86_64
-  platform: linux
+  - xorg-xproto
   license: MIT
   license_family: MIT
-  size: 828692
-  timestamp: 1697056910935
+  size: 828060
+  timestamp: 1712415742569
 - kind: conda
   name: xorg-libxau
   version: 1.0.11
@@ -17725,8 +18769,6 @@ packages:
   md5: 2c80dc38fface310c9bd81b17037fee5
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 14468
@@ -17779,8 +18821,6 @@ packages:
   md5: be93aabceefa2fac576e971aef407908
   depends:
   - libgcc-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 19126
@@ -17811,9 +18851,7 @@ packages:
   depends:
   - libgcc-ng >=12
   - xorg-libx11 >=1.7.2,<2.0a0
-  - xorg-xextproto *
-  arch: x86_64
-  platform: linux
+  - xorg-xextproto
   license: MIT
   license_family: MIT
   size: 50143
@@ -17863,10 +18901,8 @@ packages:
   md5: e9a21aa4d5e3e5f1aed71e8cefd46b6a
   depends:
   - libgcc-ng >=9.3.0
-  - xorg-fixesproto *
+  - xorg-fixesproto
   - xorg-libx11 >=1.7.0,<2.0a0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 18145
@@ -17899,12 +18935,10 @@ packages:
   md5: e77615e5141cad5a2acaa043d1cf0ca5
   depends:
   - libgcc-ng >=9.3.0
-  - xorg-inputproto *
+  - xorg-inputproto
   - xorg-libx11 >=1.7.0,<2.0a0
   - xorg-libxext 1.3.*
   - xorg-libxfixes 5.0.*
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 47287
@@ -17936,9 +18970,7 @@ packages:
   depends:
   - libgcc-ng >=12
   - xorg-libx11 >=1.8.6,<2.0a0
-  - xorg-renderproto *
-  arch: x86_64
-  platform: linux
+  - xorg-renderproto
   license: MIT
   license_family: MIT
   size: 37770
@@ -17969,8 +19001,6 @@ packages:
   md5: 06feff3d2634e3097ce2fe681474b534
   depends:
   - libgcc-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 9621
@@ -17986,8 +19016,6 @@ packages:
   md5: bce9f945da8ad2ae9b1d7165a64d0f87
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 30270
@@ -18018,8 +19046,6 @@ packages:
   md5: 3ceea9668625c18f19530de98b15d5b0
   depends:
   - libgcc-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 23875
@@ -18065,8 +19091,6 @@ packages:
   md5: b4a4381d54784606820704f7b5f05a15
   depends:
   - libgcc-ng >=9.3.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
   size: 74922
@@ -18081,8 +19105,6 @@ packages:
   md5: 2161070d867d1b1204ea749c8eec4ef0
   depends:
   - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
   license: LGPL-2.1 and GPL-2.0
   size: 418368
   timestamp: 1660346797927
@@ -18094,8 +19116,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
   sha256: 59d78af0c3e071021cfe82dc40134c19dab8cdf804324b62940f5c8cd71803ec
   md5: 39c6b54e94014701dd157f4f576ed211
-  arch: aarch64
-  platform: osx
   license: LGPL-2.1 and GPL-2.0
   size: 235693
   timestamp: 1660346961024
@@ -18107,8 +19127,6 @@ packages:
   url: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
   sha256: eb09823f34cc2dd663c0ec4ab13f246f45dcd52e5b8c47b9864361de5204a1c8
   md5: a72f9d4ea13d55d745ff1ed594747f10
-  arch: x86_64
-  platform: osx
   license: LGPL-2.1 and GPL-2.0
   size: 238119
   timestamp: 1660346964847
@@ -18123,8 +19141,6 @@ packages:
   depends:
   - vc >=14.1,<15
   - vs2015_runtime >=14.16.27033
-  arch: x86_64
-  platform: win
   license: LGPL-2.1 and GPL-2.0
   size: 217804
   timestamp: 1660346976440
@@ -18167,9 +19183,7 @@ packages:
   sha256: de0ee1e24aa6867058d3b852a15c8d7f49f262f5828772700c647186d4a96bbe
   md5: a08383f223b10b71492d27566fafbf6c
   depends:
-  - libzlib ==1.2.13 h53f4e23_5
-  arch: aarch64
-  platform: osx
+  - libzlib 1.2.13 h53f4e23_5
   license: Zlib
   license_family: Other
   size: 79577
@@ -18184,9 +19198,7 @@ packages:
   sha256: d1f4c82fd7bd240a78ce8905e931e68dca5f523c7da237b6b63c87d5625c5b35
   md5: 75a8a98b1c4671c5d2897975731da42d
   depends:
-  - libzlib ==1.2.13 h8a1eda9_5
-  arch: x86_64
-  platform: osx
+  - libzlib 1.2.13 h8a1eda9_5
   license: Zlib
   license_family: Other
   size: 90764
@@ -18201,12 +19213,10 @@ packages:
   sha256: 0f91b719c7558046bcd37fdc7ae4b9eb2b7a8e335beb8b59ae7ccb285a46aa46
   md5: a318e8622e11663f645cc7fa3260f462
   depends:
-  - libzlib ==1.2.13 hcfcfb64_5
+  - libzlib 1.2.13 hcfcfb64_5
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Zlib
   license_family: Other
   size: 107711
@@ -18222,95 +19232,87 @@ packages:
   md5: 68c34ec6149623be41a1933ab996a209
   depends:
   - libgcc-ng >=12
-  - libzlib ==1.2.13 hd590300_5
-  arch: x86_64
-  platform: linux
+  - libzlib 1.2.13 hd590300_5
   license: Zlib
   license_family: Other
   size: 92825
   timestamp: 1686575231103
 - kind: conda
   name: zstd
-  version: 1.5.5
-  build: h12be248_0
+  version: 1.5.6
+  build: h02f22dd_0
+  subdir: linux-aarch64
+  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.6-h02f22dd_0.conda
+  sha256: 484f9d0722c77685ae379fbff3ccd662af9ead7e59eb39cd6d0c677cdf25ff6c
+  md5: be8d5f8cf21aed237b8b182ea86b3dd6
+  depends:
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 539937
+  timestamp: 1714723130243
+- kind: conda
+  name: zstd
+  version: 1.5.6
+  build: h0ea2cb4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
-  sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
-  md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
+  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
   depends:
   - libzlib >=1.2.13,<1.3.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  size: 343428
-  timestamp: 1693151615801
+  size: 349143
+  timestamp: 1714723445995
 - kind: conda
   name: zstd
-  version: 1.5.5
-  build: h4c53e97_0
-  subdir: linux-aarch64
-  url: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.5-h4c53e97_0.conda
-  sha256: d1e070029e9d07a3f25e6ed082d507b0f3cff1b109dd18d0b091a5c7b86dd07b
-  md5: b74eb9dbb5c3c15cb3cee7cbdf198c75
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<1.3.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 528989
-  timestamp: 1693151197934
-- kind: conda
-  name: zstd
-  version: 1.5.5
-  build: h4f39d0f_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.5-h4f39d0f_0.conda
-  sha256: 7e1fe6057628bbb56849a6741455bbb88705bae6d6646257e57904ac5ee5a481
-  md5: 5b212cfb7f9d71d603ad891879dc7933
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 400508
-  timestamp: 1693151393180
-- kind: conda
-  name: zstd
-  version: 1.5.5
-  build: h829000d_0
+  version: 1.5.6
+  build: h915ae27_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
-  sha256: d54e31d3d8de5e254c0804abd984807b8ae5cd3708d758a8bf1adff1f5df166c
-  md5: 80abc41d0c48b82fe0f04e7f42f5cb7e
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
+  sha256: efa04a98cb149643fa54c4dad5a0179e36a5fbc88427ea0eec88ceed87fd0f96
+  md5: 4cb2cd56f039b129bb0e491c1164167e
   depends:
+  - __osx >=10.9
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  size: 499383
-  timestamp: 1693151312586
+  size: 498900
+  timestamp: 1714723303098
 - kind: conda
   name: zstd
-  version: 1.5.5
-  build: hfc55251_0
+  version: 1.5.6
+  build: ha6fb4c9_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.5-hfc55251_0.conda
-  sha256: 607cbeb1a533be98ba96cf5cdf0ddbb101c78019f1fda063261871dad6248609
-  md5: 04b88013080254850d6c01ed54810589
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
+  sha256: c558b9cc01d9c1444031bd1ce4b9cff86f9085765f17627a6cd85fc623c8a02b
+  md5: 4d056880988120e29d75bfff282e0f45
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  size: 545199
-  timestamp: 1693151163452
+  size: 554846
+  timestamp: 1714722996770
+- kind: conda
+  name: zstd
+  version: 1.5.6
+  build: hb46c0d2_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
+  sha256: 2d4fd1ff7ee79cd954ca8e81abf11d9d49954dd1fef80f27289e2402ae9c2e09
+  md5: d96942c06c3e84bfcc5efb038724a7fd
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<1.3.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 405089
+  timestamp: 1714723101397

--- a/pixi.toml
+++ b/pixi.toml
@@ -28,7 +28,7 @@ clean = { cmd = "rm -rf build bin CMakeFiles/" }
 print-env = { cmd = "echo $PATH" }
 
 [target.win-64.tasks]
-prepare = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+prepare = "cmake -G 'Visual Studio 17 2022' -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRERUN_FIND_PACKAGE:BOOL=OFF"
 build = { cmd = "cmake --build build --config RelWithDebInfo", depends_on = [
     "prepare",
 ] }
@@ -37,12 +37,30 @@ example = { cmd = "build/RelWithDebInfo/rerun_ext_example.exe", depends_on = [
 ] }
 
 [target.unix.tasks]
-prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo"
+prepare = "cmake -G 'Ninja' -B build -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRERUN_FIND_PACKAGE:BOOL=OFF"
 build = { cmd = "cmake --build build --config RelWithDebInfo --target all", depends_on = [
     "prepare",
 ] }
 example = { cmd = "build/rerun_ext_example", depends_on = ["build"] }
 format = { cmd = "clang-format -i src/*" }
+
+[feature.rerunfindpackage.target.win-64.tasks]
+prepare = "cmake -G 'Visual Studio 17 2022' -B buildrerunfindpackage -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRERUN_FIND_PACKAGE:BOOL=ON"
+build = { cmd = "cmake --build buildrerunfindpackage --config RelWithDebInfo", depends_on = [
+    "prepare",
+] }
+example = { cmd = "buildrerunfindpackage/RelWithDebInfo/rerun_ext_example.exe", depends_on = [
+    "build",
+] }
+
+[feature.rerunfindpackage.target.unix.tasks]
+prepare = "cmake -G 'Ninja' -B buildrerunfindpackage -S . -DCMAKE_BUILD_TYPE=RelWithDebInfo -DRERUN_FIND_PACKAGE:BOOL=ON"
+build = { cmd = "cmake --build buildrerunfindpackage --config RelWithDebInfo --target all", depends_on = [
+    "prepare",
+] }
+example = { cmd = "buildrerunfindpackage/rerun_ext_example", depends_on = ["build"] }
+format = { cmd = "clang-format -i src/*" }
+
 
 [dependencies]
 # Build tools:
@@ -51,9 +69,7 @@ cmake = "3.27.6"
 # Required by this example:
 eigen = "3.4.0.*"
 opencv = "4.8.1.*"
-# Installs the Rerun Python SDK so the user doesn't have to download & install rerun-cli manually.
-# TODO(jleibs): In the future we'll want to use a rerun-cli package that only contains the CLI.
-rerun-sdk = "0.15.1"
+rerun-sdk = "0.16.0.*"
 
 [target.unix.dependencies]
 # Build tools:
@@ -63,3 +79,10 @@ ninja = "1.11.1"
 [target.win-64.dependencies]
 # Build tools:
 vs2022_win-64 = "19.37.32822"
+
+[feature.rerunfindpackage.dependencies]
+librerun-sdk = "0.16.0.*"
+
+[environments]
+default = {solve-group = "defaultgroup"}
+rerunfindpackage = {features = ["rerunfindpackage"], solve-group = "defaultgroup"}


### PR DESCRIPTION
To be honest, I am not fully convince about the duplication at the pixi level (so feel free to decline or heavily change the PR), but I found convenient to have a way to quickly validate that indeed the `librerun-sdk` conda package works fine.

I also updated rerun version to 0.16.0 as the `librerun-sdk` conda-forge package is available for Windows only since 0.16.0 .